### PR TITLE
Upgrade to springfox 3.0.0-SNAPSHOT

### DIFF
--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -21,7 +21,7 @@
         <jjwt.version>0.10.6</jjwt.version>
         <junit.version>5.4.2</junit.version>
         <mockito.version>2.28.2</mockito.version>
-        <springfox.version>2.9.2</springfox.version>
+        <springfox.version>3.0.0-SNAPSHOT</springfox.version>
     </properties>
 
     <dependencies>
@@ -122,7 +122,21 @@
             <artifactId>springfox-bean-validators</artifactId>
             <version>${springfox.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-spring-webmvc</artifactId>
+            <version>${springfox.version}</version>
+        </dependency>
     </dependencies>
+
+    <repositories>
+        <!-- TODO: remove and depend on springfox 3.0.0-RELEASE once it is released -->
+        <repository>
+            <id>spring-libs-milestone</id>
+            <name>Spring Milestone Maven Repository</name>
+            <url>http://oss.jfrog.org/artifactory/oss-snapshot-local/</url>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/SwaggerConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/SwaggerConfig.java
@@ -10,10 +10,10 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc;
 
 @Configuration
-@EnableSwagger2
+@EnableSwagger2WebMvc
 @Import(BeanValidatorPluginsConfiguration.class)
 public class SwaggerConfig {
     @Bean


### PR DESCRIPTION
In 2.9.2 the example responses and params are not populated. To use this
feature the unreleased 3.0.0-SNAPSHOT has to be used.

Not the best idea to use a snapshot, but hopefully the 3.0.0 will be
released in not so long future...