### PR TITLE
[#52] Include authorities in JWS claims

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/LoginController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/LoginController.java
@@ -2,7 +2,6 @@ package pl.cyfronet.s4e.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
@@ -26,16 +25,15 @@ public class LoginController {
     private final JWTTokenService jwtTokenService;
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody @Valid LoginRequest loginRequest) throws AuthenticationException {
+    public LoginResponse login(@RequestBody @Valid LoginRequest loginRequest) throws AuthenticationException {
         val token = new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword());
-        val authToken = (UsernamePasswordAuthenticationToken) authenticationProvider.authenticate(token);
+        val authToken = authenticationProvider.authenticate(token);
 
-        String jws = jwtTokenService.generateClaimsJws(authToken.getName());
+        String jws = jwtTokenService.generateClaimsJws(authToken);
 
-        return ResponseEntity.ok(
-                LoginResponse.builder()
-                        .email(authToken.getName())
-                        .token(jws)
-                        .build());
+        return LoginResponse.builder()
+                .email(authToken.getName())
+                .token(jws)
+                .build();
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/security/JWTTokenService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/security/JWTTokenService.java
@@ -7,10 +7,12 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.JacksonDeserializer;
 import io.jsonwebtoken.io.JacksonSerializer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 import static pl.cyfronet.s4e.SecurityConfig.JWT_KEY;
 
@@ -18,6 +20,7 @@ import static pl.cyfronet.s4e.SecurityConfig.JWT_KEY;
 @RequiredArgsConstructor
 public class JWTTokenService {
     private static final long EXPIRATION_TIME = Duration.ofHours(1).toMillis();
+    protected static final String AUTHORITIES_KEY = "authorities";
 
     private final ObjectMapper objectMapper;
 
@@ -28,10 +31,15 @@ public class JWTTokenService {
                 .parseClaimsJws(token);
     }
 
-    public String generateClaimsJws(String subject) {
+    public String generateClaimsJws(Authentication auth) {
+        Claims claims = Jwts.claims()
+                .setSubject(auth.getName())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME));
+        claims.put(AUTHORITIES_KEY, auth.getAuthorities().stream()
+                .map(ga -> ga.getAuthority())
+                .collect(Collectors.toList()));
         return Jwts.builder()
-                .setSubject(subject)
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .setClaims(claims)
                 .signWith(JWT_KEY)
                 .serializeToJsonWith(new JacksonSerializer<>(objectMapper))
                 .compact();

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/security/JWTTokenServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/security/JWTTokenServiceTest.java
@@ -1,0 +1,48 @@
+package pl.cyfronet.s4e.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.JacksonDeserializer;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static pl.cyfronet.s4e.SecurityConfig.JWT_KEY;
+import static pl.cyfronet.s4e.security.JWTTokenService.AUTHORITIES_KEY;
+
+class JWTTokenServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void shouldGenerateClaims() {
+        JWTTokenService service = new JWTTokenService(objectMapper);
+
+        String[] authorities = new String[] {
+                "ROLE_1",
+                "OP_CREATE_STH"
+        };
+        val token = new TestingAuthenticationToken("test", null, authorities);
+
+        String jws = service.generateClaimsJws(token);
+
+        Jws<Claims> jwsClaims = Jwts.parser()
+                .setSigningKey(JWT_KEY)
+                .deserializeJsonWith(new JacksonDeserializer<>(objectMapper))
+                .parseClaimsJws(jws);
+
+        assertThat(jwsClaims.getBody().getSubject(), is("test"));
+        assertThat(jwsClaims.getBody().getExpiration().after(new Date()), is(true));
+        List<String> jwsAuthorities = jwsClaims.getBody().get(AUTHORITIES_KEY, List.class);
+        assertThat(jwsAuthorities, contains("ROLE_1", "OP_CREATE_STH"));
+    }
+
+}


### PR DESCRIPTION
Modify signature of JWTTokenService::generateClaimsJws, which accepts
Authentication object now, which is necessary to extract authorities.

Closes: #52.