### PR TITLE
Use @AutoConfigureMockMvc mechanism in controller tests

### DIFF
--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AppUserControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AppUserControllerTest.java
@@ -12,13 +12,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.event.EventListener;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 import pl.cyfronet.s4e.BasicTest;
 import pl.cyfronet.s4e.GreenMailSupplier;
 import pl.cyfronet.s4e.bean.AppUser;
@@ -29,7 +28,6 @@ import pl.cyfronet.s4e.data.repository.EmailVerificationRepository;
 import pl.cyfronet.s4e.event.OnEmailConfirmedEvent;
 import pl.cyfronet.s4e.event.OnRegistrationCompleteEvent;
 import pl.cyfronet.s4e.event.OnResendRegistrationTokenEvent;
-import pl.cyfronet.s4e.ex.AsyncUncaughtExceptionHandlerImpl;
 
 import java.time.LocalDateTime;
 
@@ -38,12 +36,14 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 
+@AutoConfigureMockMvc
 @BasicTest
 @Slf4j
 public class AppUserControllerTest {
@@ -56,22 +56,16 @@ public class AppUserControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private WebApplicationContext wac;
-
     @SpyBean
     private TestListener testListener;
 
-    @SpyBean
-    private AsyncUncaughtExceptionHandlerImpl asyncUncaughtExceptionHandler;
-
     private GreenMail greenMail;
 
+    @Autowired
     private MockMvc mockMvc;
 
     @BeforeEach
     public void beforeEach() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
         emailVerificationRepository.deleteAll();
         appUserRepository.deleteAll();
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/LoginControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/LoginControllerTest.java
@@ -5,11 +5,10 @@ import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 import pl.cyfronet.s4e.BasicTest;
 import pl.cyfronet.s4e.bean.AppUser;
 import pl.cyfronet.s4e.controller.request.LoginRequest;
@@ -21,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 
+@AutoConfigureMockMvc
 @BasicTest
 class LoginControllerTest {
     @Autowired
@@ -33,14 +33,10 @@ class LoginControllerTest {
     private ObjectMapper objectMapper;
 
     @Autowired
-    private WebApplicationContext wac;
-
     private MockMvc mockMvc;
 
     @BeforeEach
     public void beforeEach() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
-
         appUserRepository.deleteAll();
     }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/PlaceControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/PlaceControllerTest.java
@@ -3,9 +3,8 @@ package pl.cyfronet.s4e.controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 import pl.cyfronet.s4e.BasicTest;
 import pl.cyfronet.s4e.bean.Place;
 import pl.cyfronet.s4e.data.repository.PlaceRepository;
@@ -17,19 +16,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 
+@AutoConfigureMockMvc
 @BasicTest
 class PlaceControllerTest {
     @Autowired
     private PlaceRepository placeRepository;
 
     @Autowired
-    private WebApplicationContext wac;
-
     private MockMvc mockMvc;
 
     @BeforeEach
     public void beforeEach() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
         resetPlaces();
     }
 


### PR DESCRIPTION
Seems better to use an out of the box solution than a manual setup in @BeforeEach.

The mechanism is first used in ConfigControllerTest in #89.

Also, I removed AsyncUncaughtExceptionHandlerImpl, which was unused in AppUserControlerTest.