### PR TITLE
[#88] Add configuration endpoint

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/Constants.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/Constants.java
@@ -5,4 +5,14 @@ public final class Constants {
     public static final String API_PREFIX_S3 = "/api/s3";
     public static final String GEOSERVER_PRG_DATA_STORE = "prg";
     public static final String GEOSERVER_PRG_PATH = "/opt/geoserver/prg/";
+    /**
+     * Date format used in the system.
+     * <p>
+     * <strong>Warning:</strong> it isn't set on the formatter itself. See
+     * <a href="https://blog.codecentric.de/en/2017/08/parsing-of-localdate-query-parameters-in-spring-boot/">
+     *     this blog post
+     * </a> for a possible solution, however I couldn't get it to work in Spring Boot 2.1.4.
+     * Setting <code>spring.(mvc|jackson).date-format</code> properties also don't have effect.
+     */
+    public static final String JACKSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
@@ -1,0 +1,31 @@
+package pl.cyfronet.s4e.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pl.cyfronet.s4e.Constants;
+import pl.cyfronet.s4e.controller.response.ConfigResponse;
+
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+
+@RestController
+@RequestMapping(API_PREFIX_V1)
+@RequiredArgsConstructor
+public class ConfigController {
+    @Value("${geoserver.outsideBaseUrl}")
+    private String geoserverOutsideBaseUrl;
+
+    @Value("${geoserver.workspace}")
+    private String geoserverWorkspace;
+
+    @GetMapping("/config")
+    public ConfigResponse config() {
+        return ConfigResponse.builder()
+                .geoserverUrl(geoserverOutsideBaseUrl)
+                .geoserverWorkspace(geoserverWorkspace)
+                .backendDateFormat(Constants.JACKSON_DATE_FORMAT)
+                .build();
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
@@ -1,0 +1,12 @@
+package pl.cyfronet.s4e.controller.response;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ConfigResponse {
+    String geoserverUrl;
+    String geoserverWorkspace;
+    String backendDateFormat;
+}

--- a/s4e-backend/src/main/resources/application-development.properties
+++ b/s4e-backend/src/main/resources/application-development.properties
@@ -5,6 +5,7 @@ spring.datasource.password=sat4envi
 geoserver.username=admin
 geoserver.password=admin123
 geoserver.baseUrl=http://localhost:8080/geoserver/rest
+geoserver.outsideBaseUrl=${geoserver.baseUrl}
 geoserver.workspace=development
 
 s3.geoserver.endpoint=cyfro

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ConfigControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ConfigControllerTest.java
@@ -1,0 +1,32 @@
+package pl.cyfronet.s4e.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.Constants;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+
+@AutoConfigureMockMvc
+@BasicTest
+public class ConfigControllerTest {
+    @Value("${geoserver.outsideBaseUrl}")
+    private String geoserverOutsideBaseUrl;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void shouldReturnConfiguration() throws Exception {
+        mockMvc.perform(get(API_PREFIX_V1+"/config"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.backendDateFormat").value(Constants.JACKSON_DATE_FORMAT))
+                .andExpect(jsonPath("$.geoserverUrl").value(geoserverOutsideBaseUrl));
+    }
+}

--- a/s4e-backend/src/test/resources/application-test.properties
+++ b/s4e-backend/src/test/resources/application-test.properties
@@ -7,6 +7,7 @@ spring.flyway.clean-on-validation-error=true
 geoserver.username=admin
 geoserver.password=admin123
 geoserver.baseUrl=http://localhost:8080/geoserver/rest
+geoserver.outsideBaseUrl=${geoserver.baseUrl}
 geoserver.workspace=test
 
 s3.geoserver.endpoint=cyfro


### PR DESCRIPTION
For now, geoserverUrl, geoserverWorkspace and backendDateFormat are
exposed in the response.