### PR TITLE
Production profile properties and their customization in docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log
 testem.log
 /typings
 /.env
+/backend-production.env
 
 # System Files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -152,17 +152,10 @@ This docker-compose recipe can be used to either run whole application for demo 
 
 In order do run docker-compose following steps must be done (**unless stated otherwise working directory should be project root**):
 
-1. Run `./mvnw package -DskipTests` in the root of the project, this will build artifacts for `s4e-backend` and `s4e-web`. 
-   **NOTICE**: In some cases packaging may fail due to inability to compile some binary dependencies for frontend packages. In that case the easiest solution is to delete `s4e-web/node_moules` directory (`rm -rf s4e-web/node_modules`)
-
-2. Run `docker-compose up`
-
-3. After all services are up in the browser navigate to http://localhost:4200 - web interface should be there
-
-4. No it's time to get S3 data to the application.
+1. No it's time to get S3 data to the application.
    First make sure that you have [minio client](https://github.com/minio/mc) (`mc`) installed.
    
-5. Configure `mc`.
+2. Configure `mc`.
 
    Add configuration for local-docker and cyfronet-ceph endpoints:
    ```bash
@@ -180,16 +173,21 @@ In order do run docker-compose following steps must be done (**unless stated oth
    [2019-03-06 12:02:50 CET]      0B s4e-test-2/
    ```
 
-6. Download s3 data for minio:
+3. Download s3 data for minio:
 
    ```bash
    mc cp cyfronet-ceph/data-packs/minio-data-v1.tar.xz .
    tar -xJf minio-data-v1.tar.xz -C ./tmp
    ```
    
-7. Create a bucket with static application content as well as shown [here](#backend-static).
+4. Create a bucket with static application content as well as shown [here](#backend-static).
 
-8. You're done - application should be available on http://localhost:4200 and have 3 available products
+5. Run `./mvnw package -DskipTests` in the root of the project, this will build artifacts for `s4e-backend` and `s4e-web`. 
+   **NOTICE**: In some cases packaging may fail due to inability to compile some binary dependencies for frontend packages. In that case the easiest solution is to delete `s4e-web/node_modules` directory (`rm -rf s4e-web/node_modules`)
+
+6. Run `docker-compose up`.
+
+7. You're done - application should be available on http://localhost:4200 and have 3 available products.
 
 **IMPORTANT** If you run `docker-compose up` you'll get application all set up, but it does not support any kind of live reload, etc. If you plan on developing any part of the project (frontend or backend) you should run docker compose without module you would like to develop - for example:
 
@@ -211,6 +209,15 @@ docker-compose stop s4e-backend
 ```
 
 You will need to locally run frontend via `npm start / ng serve` and develop backend normally.
+
+
+## Production docker-compose
+
+When you are running in production set appropriate environment variables.
+Most can be found in `docker-compose.yml`, excluding the ones which backend is configured with.
+The template for backend vars is placed in `backend-production.env.template`, but you can override other variables too.
+Copy the file, modify the values as required and load it by setting `BACKEND_ENV_PATH=<path to file>` (e.g. in `.env` file).
+(The rule for env var matching to spring properties is roughly this: `SPRING_BASEPATH` matches `spring.basePath`.)
 
 
 ## FAQ

--- a/backend-development.env
+++ b/backend-development.env
@@ -1,0 +1,3 @@
+SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/sat4envi
+SPRING_PROFILES_ACTIVE=development
+GEOSERVER_BASEURL=http://geoserver:8080/geoserver/rest

--- a/backend-production.env.template
+++ b/backend-production.env.template
@@ -1,0 +1,9 @@
+SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/sat4envi
+SPRING_DATASOURCE_PASSWORD=sat4envi
+SPRING_PROFILES_ACTIVE=production
+GEOSERVER_PASSWORD=admin123
+GEOSERVER_BASEURL=http://geoserver:8080/geoserver/rest
+SPRING_MAIL_HOST=<smtp server host>
+SPRING_MAIL_PORT=<smtp server port>
+SPRING_MAIL_USERNAME=<login user to smtp server>
+SPRING_MAIL_PASSWORD=<login password to smtp server>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,8 @@ version: '3'
 services:
   s4e-backend:
     build: ./s4e-backend
-    environment:
-      - SPRING_DATASOURCE_URL=${BACKEND_SPRING_DATASOURCE_URL:-jdbc:postgresql://db:5432/sat4envi}
-      - SPRING_PROFILES_ACTIVE=${BACKEND_SPRING_PROFILES_ACTIVE:-development}
-      - GEOSERVER_BASEURL=${BACKEND_GEOSERVER_BASEURL:-http://geoserver:8080/geoserver/rest}
+    env_file:
+      - ${BACKEND_ENV_PATH:-backend-development.env}
     volumes:
       - ${BACKEND_JAR_PATH:-./s4e-backend/target/s4e-backend-0.0.1-SNAPSHOT.jar}:/app/app.jar
     ports:

--- a/s4e-backend/src/main/resources/application-production.properties
+++ b/s4e-backend/src/main/resources/application-production.properties
@@ -1,1 +1,30 @@
+# BEGIN: props from development
+spring.datasource.url=jdbc:postgresql://localhost:5433/sat4envi
+spring.datasource.username=sat4envi
+spring.datasource.password=sat4envi
+
+geoserver.username=admin
+geoserver.password=admin123
+geoserver.baseUrl=http://localhost:8080/geoserver/rest
+geoserver.outsideBaseUrl=${geoserver.baseUrl}
+geoserver.workspace=development
+
+s3.geoserver.endpoint=cyfro
+s3.geoserver.bucket=s4e-test-1
+
+# Test keys from https://developers.google.com/recaptcha/docs/faq.
+# Override these locally with your own pair if you need to.
+recaptcha.validation.secretKey=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+recaptcha.validation.siteKey=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+# END: props from development
+
+# See Sec. 3.2, https://www.baeldung.com/spring-email for the source of the mail properties.
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=<login user to smtp server>
+spring.mail.password=<login password to smtp server>
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+# Explicitly disable cleaning the db in production by Flyway.
 spring.flyway.clean-disabled=true


### PR DESCRIPTION
Copy the development profile variables to production.
They should be overridden when running the containers though.

In docker-compose.yml set system properties for s4e-backend with env_file.
The path leading to the file can be customized by setting BACKEND_ENV_PATH.

Create a default, development env_file `backend-development.env` and
a template for production use `backend-production.env.template`.