### PR TITLE
[#200] Products seed for s4e-demo data set

### DIFF
--- a/resources/geoserver/.gitignore
+++ b/resources/geoserver/.gitignore
@@ -1,0 +1,1 @@
+/s3.properties.prod

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.db.seed;
 
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -18,19 +19,32 @@ import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.data.repository.ProductTypeRepository;
 import pl.cyfronet.s4e.data.repository.SldStyleRepository;
 import pl.cyfronet.s4e.geoserver.sync.GeoServerSynchronizer;
+import pl.cyfronet.s4e.service.GeoServerService;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
-@Profile({"development", "run-seed-products"})
+@Profile({"development & !skip-seed-products", "run-seed-products"})
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class SeedProducts implements ApplicationRunner {
-    private static final LocalDateTime BASE_TIME = LocalDateTime.of(2018, 10, 4, 0, 0);
+    private static final DateTimeFormatter DATE_TIME_PATTERN = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+    private static final DateTimeFormatter DATE_PATTERN = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @Builder
+    private static class ProductParams {
+        private final LocalDateTime startInclusive;
+        private final LocalDateTime endExclusive;
+        private final String s3PathFormat;
+        private final String layerNameFormat;
+    }
 
     @Value("${seed.products.seed-db:true}")
     private boolean seedDb;
@@ -38,16 +52,27 @@ public class SeedProducts implements ApplicationRunner {
     @Value("${seed.products.sync-geoserver:true}")
     private boolean syncGeoserver;
 
+    @Value("${seed.products.sync-geoserver.reset-workspace:true}")
+    private boolean syncGeoserverResetWorkspace;
+
+    @Value("${seed.products.data-set:minio-data-v1}")
+    private String dataSet;
+
     private final ProductTypeRepository productTypeRepository;
     private final ProductRepository productRepository;
     private final SldStyleRepository sldStyleRepository;
     private final PRGOverlayRepository prgOverlayRepository;
 
+    private final GeoServerService geoServerService;
     private final GeoServerSynchronizer geoServerSynchronizer;
 
     @Async
     @Override
     public void run(ApplicationArguments args) {
+        if (syncGeoserver && syncGeoserverResetWorkspace) {
+            geoServerService.resetWorkspace();
+        }
+
         if (seedDb) {
             productRepository.deleteAll();
             productTypeRepository.deleteAll();
@@ -59,26 +84,31 @@ public class SeedProducts implements ApplicationRunner {
         }
 
         if (syncGeoserver) {
-            if (!seedDb) {
-                setAllProductsNotCreated();
+            try {
+                geoServerSynchronizer.synchronizeOverlays();
+            } catch (Exception e) {
+                log.warn(e.getMessage(), e);
             }
-            geoServerSynchronizer.resetWorkspace();
-            geoServerSynchronizer.synchronizeOverlays();
-            geoServerSynchronizer.synchronizeProducts();
         }
 
         log.info("Seeding complete");
     }
 
-    private void setAllProductsNotCreated() {
-        for (val product: productRepository.findAll()) {
-            product.setCreated(false);
-            productRepository.save(product);
+    private void seedProducts() {
+        switch (dataSet) {
+            case "minio-data-v1":
+                seedProductsMinioDataV1();
+                break;
+            case "s4e-demo":
+                seedProductsS4EDemo();
+                break;
+            default:
+                throw new IllegalStateException("Data set: '"+dataSet+"' not recognized");
         }
     }
 
-    private void seedProducts() {
-        log.info("Seeding ProductTypes");
+    private void seedProductsMinioDataV1() {
+        log.info("Seeding ProductTypes: minio-data-v1");
         List<ProductType> productTypes = Arrays.asList(new ProductType[]{
                 ProductType.builder()
                         .name("108m")
@@ -95,12 +125,98 @@ public class SeedProducts implements ApplicationRunner {
         });
         productTypeRepository.saveAll(productTypes);
 
-        log.info("Seeding Products");
-        val products = new ArrayList<Product>();
-        products.addAll(generateProducts(productTypes.get(0), "_Merkator_Europa_ir_108m"));
-        products.addAll(generateProducts(productTypes.get(1), "_Merkator_Europa_ir_108_setvak"));
-        products.addAll(generateProducts(productTypes.get(2), "_Merkator_WV-IR"));
-        productRepository.saveAll(products);
+        LocalDateTime startInclusive = LocalDateTime.of(2018, 10, 4, 0, 0);
+        LocalDateTime endExclusive = startInclusive.plusDays(1);
+
+        val productParams = Map.of(
+                "108m", ProductParams.builder()
+                        .startInclusive(startInclusive)
+                        .endExclusive(endExclusive)
+                        .layerNameFormat("108m_{timestamp}")
+                        .s3PathFormat("{timestamp}_Merkator_Europa_ir_108m.tif")
+                        .build(),
+                "Setvak", ProductParams.builder()
+                        .startInclusive(startInclusive)
+                        .endExclusive(endExclusive)
+                        .layerNameFormat("Setvak_{timestamp}")
+                        .s3PathFormat("{timestamp}_Merkator_Europa_ir_108_setvak.tif")
+                        .build(),
+                "WV-IR", ProductParams.builder()
+                        .startInclusive(startInclusive)
+                        .endExclusive(endExclusive)
+                        .layerNameFormat("WV-IR_{timestamp}")
+                        .s3PathFormat("{timestamp}_Merkator_WV-IR.tif")
+                        .build()
+        );
+
+        log.info("Seeding Products, from: "+startInclusive.toString()+" to "+endExclusive.toString());
+        for (val productType: productTypes) {
+            seedProducts(productType, productParams.get(productType.getName()));
+        }
+    }
+
+    private void seedProductsS4EDemo() {
+        log.info("Seeding ProductTypes: s4e-demo");
+        List<ProductType> productTypes = Arrays.asList(new ProductType[]{
+                ProductType.builder()
+                        .name("108m")
+                        .description("Obraz satelitarny Meteosat dla obszaru Europy w kanale 10.8 µm z zastosowanie maskowanej palety barw dla obszarów mórz i lądów.")
+                        .build(),
+                ProductType.builder()
+                        .name("NatCol")
+                        .description("Opis produktu NatCol.")
+                        .build(),
+                ProductType.builder()
+                        .name("Polsafi")
+                        .description("Opis produktu Polsafi.")
+                        .build(),
+                ProductType.builder()
+                        .name("RGB24_micro")
+                        .description("Opis produktu RGB24_micro.")
+                        .build(),
+                ProductType.builder()
+                        .name("Setvak")
+                        .description("Obraz satelitarny Meteosat w kanale 10.8 µm z paletą barwną do analizy powierzchni wysokich chmur konwekcyjnych – obszar Europy Centralnej.")
+                        .build(),
+        });
+        productTypeRepository.saveAll(productTypes);
+
+        val productParams = Map.of(
+                "108m", ProductParams.builder()
+                        .startInclusive(LocalDateTime.of(2019,10,1,0,0))
+                        .endExclusive(LocalDateTime.of(2019,11,1,0,0))
+                        .layerNameFormat("108m_{timestamp}")
+                        .s3PathFormat("MSG_Products_WM/108m/{date}/{timestamp}_kan_10800m.tif")
+                        .build(),
+                "NatCol", ProductParams.builder()
+                        .startInclusive(LocalDateTime.of(2019,06,1,0,0))
+                        .endExclusive(LocalDateTime.of(2019,07,1,0,0))
+                        .layerNameFormat("NatCol_{timestamp}")
+                        .s3PathFormat("MSG_Products_WM/NatCol/{date}/{timestamp}_RGB_Nat_Co.tif")
+                        .build(),
+                "Polsafi", ProductParams.builder()
+                        .startInclusive(LocalDateTime.of(2019,9,1,0,0))
+                        .endExclusive(LocalDateTime.of(2019,10,1,0,0))
+                        .layerNameFormat("Polsafi_{timestamp}")
+                        .s3PathFormat("MSG_Products_WM/Polsafi/{date}/{timestamp}_Polsaf.tif")
+                        .build(),
+                "RGB24_micro", ProductParams.builder()
+                        .startInclusive(LocalDateTime.of(2019,8,1,0,0))
+                        .endExclusive(LocalDateTime.of(2019,9,1,0,0))
+                        .layerNameFormat("RGB24micro_{timestamp}")
+                        .s3PathFormat("MSG_Products_WM/RGB24_micro/{date}/{timestamp}_RGB_24_micro.gif.tif")
+                        .build(),
+                "Setvak", ProductParams.builder()
+                        .startInclusive(LocalDateTime.of(2019,7,1,0,0))
+                        .endExclusive(LocalDateTime.of(2019,8,1,0,0))
+                        .layerNameFormat("Setvak_{timestamp}")
+                        .s3PathFormat("MSG_Products_WM/Setvak_Eu/{date}/{timestamp}_Eu_centr_ir_108_setvak_wtemp.tif")
+                        .build()
+        );
+
+        for (val productType: productTypes) {
+            seedProducts(productType, productParams.get(productType.getName()));
+        }
     }
 
     private void seedOverlays() {
@@ -121,21 +237,60 @@ public class SeedProducts implements ApplicationRunner {
         prgOverlayRepository.saveAll(prgOverlays);
     }
 
-    private List<Product> generateProducts(ProductType productType, String suffix) {
-        val count = 24;
-        val granules = new ArrayList<Product>();
-        for (int i = 0; i < count; i++) {
-            LocalDateTime timestamp = BASE_TIME.plusHours(i);
-            String layerName = DateTimeFormatter.ofPattern("yyyyMMddHHmm").format(timestamp) + suffix;
-            granules.add(Product.builder()
-                    .productType(productType)
-                    .timestamp(timestamp)
-                    .layerName(layerName)
-                    .s3Path(layerName+".tif")
-                    // if we're not syncing GeoServer then assume it is populated
-                    .created(!syncGeoserver)
-                    .build());
+    private void seedProducts(ProductType productType, ProductParams params) {
+        val count = Duration.between(params.startInclusive, params.endExclusive).toHours();
+        log.info("Seeding products of product type '"+productType.getName()+"', "+count+" total (from "+params.startInclusive+" to "+params.endExclusive+")");
+        for (long i = 0; i < count; i++) {
+            val timestamp = params.startInclusive.plusHours(i);
+            Function<String, String> replacer = (str) -> str
+                    .replace("{timestamp}", DATE_TIME_PATTERN.format(timestamp))
+                    .replace("{date}", DATE_PATTERN.format(timestamp));
+            val layerName = replacer.apply(params.layerNameFormat);
+            val s3Path = replacer.apply(params.s3PathFormat);
+
+            if (syncGeoserver) {
+                val product = Product.builder()
+                        .productType(productType)
+                        .timestamp(timestamp)
+                        .layerName(layerName)
+                        .s3Path(s3Path)
+                        .created(!syncGeoserver)
+                        .build();
+
+                productRepository.save(product);
+
+                try {
+                    if (!geoServerService.layerExists(product.getLayerName())) {
+                        geoServerService.addLayer(product);
+                    }
+                    product.setCreated(true);
+                    productRepository.save(product);
+                } catch (Exception e) {
+                    log.warn(String.format("Cannot create layer for %s. Deleting product", product.toString()), e);
+                    try {
+                        productRepository.delete(product);
+                    } catch (Exception e1) {
+                        // ignore
+                    }
+                }
+            // If we don't sync GeoServer, verify the layer exists before saving.
+            } else if (geoServerService.layerExists(layerName)) {
+                val product = Product.builder()
+                        .productType(productType)
+                        .timestamp(timestamp)
+                        .layerName(layerName)
+                        .s3Path(s3Path)
+                        .created(true)
+                        .build();
+
+                productRepository.save(product);
+            } else {
+                log.info(String.format("Layer '%s' doesn't exist, omitting productType '%s' timestamp %s", layerName, productType.getName(), timestamp));
+            }
+
+            if ((i+1) % 100 == 0) {
+                log.info((i+1)+"/"+count+" products of product type '"+productType.getName()+"' processed");
+            }
         }
-        return granules;
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/sync/GeoServerSynchronizer.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/sync/GeoServerSynchronizer.java
@@ -24,21 +24,6 @@ public class GeoServerSynchronizer {
 
     private final GeoServerService geoServerService;
 
-    public void resetWorkspace() {
-        geoServerService.resetWorkspace();
-    }
-
-    @Transactional
-    public void synchronizeProducts() {
-        log.info("Creating products");
-        for (val product: productRepository.findAll()) {
-            if (!product.isCreated()) {
-                geoServerService.addLayer(product);
-                product.setCreated(true);
-            }
-        }
-    }
-
     @Transactional
     public void synchronizeOverlays() {
         log.info("Creating styles");


### PR DESCRIPTION
Rework the SeedProducts to enable multiple data set support. For now
only two are available, so I don't introduce any extra abstraction over
the choice mechanism. However, I introduce a parameterized product
generation.

Improve GeoServerOperations timeout handling, which is now set to 60s
and can be customized in case of problems.

The GeoServerOperations::layerExists didn't work as expected, I now
catch the NotFound exception and translate it to false output.

Remove unused GeoServerSychronizer methods.

Closes: #200.