### PR TITLE
[#136] Reorganize seeds and allow to run them on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,26 @@ Both methods will expose the server under `http://localhost:4201`.
 
 During bootstrap Flyway will migrate the schema based on migrations placed in `src/main/resources/db/migration`.
 
-In the `development` mode the DB and GeoServer are seeded by `SeedDevelopment`.
-It is executed on every startup.
+In the `development` mode the DB and GeoServer are seeded by components from `pl.cyfronet.s4e.db.seed`.
+They are executed on every startup, but they can also be run by setting appropriate profiles.
+
+
+#### Application profiles
+
+Spring application profile can be set with the var `spring.profiles.active`.
+Several profiles can be specified in a comma separated list, e.g. `production,run-seed-products`.
+
+`development`: The seeds are run on every startup and exception handler includes information about stacktraces.
+
+`production`: No seeds are run and information about stacktraces is not included in responses.
+
+`run-seed-users`: Runs `SeedUsers`.
+
+`run-seed-products`: Runs `SeedProducts`.
+The operation of seeding products first seeds the DB, then synchronizes GeoServer to it.
+To disable either phase set `seed.products.seed-db=false` or `seed.products.sync-geoserver=false`, respectively.
+
+`run-seed-places`: Runs `SeedPlaces`.
 
 
 #### Places CSV generation

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedPlaces.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedPlaces.java
@@ -1,4 +1,4 @@
-package pl.cyfronet.s4e.db;
+package pl.cyfronet.s4e.db.seed;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,11 +17,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 
-@Profile("development")
+@Profile({"development", "run-seed-places"})
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class SeedPlaceDevelopment implements ApplicationRunner {
+public class SeedPlaces implements ApplicationRunner {
     private final PlaceRepository placeRepository;
     private final ResourceLoader resourceLoader;
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
@@ -1,0 +1,76 @@
+package pl.cyfronet.s4e.db.seed;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import pl.cyfronet.s4e.bean.AppRole;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+import pl.cyfronet.s4e.data.repository.EmailVerificationRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Profile({"development", "run-seed-users"})
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SeedUsers implements ApplicationRunner {
+    private final AppUserRepository appUserRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Async
+    @Override
+    public void run(ApplicationArguments args) {
+        emailVerificationRepository.deleteAll();
+        appUserRepository.deleteAll();
+
+        seedUsers();
+
+        log.info("Seeding users complete");
+    }
+
+    private void seedUsers() {
+        log.info("Seeding AppUsers");
+        List<AppUser> appUsers = Arrays.asList(new AppUser[]{
+                AppUser.builder()
+                        .email("cat1user@mail.pl")
+                        .password(passwordEncoder.encode("cat1user"))
+                        .role(AppRole.CAT1)
+                        .enabled(true)
+                        .build(),
+                AppUser.builder()
+                        .email("cat2user@mail.pl")
+                        .password(passwordEncoder.encode("cat2user"))
+                        .role(AppRole.CAT1)
+                        .role(AppRole.CAT2)
+                        .enabled(true)
+                        .build(),
+                AppUser.builder()
+                        .email("cat3user@mail.pl")
+                        .password(passwordEncoder.encode("cat3user"))
+                        .role(AppRole.CAT1)
+                        .role(AppRole.CAT2)
+                        .role(AppRole.CAT3)
+                        .enabled(true)
+                        .build(),
+                AppUser.builder()
+                        .email("cat4user@mail.pl")
+                        .password(passwordEncoder.encode("cat4user"))
+                        .role(AppRole.CAT1)
+                        .role(AppRole.CAT2)
+                        .role(AppRole.CAT3)
+                        .role(AppRole.CAT4)
+                        .enabled(true)
+                        .build(),
+        });
+        appUserRepository.saveAll(appUsers);
+    }
+}


### PR DESCRIPTION
Split SeedDevelopment to SeedUsers and SeedProducts, which are
independent.
Moreover, allow to turn the seeds on in profiles other than development
by setting appropriate profile `run-seed-<name>`.