### PR TITLE
[#104] Use improved GeoServer docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,15 +38,17 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minio123}
     command: server /data
   geoserver:
-    image: fiddev/geoserver:2.15.0
+    image: fiddev/geoserver:1.1.0-GS2.16.0
     volumes:
       - ./resources/geoserver/s3.properties:/opt/geoserver/s3.properties
+      - ./tmp/geoserver-data:/opt/geoserver/data_dir
     ports:
       - ${GEOSERVER_PORT:-8080}:8080
     networks:
       - net
     environment:
       GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD:-admin123}
+      JDBCCONFIG_ENABLED: "false"
   db:
     image: postgres:10-alpine
     ports:

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
@@ -231,7 +231,7 @@ public class SeedProducts implements ApplicationRunner {
         val prgOverlays = List.of(new PRGOverlay[] {
                 PRGOverlay.builder()
                         .name("wojewodztwa")
-                        .featureType("wojew%C3%B3dztwa")
+                        .featureType("wojewodztwa")
                         .sldStyle(sldStyles.get(0))
                         .build(),
                 PRGOverlay.builder()

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperationsIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperationsIntegrationTest.java
@@ -61,12 +61,12 @@ public class GeoServerOperationsIntegrationTest {
                         " all the PRG layer logic updated as required",
                 featureTypes,
                 containsInAnyOrder(
-                        "Pa%C5%84stwo",
+                        "Panstwo",
                         "gminy",
                         "jednostki_ewidencyjne",
                         "obreby_ewidencyjne",
                         "powiaty",
-                        "wojew%C3%B3dztwa"
+                        "wojewodztwa"
                 )
         );
     }
@@ -128,11 +128,11 @@ public class GeoServerOperationsIntegrationTest {
 
         assertThat(geoServerOperations.listStyles("test"), contains("styleOne"));
         assertThat(geoServerOperations.listDataStores("test"), contains("dataStoreName"));
-        assertThat(geoServerOperations.getLayer("test", "wojew%C3%B3dztwa").getLayer().getDefaultStyle().getName(), not(equalTo("test:styleOne")));
+        assertThat(geoServerOperations.getLayer("test", "wojewodztwa").getLayer().getDefaultStyle().getName(), not(equalTo("test:styleOne")));
 
-        geoServerOperations.setLayerDefaultStyle("test", "wojew%C3%B3dztwa", "styleOne");
+        geoServerOperations.setLayerDefaultStyle("test", "wojewodztwa", "styleOne");
 
-        assertThat(geoServerOperations.getLayer("test", "wojew%C3%B3dztwa").getLayer().getDefaultStyle().getName(), is(equalTo("test:styleOne")));
+        assertThat(geoServerOperations.getLayer("test", "wojewodztwa").getLayer().getDefaultStyle().getName(), is(equalTo("test:styleOne")));
     }
 
     @Test

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/GeoServerServiceIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/GeoServerServiceIntegrationTest.java
@@ -100,7 +100,7 @@ public class GeoServerServiceIntegrationTest {
         sldStyle.setCreated(true);
         PRGOverlay prgOverlay = prgOverlayRepository.save(PRGOverlay.builder()
                 .name("wojewodztwa")
-                .featureType("wojew%C3%B3dztwa")
+                .featureType("wojewodztwa")
                 .sldStyle(sldStyle)
                 .build());
 
@@ -109,7 +109,7 @@ public class GeoServerServiceIntegrationTest {
 
         geoServerService.createPrgOverlays(prgOverlays);
 
-        assertThat(geoServerOperations.layerExists("test", "wojew%C3%B3dztwa"), is(true));
-        assertThat(geoServerOperations.getLayer("test", "wojew%C3%B3dztwa").getLayer().getDefaultStyle().getName(), is(equalTo("test:wojewodztwa")));
+        assertThat(geoServerOperations.layerExists("test", "wojewodztwa"), is(true));
+        assertThat(geoServerOperations.getLayer("test", "wojewodztwa").getLayer().getDefaultStyle().getName(), is(equalTo("test:wojewodztwa")));
     }
 }


### PR DESCRIPTION
I changed the version of the GeoServer docker image in
docker-compose.yml to reflect the version scheme.

Moreover, the improved image has PRG vector layer names without
Polish diacritics, so the encoding hacks aren't required anymore.

This PR requires https://github.com/cyfronet-fid/docker-geoserver/pull/1 to be merged, or at least the new image version has to be released.

Fixes: #104.