### PR TITLE
Persist refresh tokens in TokenStore

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/AuthorizationServerConfiguration.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/AuthorizationServerConfiguration.java
@@ -33,6 +33,9 @@ public class AuthorizationServerConfiguration extends AuthorizationServerConfigu
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Autowired
+    private TokenStore tokenStore;
+
     @Override
     public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
         clients.inMemory()
@@ -50,7 +53,7 @@ public class AuthorizationServerConfiguration extends AuthorizationServerConfigu
     public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
         endpoints
                 .approvalStoreDisabled()
-                .tokenStore(tokenStore())
+                .tokenStore(tokenStore)
                 .accessTokenConverter(jwtAccessTokenConverter())
                 .authenticationManager(authenticationManager);
     }
@@ -69,7 +72,7 @@ public class AuthorizationServerConfiguration extends AuthorizationServerConfigu
     }
 
     @Bean
-    public TokenStore tokenStore() {
+    public JwtTokenStore jwtTokenStore() {
         return new JwtTokenStore(jwtAccessTokenConverter());
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/Constants.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/Constants.java
@@ -1,5 +1,7 @@
 package pl.cyfronet.s4e;
 
+import java.time.ZoneId;
+
 public final class Constants {
     public static final String API_PREFIX_V1 = "/api/v1";
     public static final String API_PREFIX_S3 = "/api/s3";
@@ -15,4 +17,5 @@ public final class Constants {
      * Setting <code>spring.(mvc|jackson).date-format</code> properties also don't have effect.
      */
     public static final String JACKSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+    public static final ZoneId ZONE_ID = ZoneId.of("UTC");
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/RefreshToken.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/RefreshToken.java
@@ -2,27 +2,23 @@ package pl.cyfronet.s4e.bean;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
-import java.util.Set;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
 @Entity
 @Data
 @Builder
-public class AppUser {
+public class RefreshToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @ManyToOne(optional = false)
+    private AppUser appUser;
     @NotEmpty
-    private String email;
-    /// password hash
-    @NotEmpty
-    private String password;
-
-    @Singular
-    private Set<AppRole> roles;
-
-    private boolean enabled;
+    private String jti;
+    @NotNull
+    private LocalDateTime expiryTimestamp;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/RefreshTokenRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package pl.cyfronet.s4e.data.repository;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.repository.CrudRepository;
+import pl.cyfronet.s4e.bean.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByJti(String jti);
+    @Modifying
+    void deleteByJti(String jti);
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/security/PersistingJwtTokenStore.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/security/PersistingJwtTokenStore.java
@@ -1,0 +1,98 @@
+package pl.cyfronet.s4e.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+import lombok.val;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.jwt.Jwt;
+import org.springframework.security.jwt.JwtHelper;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
+import org.springframework.stereotype.Component;
+import pl.cyfronet.s4e.Constants;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.bean.RefreshToken;
+import pl.cyfronet.s4e.data.repository.RefreshTokenRepository;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@Primary
+@RequiredArgsConstructor
+public class PersistingJwtTokenStore implements TokenStore {
+    private interface JwtTokenStoreExcluded {
+        void storeRefreshToken(OAuth2RefreshToken refreshToken, OAuth2Authentication authentication);
+        OAuth2RefreshToken readRefreshToken(String tokenValue);
+        void removeRefreshToken(OAuth2RefreshToken token);
+    }
+
+    @Delegate(excludes = JwtTokenStoreExcluded.class)
+    private final JwtTokenStore jwtTokenStore;
+
+    private final ObjectMapper objectMapper;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public OAuth2RefreshToken readRefreshToken(String tokenValue) {
+        var refreshToken = jwtTokenStore.readRefreshToken(tokenValue);
+        String jti = extractJtiFromEncodedRefreshToken(tokenValue);
+        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByJti(jti);
+        // If the token with a matching jti isn't found in the db then treat the token as revoked.
+        if (optionalRefreshToken.isEmpty()) {
+            refreshToken = null;
+        }
+        return refreshToken;
+    }
+
+    @Override
+    public void storeRefreshToken(OAuth2RefreshToken refreshToken, OAuth2Authentication authentication) {
+        AppUser appUser = ((AppUserDetails) authentication.getPrincipal()).getAppUser();
+        String jti = extractJtiFromEncodedRefreshToken(refreshToken.getValue());
+        LocalDateTime expiryTimestamp = extractExpirationFromEncodedRefreshToken(refreshToken.getValue());
+        refreshTokenRepository.save(RefreshToken.builder()
+                .appUser(appUser)
+                .jti(jti)
+                .expiryTimestamp(expiryTimestamp)
+                .build());
+    }
+
+    @Override
+    public void removeRefreshToken(OAuth2RefreshToken token) {
+        String jti = extractJtiFromEncodedRefreshToken(token.getValue());
+        refreshTokenRepository.deleteByJti(jti);
+    }
+
+    private String extractJtiFromEncodedRefreshToken(String tokenValue) {
+        try {
+            Map map = extractClaimsFromEncodedRefreshToken(tokenValue);
+            return (String) map.get(AccessTokenConverter.JTI);
+        } catch (Exception e) {
+            throw new InvalidTokenException("Cannot read claims from JSON", e);
+        }
+    }
+
+    private LocalDateTime extractExpirationFromEncodedRefreshToken(String tokenValue) {
+        try {
+            Map map = extractClaimsFromEncodedRefreshToken(tokenValue);
+            val instant = Instant.ofEpochSecond((Integer) map.get(AccessTokenConverter.EXP));
+            return LocalDateTime.ofInstant(instant, Constants.ZONE_ID);
+        } catch (Exception e) {
+            throw new InvalidTokenException("Cannot read claims from JSON", e);
+        }
+    }
+
+    private Map<String, Object> extractClaimsFromEncodedRefreshToken(String tokenValue) throws IOException {
+        Jwt jwt = JwtHelper.decode(tokenValue);
+        return objectMapper.readValue(jwt.getClaims(), Map.class);
+    }
+}

--- a/s4e-backend/src/main/resources/db/migration/V7__add_refresh_token_table.sql
+++ b/s4e-backend/src/main/resources/db/migration/V7__add_refresh_token_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE refresh_token (
+    id BIGSERIAL PRIMARY KEY,
+    app_user_id BIGSERIAL REFERENCES app_user NOT NULL,
+    jti VARCHAR UNIQUE NOT NULL,
+    expiry_timestamp TIMESTAMP NOT NULL
+);

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/security/PersistingJwtTokenStoreTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/security/PersistingJwtTokenStoreTest.java
@@ -1,0 +1,106 @@
+package pl.cyfronet.s4e.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.bean.AppRole;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+import pl.cyfronet.s4e.data.repository.RefreshTokenRepository;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@BasicTest
+class PersistingJwtTokenStoreTest {
+    private static final String USER_ID = "test@test.pl";
+    private static final String USER_PASSWORD = "testPassword";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void beforeEach() {
+        refreshTokenRepository.deleteAll();
+        appUserRepository.deleteAll();
+    }
+
+    @Test
+    public void testRefreshTokenRevocationFlow() throws Exception {
+        // Create the test user.
+        appUserRepository.save(AppUser.builder()
+                .email(USER_ID)
+                .password(passwordEncoder.encode(USER_PASSWORD))
+                .role(AppRole.CAT1)
+                .enabled(true)
+                .build());
+
+        assertThat(refreshTokenRepository.count(), is(equalTo(0L)));
+
+        // Authorize, get refresh token.
+        val retToken = mockMvc.perform(post("/oauth/token")
+                .param("grant_type", "password")
+                .param("username", USER_ID)
+                .param("password", USER_PASSWORD)
+                .header("Authorization", httpBasicCredentials("s4e", "secret")))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(refreshTokenRepository.count(), is(equalTo(1L)));
+
+        String refreshToken = objectMapper.readTree(retToken.getResponse().getContentAsString())
+                .get("refresh_token").asText();
+
+        // Check the refresh token works.
+
+        mockMvc.perform(post("/oauth/token")
+                .param("grant_type", "refresh_token")
+                .param("refresh_token", refreshToken)
+                .header("Authorization", httpBasicCredentials("s4e", "secret")))
+                .andExpect(status().isOk());
+
+        assertThat(refreshTokenRepository.count(), is(equalTo(1L)));
+
+        // Remove the refresh token from db.
+        refreshTokenRepository.deleteAll();
+
+        // Check refresh token is revoked.
+        mockMvc.perform(post("/oauth/token")
+                .param("grant_type", "refresh_token")
+                .param("refresh_token", refreshToken)
+                .header("Authorization", httpBasicCredentials("s4e", "secret")))
+                .andExpect(status().isBadRequest());
+    }
+
+    private String httpBasicCredentials(String userName, String password) {
+        String headerValue = "Basic ";
+        byte[] toEncode = (userName + ":" + password).getBytes(StandardCharsets.UTF_8);
+        headerValue += new String(Base64.getEncoder().encode(toEncode), StandardCharsets.UTF_8);
+        return headerValue;
+    }
+}


### PR DESCRIPTION
Create RefreshToken entity which represents created refresh tokens.

Create the PersistingJwtTokenStore which stores created refresh tokens
and verifies if it exists when reading.
The newly created store delegates other actions to the JwtTokenStore
instance.

For now I haven't created any tests for that, they should be added.
They should verify if a token can be revoked by removing a db record.