### PR TITLE
[#120] reCAPTCHA backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ I assume you have built the jar file, so, being in the root directory, run
 The generated file should overwrite the pre-existing one, and you can commit the resulting csv into the repo.
 
 
+#### reCAPTCHA
+
+It is configured with two properties:
+```
+recaptcha.validation.secretKey=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+recaptcha.validation.siteKey=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+```
+The values present in `application-development.properties` (and above) are taken from the reCAPTCHA FAQ and the service
+will always say that the response is ok when using them.
+To test the production experience generate the keys yourself under https://www.google.com/recaptcha/admin/create.
+(You can use the domain `localhost` to test locally.)
+
+
 #### API docs
 
 We use Swagger to create API documentation.

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.mkopylec</groupId>
+            <artifactId>recaptcha-spring-boot-starter</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.controller;
 
+import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,12 +21,27 @@ public class ConfigController {
     @Value("${geoserver.workspace}")
     private String geoserverWorkspace;
 
+    @Value("${recaptcha.validation.siteKey}")
+    private String recaptchaSiteKey;
+
+    @ApiOperation("Get the front-end app configuration")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "OK", examples = @Example({
+                    @ExampleProperty(mediaType = "application/json", value = "{\n" +
+                            "    \"geoserverUrl\": \"http://localhost:8080/geoserver/rest\",\n" +
+                            "    \"geoserverWorkspace\": \"development\",\n" +
+                            "    \"backendDateFormat\": \"yyyy-MM-dd'T'HH:mm:ss\",\n" +
+                            "    \"recaptchaSiteKey\": \"6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI\"\n" +
+                            "}")
+            }))
+    })
     @GetMapping("/config")
     public ConfigResponse config() {
         return ConfigResponse.builder()
                 .geoserverUrl(geoserverOutsideBaseUrl)
                 .geoserverWorkspace(geoserverWorkspace)
                 .backendDateFormat(Constants.JACKSON_DATE_FORMAT)
+                .recaptchaSiteKey(recaptchaSiteKey)
                 .build();
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
@@ -9,4 +9,5 @@ public class ConfigResponse {
     String geoserverUrl;
     String geoserverWorkspace;
     String backendDateFormat;
+    String recaptchaSiteKey;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/SeedDevelopment.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/SeedDevelopment.java
@@ -31,6 +31,7 @@ public class SeedDevelopment implements ApplicationRunner {
     private final SldStyleRepository sldStyleRepository;
     private final PRGOverlayRepository prgOverlayRepository;
     private final AppUserRepository appUserRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
 
     private final PasswordEncoder passwordEncoder;
 
@@ -39,6 +40,7 @@ public class SeedDevelopment implements ApplicationRunner {
     @Async
     @Override
     public void run(ApplicationArguments args) {
+        emailVerificationRepository.deleteAll();
         appUserRepository.deleteAll();
         productRepository.deleteAll();
         productTypeRepository.deleteAll();

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandler.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandler.java
@@ -40,6 +40,11 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @ExceptionHandler(RecaptchaException.class)
+    public ResponseEntity<?> handleRecaptchaException(RecaptchaException e) {
+        return ResponseEntity.badRequest().body(errorHandlerHelper.toResponseMap(e));
+    }
+
     @ExceptionHandler(RegistrationTokenExpiredException.class)
     public ResponseEntity<?> handleRegistrationTokenExpiredException() {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandlerHelper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandlerHelper.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.ex;
 
+import com.github.mkopylec.recaptcha.validation.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.context.MessageSource;
@@ -46,6 +47,18 @@ public class ErrorHandlerHelper {
             map.putIfAbsent(fieldError.getField(), new ArrayList<>());
             ((List) map.get(fieldError.getField())).add(getMessage(fieldError));
         }
+
+        optionallyAddDevelopmentInformation(map, e);
+        return map;
+    }
+
+    public Map<String, Object> toResponseMap(RecaptchaException e) {
+        val errorCodes = e.getErrorCodes();
+        val map = new LinkedHashMap<String, Object>();
+
+        map.put("recaptcha", errorCodes.stream()
+                .map(ErrorCode::getText)
+                .collect(Collectors.toList()));
 
         optionallyAddDevelopmentInformation(map, e);
         return map;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/RecaptchaException.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/RecaptchaException.java
@@ -1,0 +1,20 @@
+package pl.cyfronet.s4e.ex;
+
+import com.github.mkopylec.recaptcha.validation.ErrorCode;
+import lombok.Getter;
+
+import java.util.List;
+
+public class RecaptchaException extends Exception {
+    @Getter
+    private final List<ErrorCode> errorCodes;
+
+    public RecaptchaException(String message, List<ErrorCode> errorCodes, Throwable cause) {
+        super(message, cause);
+        this.errorCodes = errorCodes;
+    }
+
+    public RecaptchaException(String message, List<ErrorCode> errorCodes) {
+        this(message, errorCodes, null);
+    }
+}

--- a/s4e-backend/src/main/resources/application-development.properties
+++ b/s4e-backend/src/main/resources/application-development.properties
@@ -10,3 +10,8 @@ geoserver.workspace=development
 
 s3.geoserver.endpoint=cyfro
 s3.geoserver.bucket=s4e-test-1
+
+# Test keys from https://developers.google.com/recaptcha/docs/faq.
+# Override these locally with your own pair if you need to.
+recaptcha.validation.secretKey=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+recaptcha.validation.siteKey=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/s4e-backend/src/test/resources/application-test.properties
+++ b/s4e-backend/src/test/resources/application-test.properties
@@ -22,3 +22,5 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls=true
 spring.mail.protocol=smtp
 spring.mail.test-connection=false
+
+recaptcha.testing.enabled=true


### PR DESCRIPTION
Add dependency to recaptcha-spring-boot-starter, which handles
sending request to the Google reCAPTCHA service.

The RecaptchaValidator is called in the AppUserController::register,
validating the received param `g-recaptcha-response`.

In case of validator error appropriate error codes are returned in
field `recaptcha`.

For tests the validator test mode is enabled, and in development it
uses the always-returning-true key-set which is recommended for tests in
reCAPTCHA FAQ.

Add field `recaptchaSiteKey` to the `/api/v1/config` response.

Fixes: #120.