### PR TITLE
Backend dependencies update - 2019.08

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.5.RELEASE</version>
+        <version>2.1.7.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -18,9 +18,10 @@
     <description>Sat4envi backend</description>
 
     <properties>
-        <jjwt.version>0.10.6</jjwt.version>
-        <junit.version>5.4.2</junit.version>
-        <mockito.version>2.28.2</mockito.version>
+        <jjwt.version>0.10.7</jjwt.version>
+        <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
+        <junit.version>5.5.1</junit.version>
+        <mockito.version>3.0.0</mockito.version>
         <springfox.version>3.0.0-SNAPSHOT</springfox.version>
     </properties>
 
@@ -49,18 +50,18 @@
         <dependency>
             <groupId>org.springframework.security.oauth.boot</groupId>
             <artifactId>spring-security-oauth2-autoconfigure</artifactId>
-            <version>2.1.5.RELEASE</version>
+            <version>2.1.7.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-resource-server</artifactId>
-            <version>5.1.5.RELEASE</version>
+            <version>${spring-security.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.mkopylec</groupId>
             <artifactId>recaptcha-spring-boot-starter</artifactId>
-            <version>2.3.0</version>
+            <version>${recaptcha-starter.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
spring-boot-starter 2.1.5.RELEASE -> 2.1.7.RELEASE
jjwt 0.10.6 -> 0.10.7
junit 5.4.2 -> 5.5.1
mockito 2.28.2 -> 3.0.0
recaptcha-starter 2.3.0 -> 2.3.1