### PR TITLE
[#28] Email verification

### DIFF
--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
@@ -69,6 +73,25 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>-->
+        <dependency>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail</artifactId>
+            <version>1.5.10</version>
+            <scope>test</scope>
+            <!-- junit 5 isn't in junit:junit, so exclude it -->
+            <exclusions>
+                <exclusion>
+                    <artifactId>junit</artifactId>
+                    <groupId>junit</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.1.6</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/I18nConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/I18nConfig.java
@@ -1,6 +1,7 @@
 package pl.cyfronet.s4e;
 
 import lombok.val;
+import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ResourceBundleMessageSource;
@@ -8,7 +9,7 @@ import org.springframework.context.support.ResourceBundleMessageSource;
 @Configuration
 public class I18nConfig {
     @Bean
-    public ResourceBundleMessageSource resourceBundleMessageSource() {
+    public MessageSource messageSource() {
         val resourceBundleMessageSource = new ResourceBundleMessageSource();
         resourceBundleMessageSource.setDefaultEncoding("UTF-8");
         resourceBundleMessageSource.setBasename("messages");

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/LoggingMailSender.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/LoggingMailSender.java
@@ -1,0 +1,51 @@
+package pl.cyfronet.s4e;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailParseException;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.stereotype.Component;
+
+import javax.mail.Address;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Profile("development")
+@Component
+@Slf4j
+public class LoggingMailSender extends JavaMailSenderImpl {
+    @Override
+    protected void doSend(MimeMessage[] mimeMessages, Object[] originalMessages) throws MailException {
+        for (val mimeMessage: mimeMessages) {
+            try {
+                log.info(messageToString(mimeMessage));
+            } catch (MessagingException | IOException e) {
+                throw new MailParseException(e);
+            }
+        }
+    }
+
+    protected static String messageToString(MimeMessage mimeMessage) throws MessagingException, IOException {
+        return "\n" +
+                "To: "+getRecipientsString(mimeMessage)+"\n"+
+                "Subject: "+mimeMessage.getSubject()+"\n"+
+                mimeMessage.getContent();
+    }
+
+    private static String getRecipientsString(MimeMessage mimeMessage) throws MessagingException {
+            Address[] recipients = mimeMessage.getRecipients(Message.RecipientType.TO);
+            List<String> addresses = Arrays.stream(recipients)
+                    .map(rec -> (InternetAddress) rec)
+                    .map(addr -> addr.getAddress())
+                    .collect(Collectors.toList());
+            return String.join(",", addresses);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/SwaggerConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/SwaggerConfig.java
@@ -24,7 +24,8 @@ public class SwaggerConfig {
                     .paths(PathSelectors.ant("/api/v1*/**"))
                     .build()
                 .groupName("v1")
-                .apiInfo(apiInfo());
+                .apiInfo(apiInfo())
+                .useDefaultResponseMessages(false);
     }
 
     private ApiInfo apiInfo() {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ThreadConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ThreadConfig.java
@@ -2,16 +2,19 @@ package pl.cyfronet.s4e;
 
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import pl.cyfronet.s4e.ex.AsyncUncaughtExceptionHandlerImpl;
 
 import java.util.concurrent.Executor;
 
 @Configuration
 @EnableAsync
 public class ThreadConfig implements AsyncConfigurer {
+
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -25,6 +28,11 @@ public class ThreadConfig implements AsyncConfigurer {
 
     @Override
     public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
-        return new SimpleAsyncUncaughtExceptionHandler();
+        return asyncUncaughtExceptionHandler();
+    }
+
+    @Bean
+    public AsyncUncaughtExceptionHandler asyncUncaughtExceptionHandler() {
+        return new AsyncUncaughtExceptionHandlerImpl(new SimpleAsyncUncaughtExceptionHandler());
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/EmailVerification.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/EmailVerification.java
@@ -1,0 +1,24 @@
+package pl.cyfronet.s4e.bean;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Builder
+public class EmailVerification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @OneToOne(optional = false)
+    private AppUser appUser;
+    @NotEmpty
+    private String token;
+    @NotNull
+    private LocalDateTime expiryTimestamp;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/AppUserController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/AppUserController.java
@@ -1,19 +1,29 @@
 package pl.cyfronet.s4e.controller;
 
+import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import pl.cyfronet.s4e.bean.AppRole;
 import pl.cyfronet.s4e.bean.AppUser;
 import pl.cyfronet.s4e.controller.request.RegisterRequest;
+import pl.cyfronet.s4e.event.OnEmailConfirmedEvent;
+import pl.cyfronet.s4e.event.OnRegistrationCompleteEvent;
+import pl.cyfronet.s4e.event.OnResendRegistrationTokenEvent;
 import pl.cyfronet.s4e.ex.AppUserCreationException;
+import pl.cyfronet.s4e.ex.NotFoundException;
+import pl.cyfronet.s4e.ex.RegistrationTokenExpiredException;
 import pl.cyfronet.s4e.service.AppUserService;
+import pl.cyfronet.s4e.service.EmailVerificationService;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import java.time.LocalDateTime;
 
 import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 
@@ -22,19 +32,86 @@ import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 @RequiredArgsConstructor
 public class AppUserController {
     private final AppUserService appUserService;
+    private final EmailVerificationService emailVerificationService;
     private final PasswordEncoder passwordEncoder;
+    private final ApplicationEventPublisher eventPublisher;
 
+    @ApiOperation("Register a new user")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "If user was registered. But also, when the username was taken and the registration didn't succeed"),
+            @ApiResponse(code = 400, message = "The request was not valid", examples = @Example({
+                    @ExampleProperty(mediaType = "application/json", value = "{\"email\":[\"musi być adresem e-mail\"]}")
+            }))
+    })
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody @Valid RegisterRequest registerRequest) throws AppUserCreationException {
-        appUserService.save(AppUser.builder()
+    public ResponseEntity<?> register(
+            @RequestBody @Valid RegisterRequest registerRequest
+    ) throws AppUserCreationException {
+        AppUser appUser = appUserService.save(AppUser.builder()
                 .email(registerRequest.getEmail())
                 .password(passwordEncoder.encode(registerRequest.getPassword()))
                 // for now it will be only possible to register as the lowest category
                 .role(AppRole.CAT1)
-                // FIXME: Enabled should be set to false here and only after email has been verified set to true.
-                //        See #28.
-                .enabled(true)
+                .enabled(false)
                 .build());
+
+        eventPublisher.publishEvent(new OnRegistrationCompleteEvent(appUser, LocaleContextHolder.getLocale()));
+
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation("Resend an email verification token based on email")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Email with a new email verification token was sent provided user with it existed and wasn't activated yet")
+    })
+    @PostMapping("/resend-registration-token-by-email")
+    public ResponseEntity<?> resendRegistrationTokenByEmail(@RequestParam @Email @NotEmpty @Valid String email) {
+        val optionalAppUser = appUserService.findByEmail(email);
+
+        if (optionalAppUser.isPresent()) {
+            eventPublisher.publishEvent(new OnResendRegistrationTokenEvent(optionalAppUser.get(), LocaleContextHolder.getLocale()));
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation("Resend registration token based on token")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Email with a new registration token was resent"),
+            @ApiResponse(code = 404, message = "The token was not found")
+    })
+    @PostMapping("/resend-registration-token-by-token")
+    public ResponseEntity<?> resendRegistrationTokenByToken(@RequestParam @NotEmpty @Valid String token) throws NotFoundException {
+        val optionalToken = emailVerificationService.findByToken(token);
+
+        if (optionalToken.isPresent()) {
+            eventPublisher.publishEvent(new OnResendRegistrationTokenEvent(optionalToken.get().getAppUser(), LocaleContextHolder.getLocale()));
+            return ResponseEntity.ok().build();
+        } else {
+            throw new NotFoundException("Provided token '"+token+"' not found");
+        }
+    }
+
+    @ApiOperation("Confirm user email")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "User account was activated"),
+            @ApiResponse(code = 401, message = "The token has expired"),
+            @ApiResponse(code = 404, message = "The token wasn't found")
+    })
+    @PostMapping("/confirm-email")
+    public ResponseEntity<?> confirmEmail(@RequestParam @NotEmpty @Valid String token) throws NotFoundException, AppUserCreationException, RegistrationTokenExpiredException {
+        val verificationToken = emailVerificationService.findByToken(token)
+                .orElseThrow(() -> new NotFoundException("Provided token '"+token+"' not found"));
+
+        if (verificationToken.getExpiryTimestamp().isBefore(LocalDateTime.now())) {
+            throw new RegistrationTokenExpiredException("Provided token '"+token+"' expired");
+        }
+
+        val appUser = verificationToken.getAppUser();
+        appUser.setEnabled(true);
+        appUserService.save(appUser);
+
+        eventPublisher.publishEvent(new OnEmailConfirmedEvent(verificationToken, LocaleContextHolder.getLocale()));
 
         return ResponseEntity.ok().build();
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/LoginRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/LoginRequest.java
@@ -1,11 +1,13 @@
 package pl.cyfronet.s4e.controller.request;
 
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 @Data
+@Builder
 public class LoginRequest {
     @Email
     @NotEmpty

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/EmailVerificationRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/EmailVerificationRepository.java
@@ -1,0 +1,11 @@
+package pl.cyfronet.s4e.data.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import pl.cyfronet.s4e.bean.EmailVerification;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends CrudRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findByToken(String token);
+    Optional<EmailVerification> findByAppUserId(Long appUserId);
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/event/OnEmailConfirmedEvent.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/event/OnEmailConfirmedEvent.java
@@ -1,0 +1,20 @@
+package pl.cyfronet.s4e.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import pl.cyfronet.s4e.bean.EmailVerification;
+
+import java.util.Locale;
+
+@Getter
+public class OnEmailConfirmedEvent extends ApplicationEvent {
+    private final EmailVerification emailVerification;
+    private final Locale locale;
+
+    public OnEmailConfirmedEvent(EmailVerification emailVerification, Locale locale) {
+        super(emailVerification);
+
+        this.emailVerification = emailVerification;
+        this.locale = locale;
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/event/OnRegistrationCompleteEvent.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/event/OnRegistrationCompleteEvent.java
@@ -1,0 +1,20 @@
+package pl.cyfronet.s4e.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import pl.cyfronet.s4e.bean.AppUser;
+
+import java.util.Locale;
+
+@Getter
+public class OnRegistrationCompleteEvent extends ApplicationEvent {
+    private final AppUser appUser;
+    private final Locale locale;
+
+    public OnRegistrationCompleteEvent(AppUser appUser, Locale locale) {
+        super(appUser);
+
+        this.appUser = appUser;
+        this.locale = locale;
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/event/OnResendRegistrationTokenEvent.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/event/OnResendRegistrationTokenEvent.java
@@ -1,0 +1,20 @@
+package pl.cyfronet.s4e.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import pl.cyfronet.s4e.bean.AppUser;
+
+import java.util.Locale;
+
+@Getter
+public class OnResendRegistrationTokenEvent extends ApplicationEvent {
+    private final AppUser appUser;
+    private final Locale locale;
+
+    public OnResendRegistrationTokenEvent(AppUser appUser, Locale locale) {
+        super(appUser);
+
+        this.appUser = appUser;
+        this.locale = locale;
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/AsyncUncaughtExceptionHandlerImpl.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/AsyncUncaughtExceptionHandlerImpl.java
@@ -1,0 +1,24 @@
+package pl.cyfronet.s4e.ex;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class AsyncUncaughtExceptionHandlerImpl implements AsyncUncaughtExceptionHandler {
+    private final AsyncUncaughtExceptionHandler defaultHandler;
+
+    @Override
+    public void handleUncaughtException(Throwable e, Method method, Object... params) {
+        if (e instanceof IllegalStateException) {
+            log.info("An uncaught exception was thrown from "+method, e);
+        } else {
+            defaultHandler.handleUncaughtException(e, method, params);
+        }
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandler.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,9 +19,9 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class ErrorHandler extends ResponseEntityExceptionHandler {
     private final ErrorHandlerHelper errorHandlerHelper;
 
-    @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<?> handleCannotAuthenticateException(AuthenticationException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorHandlerHelper.toResponseMap(e));
+    @ExceptionHandler(DisabledException.class)
+    public ResponseEntity<?> handleDisabledException(DisabledException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorHandlerHelper.toResponseMap(e));
     }
 
     @ExceptionHandler(AccessDeniedException.class)
@@ -28,10 +29,25 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorHandlerHelper.toResponseMap(e));
     }
 
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<?> handleCannotAuthenticateException(AuthenticationException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorHandlerHelper.toResponseMap(e));
+    }
+
     @ExceptionHandler(AppUserCreationException.class)
     public ResponseEntity<?> handleAppUserCreationException() {
         // don't return an error status in this case, as it would open the system to account enumeration attack
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @ExceptionHandler(RegistrationTokenExpiredException.class)
+    public ResponseEntity<?> handleRegistrationTokenExpiredException() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<?> handleNotFoundException() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
     }
 
     @Override

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandlerHelper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandlerHelper.java
@@ -2,9 +2,9 @@ package pl.cyfronet.s4e.ex;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ErrorHandlerHelper {
     private final Environment env;
-    private final ResourceBundleMessageSource resourceBundleMessageSource;
+    private final MessageSource messageSource;
 
     public Map<String, Object> toResponseMap(Exception e) {
         String message = e.getMessage();
@@ -52,7 +52,7 @@ public class ErrorHandlerHelper {
     }
 
     public String getMessage(DefaultMessageSourceResolvable error) {
-        return resourceBundleMessageSource.getMessage(error, LocaleContextHolder.getLocale());
+        return messageSource.getMessage(error, LocaleContextHolder.getLocale());
     }
 
     public void optionallyAddDevelopmentInformation(Map<String, Object> map, Exception e) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/RegistrationTokenExpiredException.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/RegistrationTokenExpiredException.java
@@ -1,0 +1,22 @@
+package pl.cyfronet.s4e.ex;
+
+public class RegistrationTokenExpiredException extends Exception {
+    public RegistrationTokenExpiredException() {
+    }
+
+    public RegistrationTokenExpiredException(String message) {
+        super(message);
+    }
+
+    public RegistrationTokenExpiredException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RegistrationTokenExpiredException(Throwable cause) {
+        super(cause);
+    }
+
+    public RegistrationTokenExpiredException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/EmailVerificationListener.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/EmailVerificationListener.java
@@ -1,0 +1,85 @@
+package pl.cyfronet.s4e.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.context.MessageSource;
+import org.springframework.context.event.EventListener;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.bean.EmailVerification;
+import pl.cyfronet.s4e.event.OnEmailConfirmedEvent;
+import pl.cyfronet.s4e.event.OnRegistrationCompleteEvent;
+import pl.cyfronet.s4e.event.OnResendRegistrationTokenEvent;
+import pl.cyfronet.s4e.service.EmailVerificationService;
+
+import java.util.Locale;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationListener {
+    private final JavaMailSender javaMailSender;
+    private final EmailVerificationService emailVerificationService;
+    private final MessageSource messageSource;
+
+    @Async
+    @EventListener
+    public void handle(OnRegistrationCompleteEvent event) {
+        sendConfirmationEmail(event.getAppUser(), event.getLocale());
+    }
+
+    @Async
+    @EventListener
+    public void handle(OnResendRegistrationTokenEvent event) {
+        AppUser appUser = event.getAppUser();
+
+        Optional<EmailVerification> optionalExistingVerificationToken = emailVerificationService.findByAppUserId(appUser.getId());
+        if (optionalExistingVerificationToken.isPresent()) {
+            emailVerificationService.delete(optionalExistingVerificationToken.get().getId());
+        }
+
+        sendConfirmationEmail(appUser, event.getLocale());
+    }
+
+    @Async
+    @EventListener
+    public void handle(OnEmailConfirmedEvent event) {
+        EmailVerification emailVerification = event.getEmailVerification();
+        AppUser appUser = emailVerification.getAppUser();
+
+        emailVerificationService.delete(emailVerification.getId());
+
+        String recipientAddress = appUser.getEmail();
+        String subject = messageSource.getMessage("email.account-activated.subject", null, event.getLocale());
+
+        sendEmail(
+                recipientAddress,
+                subject,
+                messageSource.getMessage("email.account-activated.text", new Object[]{
+                        appUser.getEmail()
+                }, event.getLocale()));
+    }
+
+    private void sendConfirmationEmail(AppUser appUser, Locale locale) {
+        val verificationToken = emailVerificationService.create(appUser);
+
+        String recipientAddress = appUser.getEmail();
+        String subject = messageSource.getMessage("email.confirm-email.subject", null, locale);
+        String confirmationUrl = "/confirm-email?token=" + verificationToken.getToken();
+
+        String text = messageSource.getMessage("email.confirm-email.text", new Object[]{confirmationUrl}, locale);
+
+        sendEmail(recipientAddress, subject, text);
+    }
+
+    private void sendEmail(String to, String subject, String text) {
+        val email = new SimpleMailMessage();
+        email.setTo(to);
+        email.setSubject(subject);
+        email.setText(text);
+        javaMailSender.send(email);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/AppUserService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/AppUserService.java
@@ -9,6 +9,8 @@ import pl.cyfronet.s4e.bean.AppUser;
 import pl.cyfronet.s4e.data.repository.AppUserRepository;
 import pl.cyfronet.s4e.ex.AppUserCreationException;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -23,5 +25,9 @@ public class AppUserService {
             log.info("Cannot create AppUser with email '"+appUser.getEmail()+"'", e);
             throw new AppUserCreationException(e);
         }
+    }
+
+    public Optional<AppUser> findByEmail(String email) {
+        return appUserRepository.findByEmail(email);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/EmailVerificationService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/EmailVerificationService.java
@@ -1,0 +1,45 @@
+package pl.cyfronet.s4e.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.bean.EmailVerification;
+import pl.cyfronet.s4e.data.repository.EmailVerificationRepository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAmount;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+    private static final TemporalAmount EXPIRE_IN = Duration.ofDays(1);
+
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    public Optional<EmailVerification> findByAppUserId(Long appUserId) {
+        return emailVerificationRepository.findByAppUserId(appUserId);
+    }
+
+    public Optional<EmailVerification> findByToken(String token) {
+        return emailVerificationRepository.findByToken(token);
+    }
+
+    public EmailVerification create(AppUser appUser) {
+        if (appUser.isEnabled()) {
+            throw new IllegalStateException("Cannot create ValidationToken for an enabled AppUser");
+        }
+        String token = UUID.randomUUID().toString();
+        return emailVerificationRepository.save(EmailVerification.builder()
+                .appUser(appUser)
+                .token(token)
+                .expiryTimestamp(LocalDateTime.now().plus(EXPIRE_IN))
+                .build());
+    }
+
+    public void delete(Long id) {
+        emailVerificationRepository.deleteById(id);
+    }
+}

--- a/s4e-backend/src/main/resources/db/migration/V3__add_email_verification_table.sql
+++ b/s4e-backend/src/main/resources/db/migration/V3__add_email_verification_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE email_verification (
+    id BIGSERIAL PRIMARY KEY,
+    app_user_id BIGSERIAL UNIQUE REFERENCES app_user NOT NULL,
+    token VARCHAR UNIQUE NOT NULL,
+    expiry_timestamp TIMESTAMP NOT NULL
+);

--- a/s4e-backend/src/main/resources/messages_pl_PL.properties
+++ b/s4e-backend/src/main/resources/messages_pl_PL.properties
@@ -1,3 +1,9 @@
 Email=musi być adresem e-mail
 NotEmpty=musi nie być puste
 Size.registerRequest.password=musi mieć co najmniej {2} znaków długości
+
+email.confirm-email.subject=Potwierdzenie rejestracji
+email.confirm-email.text=Konto utworzone. Wejdź w {0} aby potwierdzić adres email.
+
+email.account-activated.subject=Potwierdzenie aktywacji
+email.account-activated.text=Konto {0} aktywowane.

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/GreenMailSupplier.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/GreenMailSupplier.java
@@ -1,0 +1,18 @@
+package pl.cyfronet.s4e;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import lombok.val;
+
+import java.util.function.Supplier;
+
+import static com.icegreen.greenmail.configuration.GreenMailConfiguration.aConfig;
+
+public class GreenMailSupplier implements Supplier<GreenMail> {
+    @Override
+    public GreenMail get() {
+        val greenMail = new GreenMail(ServerSetupTest.SMTP);
+        greenMail.withConfiguration(aConfig().withDisabledAuthentication());
+        return greenMail;
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/LoggingMailSenderTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/LoggingMailSenderTest.java
@@ -1,0 +1,23 @@
+package pl.cyfronet.s4e;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.SimpleMailMessage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class LoggingMailSenderTest {
+    @Test
+    void shouldCallDoSend() {
+        LoggingMailSender mailSender = spy(new LoggingMailSender());
+
+        SimpleMailMessage email = new SimpleMailMessage();
+        email.setTo("test@somewhere.pl");
+        email.setSubject("Lorem ipsum sid dolor");
+        email.setText("Amet and something else");
+        mailSender.send(email);
+
+        verify(mailSender).doSend(any(), any());
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AppUserControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AppUserControllerTest.java
@@ -1,22 +1,44 @@
 package pl.cyfronet.s4e.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.store.MailFolder;
+import com.icegreen.greenmail.store.StoredMessage;
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.GreenMail;
 import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Duration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.GreenMailSupplier;
 import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.bean.EmailVerification;
 import pl.cyfronet.s4e.controller.request.RegisterRequest;
 import pl.cyfronet.s4e.data.repository.AppUserRepository;
+import pl.cyfronet.s4e.data.repository.EmailVerificationRepository;
+import pl.cyfronet.s4e.event.OnEmailConfirmedEvent;
+import pl.cyfronet.s4e.event.OnRegistrationCompleteEvent;
+import pl.cyfronet.s4e.event.OnResendRegistrationTokenEvent;
+import pl.cyfronet.s4e.ex.AsyncUncaughtExceptionHandlerImpl;
 
+import java.time.LocalDateTime;
+
+import static com.icegreen.greenmail.util.GreenMailUtil.getBody;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -29,17 +51,49 @@ public class AppUserControllerTest {
     private AppUserRepository appUserRepository;
 
     @Autowired
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     @Autowired
     private WebApplicationContext wac;
+
+    @SpyBean
+    private TestListener testListener;
+
+    @SpyBean
+    private AsyncUncaughtExceptionHandlerImpl asyncUncaughtExceptionHandler;
+
+    private GreenMail greenMail;
 
     private MockMvc mockMvc;
 
     @BeforeEach
     public void beforeEach() {
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+        emailVerificationRepository.deleteAll();
         appUserRepository.deleteAll();
+
+        greenMail = new GreenMailSupplier().get();
+        greenMail.start();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        greenMail.stop();
+    }
+
+    @Component
+    private static class TestListener {
+        @EventListener
+        public void handle(OnRegistrationCompleteEvent event) { }
+
+        @EventListener
+        public void handle(OnEmailConfirmedEvent event) { }
+
+        @EventListener
+        public void handle(OnResendRegistrationTokenEvent event) { }
     }
 
     @Test
@@ -48,6 +102,8 @@ public class AppUserControllerTest {
                 .email("some@email.pl")
                 .password("admin123")
                 .build();
+        GreenMailUser mailUser = greenMail.setUser("some@email.pl", "");
+        MailFolder inbox = getInbox(greenMail, mailUser);
 
         assertThat(appUserRepository.findByEmail(registerRequest.getEmail()).isPresent(), is(false));
 
@@ -56,7 +112,18 @@ public class AppUserControllerTest {
                 .content(objectMapper.writeValueAsBytes(registerRequest)))
                 .andExpect(status().isOk());
 
+        // AppUser should have been created and the OnRegistrationCompleteEvent fired.
         assertThat(appUserRepository.findByEmail(registerRequest.getEmail()).isPresent(), is(true));
+        verify(testListener).handle(any(OnRegistrationCompleteEvent.class));
+        verifyNoMoreInteractions(testListener);
+
+        // Email sending handler is executed in @Async method so allow it to run
+        await().atMost(Duration.ONE_SECOND)
+                .until(() -> inbox.getMessageCount() == 1);
+
+        // The message should contain a link with the token.
+        StoredMessage storedMessage = inbox.getMessages().get(0);
+        assertThat(getBody(storedMessage.getMimeMessage()), containsString("?token="));
     }
 
     @Test
@@ -78,7 +145,9 @@ public class AppUserControllerTest {
                 .andExpect(jsonPath("email.length()", is(equalTo(1))))
                 .andExpect(jsonPath("password.length()", is(equalTo(2))));
 
+        // No AppUser should have been created.
         assertThat(appUserRepository.findByEmail(registerRequest.getEmail()).isPresent(), is(false));
+        verifyNoMoreInteractions(testListener);
     }
 
     @Test
@@ -99,6 +168,195 @@ public class AppUserControllerTest {
                 .content(objectMapper.writeValueAsBytes(registerRequest)))
                 .andExpect(status().isOk());
 
-        assertThat(appUserRepository.findByEmail(registerRequest.getEmail()).isPresent(), is(true));
+        // The account should not have been updated. This means the same password hash and no event fired.
+        AppUser appUser = appUserRepository.findByEmail(registerRequest.getEmail()).get();
+        assertThat(appUser.getPassword(), is(equalTo("someHash")));
+        verifyNoMoreInteractions(testListener);
+    }
+
+    @Test
+    public void shouldActivateUserBasedOnToken() throws Exception {
+        AppUser appUser = appUserRepository.save(AppUser.builder()
+                .email("some@email.pl")
+                .password("someHash")
+                .enabled(false)
+                .build());
+        GreenMailUser mailUser = greenMail.setUser("some@email.pl", "");
+        MailFolder inbox = getInbox(greenMail, mailUser);
+
+        EmailVerification emailVerification = emailVerificationRepository.save(EmailVerification.builder()
+                .appUser(appUser)
+                .expiryTimestamp(LocalDateTime.now().plusHours(1))
+                .token("theTokenValue")
+                .build());
+
+        assertThat(appUser.isEnabled(), is(false));
+
+        mockMvc.perform(post(API_PREFIX_V1+"/confirm-email")
+                .param("token", emailVerification.getToken())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // The AppUser should have enabled flag updated
+        AppUser updatedAppUser = appUserRepository.findById(appUser.getId()).get();
+        assertThat(updatedAppUser.isEnabled(), is(true));
+
+        // and OnEmailConfirmedEvent should have been fired.
+        verify(testListener).handle(any(OnEmailConfirmedEvent.class));
+        verifyNoMoreInteractions(testListener);
+
+        // Email sending handler is executed in @Async method so allow it to run.
+        await().atMost(Duration.ONE_SECOND)
+                .until(() -> inbox.getMessageCount() == 1);
+
+        // EmailVerification is only removed in the EmailConfirmationListener, so it is verified after
+        // the email has been received.
+        assertThat(emailVerificationRepository.findById(emailVerification.getId()).isPresent(), is(false));
+
+        // Finally, an email with info that the account has been activated should be sent.
+        StoredMessage storedMessage = inbox.getMessages().get(0);
+        assertThat(getBody(storedMessage.getMimeMessage()), containsString(appUser.getEmail()));
+    }
+
+    @Test
+    public void shouldntActivateUserBasedOnExpiredToken() throws Exception {
+        AppUser appUser = appUserRepository.save(AppUser.builder()
+                .email("some@email.pl")
+                .password("someHash")
+                .enabled(false)
+                .build());
+
+        EmailVerification emailVerification = emailVerificationRepository.save(EmailVerification.builder()
+                .appUser(appUser)
+                .expiryTimestamp(LocalDateTime.now().minusHours(1))
+                .token("theTokenValue")
+                .build());
+
+        assertThat(appUser.isEnabled(), is(false));
+
+        mockMvc.perform(post(API_PREFIX_V1+"/confirm-email")
+                .param("token", emailVerification.getToken())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+
+        // The AppUser shouldn't have enabled flag updated
+        AppUser updatedAppUser = appUserRepository.findById(appUser.getId()).get();
+        assertThat(updatedAppUser.isEnabled(), is(false));
+
+        // and OnEmailConfirmedEvent should not be fired.
+        verifyNoMoreInteractions(testListener);
+    }
+
+    @Test
+    public void shouldResendTokenByEmail() throws Exception {
+        final String EMAIL = "some@email.pl";
+
+        AppUser appUser = appUserRepository.save(AppUser.builder()
+                .email(EMAIL)
+                .password("someHash")
+                .enabled(false)
+                .build());
+
+        EmailVerification emailVerification = emailVerificationRepository.save(EmailVerification.builder()
+                .appUser(appUser)
+                .expiryTimestamp(LocalDateTime.now().plusHours(1))
+                .token("theTokenValue")
+                .build());
+
+        GreenMailUser mailUser = greenMail.setUser(EMAIL, "");
+        MailFolder inbox = getInbox(greenMail, mailUser);
+
+        assertThat(appUser.isEnabled(), is(false));
+
+        mockMvc.perform(post(API_PREFIX_V1+"/resend-registration-token-by-email")
+                .param("email", EMAIL))
+                .andExpect(status().isOk());
+
+        // OnResendRegistrationTokenEvent should be fired.
+        verify(testListener).handle(any(OnResendRegistrationTokenEvent.class));
+        verifyNoMoreInteractions(testListener);
+
+        // Email sending handler is executed in @Async method so allow it to run.
+        await().atMost(Duration.ONE_SECOND)
+                .until(() -> inbox.getMessageCount() == 1);
+
+        // The message should contain a link with the token.
+        StoredMessage storedMessage = inbox.getMessages().get(0);
+        assertThat(getBody(storedMessage.getMimeMessage()), containsString("?token="));
+
+        // The old token should be deleted
+        assertThat(emailVerificationRepository.findById(emailVerification.getId()).isPresent(), is(false));
+        // and new one created.
+        assertThat(emailVerificationRepository.findByAppUserId(appUser.getId()).isPresent(), is(true));
+    }
+
+    @Test
+    public void shouldntResendTokenIfAppUserNotFound() throws Exception {
+        mockMvc.perform(post(API_PREFIX_V1+"/resend-registration-token-by-email")
+                .param("email", "some@email.pl"))
+                .andExpect(status().isOk());
+
+        // OnResendRegistrationTokenEvent shouldn't be fired.
+        verifyNoMoreInteractions(testListener);
+    }
+
+    @Test
+    public void shouldResendTokenByExistingToken() throws Exception {
+        final String EMAIL = "some@email.pl";
+        final String TOKEN = "theTokenValue";
+
+        AppUser appUser = appUserRepository.save(AppUser.builder()
+                .email(EMAIL)
+                .password("someHash")
+                .enabled(false)
+                .build());
+
+        EmailVerification emailVerification = emailVerificationRepository.save(EmailVerification.builder()
+                .appUser(appUser)
+                .expiryTimestamp(LocalDateTime.now().plusHours(1))
+                .token(TOKEN)
+                .build());
+
+        GreenMailUser mailUser = greenMail.setUser(EMAIL, "");
+        MailFolder inbox = getInbox(greenMail, mailUser);
+
+        assertThat(appUser.isEnabled(), is(false));
+
+        mockMvc.perform(post(API_PREFIX_V1+"/resend-registration-token-by-token")
+                .param("token", TOKEN))
+                .andExpect(status().isOk());
+
+        // OnResendRegistrationTokenEvent should be fired.
+        verify(testListener).handle(any(OnResendRegistrationTokenEvent.class));
+        verifyNoMoreInteractions(testListener);
+
+        // Email sending handler is executed in @Async method so allow it to run.
+        await().atMost(Duration.ONE_SECOND)
+                .until(() -> inbox.getMessageCount() == 1);
+
+        // The message should contain a link with the token.
+        StoredMessage storedMessage = inbox.getMessages().get(0);
+        assertThat(getBody(storedMessage.getMimeMessage()), containsString("?token="));
+
+        // The old token should be deleted
+        assertThat(emailVerificationRepository.findById(emailVerification.getId()).isPresent(), is(false));
+        // and new one created.
+        assertThat(emailVerificationRepository.findByAppUserId(appUser.getId()).isPresent(), is(true));
+    }
+
+    @Test
+    public void shouldntResendTokenByNonExistingToken() throws Exception {
+        final String TOKEN = "theTokenValue";
+
+        mockMvc.perform(post(API_PREFIX_V1+"/resend-registration-token-by-token")
+                .param("token", TOKEN))
+                .andExpect(status().isNotFound());
+
+        // OnResendRegistrationTokenEvent shouldn't be fired.
+        verifyNoMoreInteractions(testListener);
+    }
+
+    public static MailFolder getInbox(GreenMail greenMail, GreenMailUser mailUser) throws FolderException {
+        return greenMail.getManagers().getImapHostManager().getInbox(mailUser);
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/LoginControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/LoginControllerTest.java
@@ -1,0 +1,118 @@
+package pl.cyfronet.s4e.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.controller.request.LoginRequest;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+
+@BasicTest
+class LoginControllerTest {
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void beforeEach() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+
+        appUserRepository.deleteAll();
+    }
+
+    @Test
+    public void shouldReturnJWSToken() throws Exception {
+        val appUser = appUserRepository.save(AppUser.builder()
+                .email("some@email.com")
+                .password(passwordEncoder.encode("password"))
+                .enabled(true)
+                .build());
+
+        val loginRequest = LoginRequest.builder()
+                .email(appUser.getEmail())
+                .password("password")
+                .build();
+
+        mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(loginRequest)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("email", is(equalTo("some@email.com"))))
+            .andExpect(jsonPath("token", is(not(isEmptyOrNullString()))));
+    }
+
+    @Test
+    public void shouldReturn403ForDisabledAccount() throws Exception {
+        val appUser = appUserRepository.save(AppUser.builder()
+                .email("some@email.com")
+                .password(passwordEncoder.encode("password"))
+                .enabled(false)
+                .build());
+
+        val loginRequest = LoginRequest.builder()
+                .email(appUser.getEmail())
+                .password("password")
+                .build();
+
+        mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(loginRequest)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void shouldReturn401ForIncorrectCredentials() throws Exception {
+        val appUser = appUserRepository.save(AppUser.builder()
+                .email("some@email.com")
+                .password(passwordEncoder.encode("password"))
+                .enabled(true)
+                .build());
+
+        val loginRequest = LoginRequest.builder()
+                .email(appUser.getEmail())
+                .password("incorrectPassword")
+                .build();
+
+        mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(loginRequest)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void shouldReturn401ForNonexistentAccount() throws Exception {
+        val loginRequest = LoginRequest.builder()
+                .email("does@not.exist")
+                .password("password")
+                .build();
+
+        mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(loginRequest)))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/listener/EmailVerificationListenerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/listener/EmailVerificationListenerTest.java
@@ -1,0 +1,68 @@
+package pl.cyfronet.s4e.listener;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.bean.EmailVerification;
+import pl.cyfronet.s4e.event.OnResendRegistrationTokenEvent;
+import pl.cyfronet.s4e.service.EmailVerificationService;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+class EmailVerificationListenerTest {
+    private EmailVerificationListener listener;
+    private JavaMailSender javaMailSender;
+    private EmailVerificationService emailVerificationService;
+    private MessageSource messageSource;
+
+    @BeforeEach
+    public void beforeEach() {
+        javaMailSender = mock(JavaMailSender.class);
+        emailVerificationService = mock(EmailVerificationService.class);
+        messageSource = mock(MessageSource.class);
+        listener = new EmailVerificationListener(javaMailSender, emailVerificationService, messageSource);
+    }
+
+    @Test
+    public void onResendRegistrationTokenEventShouldDeleteExistingToken() {
+        AppUser appUser = AppUser.builder()
+                .email("some@email.pl")
+                .build();
+        EmailVerification emailVerification = EmailVerification.builder()
+                .id(42L)
+                .appUser(appUser)
+                .token("someToken")
+                .build();
+
+        when(emailVerificationService.findByAppUserId(appUser.getId())).thenReturn(Optional.of(emailVerification));
+        when(emailVerificationService.create(appUser)).thenReturn(emailVerification);
+
+        listener.handle(new OnResendRegistrationTokenEvent(appUser, null));
+
+        verify(emailVerificationService).delete(42L);
+    }
+
+    @Test
+    public void onResendRegistrationTokenEventShouldSendEmail() {
+        AppUser appUser = AppUser.builder()
+                .email("some@email.pl")
+                .build();
+        EmailVerification emailVerification = EmailVerification.builder()
+                .id(42L)
+                .appUser(appUser)
+                .token("someToken")
+                .build();
+
+        when(emailVerificationService.create(appUser)).thenReturn(emailVerification);
+
+        listener.handle(new OnResendRegistrationTokenEvent(appUser, null));
+
+        verify(javaMailSender).send(any(SimpleMailMessage.class));
+    }
+
+}

--- a/s4e-backend/src/test/resources/application-test.properties
+++ b/s4e-backend/src/test/resources/application-test.properties
@@ -11,3 +11,13 @@ geoserver.workspace=test
 
 s3.geoserver.endpoint=cyfro
 s3.geoserver.bucket=s4e-test-1
+
+spring.mail.default-encoding=UTF-8
+spring.mail.host=localhost
+spring.mail.username=user
+spring.mail.password=userPass
+spring.mail.port=3025
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls=true
+spring.mail.protocol=smtp
+spring.mail.test-connection=false


### PR DESCRIPTION
Add token based email verification. An AppUser is created with field
enabled=false, and it can be activated using the token sent by mail.

The logic of sending emails is decoupled from the controller to async
event listeners.

Create LoggingMailSender, which outputs email contents to log.

For testing I introduced GreenMail, which is used to verify appropriate
emails are sent.

The email contents are put in messages_pl_PL.properties.