### PR TITLE
GS JDBCConfig and more data

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Both methods will expose the server under `http://localhost:4201`.
 
 During bootstrap Flyway will migrate the schema based on migrations placed in `src/main/resources/db/migration`.
 
-In the `development` mode the DB and GeoServer are seeded by components from `pl.cyfronet.s4e.db.seed`.
-They are executed on every startup, but they can also be run by setting appropriate profiles.
+In the `development` profile the DB and GeoServer are seeded by components from `pl.cyfronet.s4e.db.seed`.
+They are executed on every startup, but they can also be run or skipped by setting appropriate profiles.
 
 
 #### Application profiles
@@ -78,6 +78,12 @@ The operation of seeding products first seeds the DB, then synchronizes GeoServe
 To disable either phase set `seed.products.seed-db=false` or `seed.products.sync-geoserver=false`, respectively.
 
 `run-seed-places`: Runs `SeedPlaces`.
+
+`skip-seed-users`: Skip execution of `SeedUsers` in profile `development`.
+
+`skip-seed-products`: Skip execution of `SeedProducts` in profile `development`.
+
+`skip-seed-places`: Skip execution of `SeedPlaces` in profile `development`.
 
 
 #### Places CSV generation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,16 +38,21 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minio123}
     command: server /data
   geoserver:
-    image: savi/geoserver:1.0.0-GS2.15.1
+    image: savi/geoserver:1.1.0-GS2.16.0
     volumes:
       - ./resources/geoserver/s3.properties:/opt/geoserver/s3.properties
-      - ./tmp/geoserver-data:/opt/geoserver/data_dir
     ports:
       - ${GEOSERVER_PORT:-8080}:8080
     networks:
       - net
     environment:
       GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD:-admin123}
+      JDBCCONFIG_ENABLED: "false"
+      JDBCCONFIG_INITDB: "true"
+      JDBCCONFIG_IMPORT: "true"
+      JDBCCONFIG_JDBC_URL: jdbc:postgresql:\/\/db-geoserver:5432\/gscatalog
+      JDBCCONFIG_USERNAME: gscatalog
+      JDBCCONFIG_PASSWORD: gscatalog
   db:
     image: postgres:10-alpine
     ports:
@@ -58,6 +63,16 @@ services:
       POSTGRES_DB: ${DB_POSTGRES_DB:-sat4envi}
       POSTGRES_USER: ${DB_POSTGRES_USER:-sat4envi}
       POSTGRES_PASSWORD: ${DB_POSTGRES_PASSWORD:-sat4envi}
+  db-geoserver:
+    image: postgres:10-alpine
+    ports:
+      - ${DB_PORT:-5435}:5432
+    networks:
+      - net
+    environment:
+      POSTGRES_DB: ${DB_GEOSERVER_POSTGRES_DB:-gscatalog}
+      POSTGRES_USER: ${DB_GEOSERVER_POSTGRES_USER:-gscatalog}
+      POSTGRES_PASSWORD: ${DB_GEOSERVER_POSTGRES_PASSWORD:-gscatalog}
   db-test:
     image: postgres:10-alpine
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,10 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minio123}
     command: server /data
   geoserver:
-    image: fiddev/geoserver:2.15.0
+    image: savi/geoserver:1.0.0-GS2.15.1
     volumes:
       - ./resources/geoserver/s3.properties:/opt/geoserver/s3.properties
+      - ./tmp/geoserver-data:/opt/geoserver/data_dir
     ports:
       - ${GEOSERVER_PORT:-8080}:8080
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minio123}
     command: server /data
   geoserver:
-    image: savi/geoserver:1.1.0-GS2.16.0
+    image: jswk/geoserver:1.1.0-GS2.16.0
     volumes:
       - ./resources/geoserver/s3.properties:/opt/geoserver/s3.properties
     ports:

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedPlaces.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedPlaces.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 
-@Profile({"development", "run-seed-places"})
+@Profile({"development & !skip-seed-places", "run-seed-places"})
 @Component
 @RequiredArgsConstructor
 @Slf4j

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
@@ -115,7 +115,7 @@ public class SeedProducts implements ApplicationRunner {
         val prgOverlays = new ArrayList<PRGOverlay>();
         prgOverlays.add(PRGOverlay.builder()
                 .name("wojewodztwa")
-                .featureType("wojew%C3%B3dztwa")
+                .featureType("wojewodztwa")
                 .sldStyle(sldStyles.get(0))
                 .build());
         prgOverlayRepository.saveAll(prgOverlays);

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
@@ -123,7 +123,7 @@ public class SeedProducts implements ApplicationRunner {
     }
 
     private List<Product> generateProducts(ProductType productType, String suffix) {
-        val count = 24 * 30; // 1 month worth of layers. One each hour.
+        val count = 24 * 3000;
         val products = new ArrayList<Product>();
         for (int i = 0; i < count; i++) {
             val timestamp = BASE_TIME.plusHours(i);

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
@@ -25,12 +25,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-@Profile({"development", "run-seed-products"})
+@Profile({"development & !skip-seed-products", "run-seed-products"})
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class SeedProducts implements ApplicationRunner {
     private static final LocalDateTime BASE_TIME = LocalDateTime.of(2018, 10, 4, 0, 0);
+    private static final DateTimeFormatter DATE_TIME_PATTERN = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
     @Value("${seed.products.seed-db:true}")
     private boolean seedDb;
@@ -122,20 +123,24 @@ public class SeedProducts implements ApplicationRunner {
     }
 
     private List<Product> generateProducts(ProductType productType, String suffix) {
-        val count = 24;
-        val granules = new ArrayList<Product>();
+        val count = 24 * 30; // 1 month worth of layers. One each hour.
+        val products = new ArrayList<Product>();
         for (int i = 0; i < count; i++) {
-            LocalDateTime timestamp = BASE_TIME.plusHours(i);
-            String layerName = DateTimeFormatter.ofPattern("yyyyMMddHHmm").format(timestamp) + suffix;
-            granules.add(Product.builder()
+            val timestamp = BASE_TIME.plusHours(i);
+            val layerName = DATE_TIME_PATTERN.format(timestamp) + suffix;
+
+            val timestampModuloDay = BASE_TIME.plusHours(i % 24); // The timestamp we actually have data for.
+            val s3Path = DATE_TIME_PATTERN.format(timestampModuloDay) + suffix + ".tif";
+
+            products.add(Product.builder()
                     .productType(productType)
                     .timestamp(timestamp)
                     .layerName(layerName)
-                    .s3Path(layerName+".tif")
+                    .s3Path(s3Path)
                     // if we're not syncing GeoServer then assume it is populated
                     .created(!syncGeoserver)
                     .build());
         }
-        return granules;
+        return products;
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/sync/GeoServerSynchronizer.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/sync/GeoServerSynchronizer.java
@@ -30,13 +30,22 @@ public class GeoServerSynchronizer {
 
     @Transactional
     public void synchronizeProducts() {
-        log.info("Creating products");
+        long total = productRepository.count();
+        log.info("Creating products, "+total+" total");
+        int i = 0;
+        int createdCount = 0;
         for (val product: productRepository.findAll()) {
             if (!product.isCreated()) {
                 geoServerService.addLayer(product);
                 product.setCreated(true);
+                createdCount++;
+            }
+            i++;
+            if ((i+1) % 100 == 0) {
+                log.info((i+1)+"/"+total+" products processed");
             }
         }
+        log.info("All products are created, "+total+" total, "+createdCount+" needed creation");
     }
 
     @Transactional

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperationsIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperationsIntegrationTest.java
@@ -61,12 +61,12 @@ public class GeoServerOperationsIntegrationTest {
                         " all the PRG layer logic updated as required",
                 featureTypes,
                 containsInAnyOrder(
-                        "Pa%C5%84stwo",
+                        "Panstwo",
                         "gminy",
                         "jednostki_ewidencyjne",
                         "obreby_ewidencyjne",
                         "powiaty",
-                        "wojew%C3%B3dztwa"
+                        "wojewodztwa"
                 )
         );
     }
@@ -128,11 +128,11 @@ public class GeoServerOperationsIntegrationTest {
 
         assertThat(geoServerOperations.listStyles("test"), contains("styleOne"));
         assertThat(geoServerOperations.listDataStores("test"), contains("dataStoreName"));
-        assertThat(geoServerOperations.getLayer("test", "wojew%C3%B3dztwa").getLayer().getDefaultStyle().getName(), not(equalTo("test:styleOne")));
+        assertThat(geoServerOperations.getLayer("test", "wojewodztwa").getLayer().getDefaultStyle().getName(), not(equalTo("test:styleOne")));
 
-        geoServerOperations.setLayerDefaultStyle("test", "wojew%C3%B3dztwa", "styleOne");
+        geoServerOperations.setLayerDefaultStyle("test", "wojewodztwa", "styleOne");
 
-        assertThat(geoServerOperations.getLayer("test", "wojew%C3%B3dztwa").getLayer().getDefaultStyle().getName(), is(equalTo("test:styleOne")));
+        assertThat(geoServerOperations.getLayer("test", "wojewodztwa").getLayer().getDefaultStyle().getName(), is(equalTo("test:styleOne")));
     }
 
     @Test

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/GeoServerServiceIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/GeoServerServiceIntegrationTest.java
@@ -100,7 +100,7 @@ public class GeoServerServiceIntegrationTest {
         sldStyle.setCreated(true);
         PRGOverlay prgOverlay = prgOverlayRepository.save(PRGOverlay.builder()
                 .name("wojewodztwa")
-                .featureType("wojew%C3%B3dztwa")
+                .featureType("wojewodztwa")
                 .sldStyle(sldStyle)
                 .build());
 
@@ -109,7 +109,7 @@ public class GeoServerServiceIntegrationTest {
 
         geoServerService.createPrgOverlays(prgOverlays);
 
-        assertThat(geoServerOperations.layerExists("test", "wojew%C3%B3dztwa"), is(true));
-        assertThat(geoServerOperations.getLayer("test", "wojew%C3%B3dztwa").getLayer().getDefaultStyle().getName(), is(equalTo("test:wojewodztwa")));
+        assertThat(geoServerOperations.layerExists("test", "wojewodztwa"), is(true));
+        assertThat(geoServerOperations.getLayer("test", "wojewodztwa").getLayer().getDefaultStyle().getName(), is(equalTo("test:wojewodztwa")));
     }
 }

--- a/s4e-web/src/app/views/map-view/state/overlay/overlay.service.ts
+++ b/s4e-web/src/app/views/map-view/state/overlay/overlay.service.ts
@@ -19,7 +19,7 @@ export class OverlayService {
     this.overlayStore.setLoading(true);
     // :TODO replace mock with HTTP request
     of([{
-      id: this.CONFIG.geoserverWorkspace + ':wojew%C3%B3dztwa',
+      id: this.CONFIG.geoserverWorkspace + ':wojewodztwa',
       caption: 'regions',
       type: 'wms' as OverlayType
     }]).pipe(finalize(() => this.overlayStore.setLoading(false))).subscribe(overlays => this.overlayStore.set(overlays));


### PR DESCRIPTION
Docker-compose changes and operation
------------------------------------

There is an extra service: db-geoserver for storing GS config.

Geoserver service has several extra env vars which must be set
appropriately.

JDBCCONFIG_ENABLED, if set to false then JDBCConfig is disabled. Other
vars don't take effect then.

JDBCCONFIG_INITDB and JDBCCONFIG_IMPORT, only set them to true when db
is not yet initialized. On the first run, when JDBCCONFIG_ENABLED=true,
a DB schema is created (INITDB) and existing config from data_dir is
imported to it (IMPORT). Set them to false after the first run with DB
config.

New GeoServer image
-------------------

docker-compose now uses savi/geoserver:1.1.0-GS2.16.0 image.
It can be built from an appropriate tag in docker-geoserver repo.
Follow instructions from its README to build it. To tag it run
`docker build -t savi/geoserver:1.1.0-GS2.16.0 .`.