### PR TITLE
[#262] Modal Module

### DIFF
--- a/s4e-web/package-lock.json
+++ b/s4e-web/package-lock.json
@@ -11445,11 +11445,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "ngx-bootstrap": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-3.2.0.tgz",
-      "integrity": "sha512-oLSLIWZgRiIfcuxyXLMZUOhX3wZtg6lpuMbdo/0UzMDg2bSOe1XPskcKZ/iuOa3FOlU9rjuYMzswHYYV5f/QCA=="
-    },
     "ngx-take-until-destroy": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/ngx-take-until-destroy/-/ngx-take-until-destroy-5.4.0.tgz",

--- a/s4e-web/package.json
+++ b/s4e-web/package.json
@@ -64,7 +64,6 @@
     "moment": "^2.24.0",
     "ng-pick-datetime": "^7.0.0",
     "ng-recaptcha": "^5.0.0",
-    "ngx-bootstrap": "^3.2.0",
     "ngx-take-until-destroy": "^5.4.0",
     "ol": "^5.3.3",
     "proj4": "^2.5.0",

--- a/s4e-web/src/app/app.module.ts
+++ b/s4e-web/src/app/app.module.ts
@@ -26,6 +26,7 @@ import {ActivateModule} from './views/activate/activate.module';
 import {InjectorModule} from './common/injector.module';
 import {S4eConfig} from './utils/initializer/config.service';
 import {SettingsModule} from './views/settings/settings.module';
+import {ModalModule} from './modal/modal.module';
 
 registerLocaleData(localePl, 'pl');
 
@@ -50,7 +51,8 @@ export function initializeApp(configService: S4eConfig): () => Promise<any> {
     MapModule,
     ProfileModule,
     InjectorModule,
-    SettingsModule
+    SettingsModule,
+    ModalModule
   ],
   providers: [
     S4eConfig,

--- a/s4e-web/src/app/common/share.module.ts
+++ b/s4e-web/src/app/common/share.module.ts
@@ -4,24 +4,19 @@ import {HttpClientModule} from '@angular/common/http';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {InjectorModule} from './injector.module';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import {FontAwesomeModule} from '@fortawesome/angular-fontawesome';
 import localePl from '@angular/common/locales/pl';
 import {registerLocaleData} from '@angular/common';
-import { library } from '@fortawesome/fontawesome-svg-core';
+import {library} from '@fortawesome/fontawesome-svg-core';
 import {fas} from '@fortawesome/free-solid-svg-icons';
 import {UtilsModule} from '../utils/utils.module';
-import {FormErrorComponent} from '../components/form-error/form-error.component';
 
 registerLocaleData(localePl, 'pl');
 library.add(fas);
 
 @NgModule({
-  declarations: [
-  ],
-  imports: [
-  ],
+  declarations: [],
+  imports: [],
   exports: [
     BrowserModule,
     HttpClientModule,
@@ -39,9 +34,7 @@ export class ShareModule {
       {
         ngModule: ShareModule,
         providers: []
-      },
-      TooltipModule.forRoot(),
-      BsDropdownModule.forRoot()
+      }
     ];
   }
 }

--- a/s4e-web/src/app/components/root/root.component.html
+++ b/s4e-web/src/app/components/root/root.component.html
@@ -1,4 +1,5 @@
 <router-outlet></router-outlet>
+<s4e-modal-outlet></s4e-modal-outlet>
 <button *ngIf="PRODUCTION === false"
         class="dev-reset-btn btn btn-warning btn-sm"
         i18n-tooltip
@@ -7,3 +8,13 @@
         (click)="devRefreshState()">
   <span class="fas fa-xs fa-redo-alt"></span>
 </button>
+
+<button *ngIf="PRODUCTION === false"
+        class="dev-modal-demo-btn btn btn-warning btn-sm"
+        i18n-tooltip
+        tooltip="DEV POKAŻ MODALE"
+        placement="left"
+        (click)="modalDemo()">
+  <span class="fas fa-xs fa-window-restore"></span>
+</button>
+

--- a/s4e-web/src/app/components/root/root.component.scss
+++ b/s4e-web/src/app/components/root/root.component.scss
@@ -2,4 +2,12 @@
   position: fixed;
   bottom: 10px;
   right: 10px;
+  z-index: 5000;
+}
+
+.dev-modal-demo-btn {
+  position: fixed;
+  bottom: 70px;
+  right: 10px;
+  z-index: 5000;
 }

--- a/s4e-web/src/app/components/root/root.component.ts
+++ b/s4e-web/src/app/components/root/root.component.ts
@@ -1,6 +1,8 @@
 import {Component} from '@angular/core';
 import {resetStores} from '@datorama/akita';
 import {environment} from '../../../environments/environment';
+import {ModalService} from '../../modal/state/modal.service';
+import {DUMMY_MODAL_ID} from '../../modal/components/dummy-modal/dummy-modal.model';
 
 @Component({
   selector: 's4e-root',
@@ -10,11 +12,25 @@ import {environment} from '../../../environments/environment';
 export class RootComponent {
   PRODUCTION: boolean = environment.production;
 
+  constructor(private modalService: ModalService) {
+  }
+
   /**
    * THIS IS ONLY FOR NON PRODUCTION PURPOSES
    */
   devRefreshState() {
     resetStores();
     location.reload();
+  }
+
+  /**
+   * THIS IS ONLY FOR NON PRODUCTION PURPOSES, UI design
+   * :TODO after properly styling ModalModule this method should be removed
+   */
+  async modalDemo() {
+    if (await this.modalService.confirm('Confirm Modal', 'Jeśli naciśniesz OK zobaczysz ALERT modal')) {
+      await this.modalService.alert('Alert Modal', 'Po kliknięciu OK zobaczysz generyczny modal');
+      this.modalService.show({id: DUMMY_MODAL_ID});
+    }
   }
 }

--- a/s4e-web/src/app/modal/components/alert-modal/alert-modal.component.html
+++ b/s4e-web/src/app/modal/components/alert-modal/alert-modal.component.html
@@ -1,0 +1,7 @@
+<s4e-generic-modal [buttonX]="false">
+  <div class="s4e-modal-header">{{ title }}</div>
+  <div class="s4e-modal-body" [innerHtml]="content"></div>
+  <div class="s4e-modal-footer">
+    <button class="button button--primary" id="accept_btn" (click)="dismiss()" i18n>Ok</button>
+  </div>
+</s4e-generic-modal>

--- a/s4e-web/src/app/modal/components/alert-modal/alert-modal.component.spec.ts
+++ b/s4e-web/src/app/modal/components/alert-modal/alert-modal.component.spec.ts
@@ -1,0 +1,51 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {AlertModalComponent} from './alert-modal.component';
+import {By} from '@angular/platform-browser';
+import {ModalModule} from '../../modal.module';
+import {MODAL_DEF} from '../../modal.providers';
+import {createModal} from '../../state/modal.model';
+import {ALERT_MODAL_ID, AlertModal} from './alert-modal.model';
+import {ModalService} from '../../state/modal.service';
+
+describe('AlertModalComponent', () => {
+  let component: AlertModalComponent;
+  let compiled: HTMLElement;
+  let service: ModalService;
+  let fixture: ComponentFixture<AlertModalComponent>;
+  const content = 'CNT';
+  const title = 'TITLE';
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ModalModule],
+      providers: [
+        {provide: MODAL_DEF, useValue: createModal({id: ALERT_MODAL_ID, size: 'sm', content, title} as AlertModal)}
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AlertModalComponent);
+    service = TestBed.get(ModalService);
+    component = fixture.componentInstance;
+    compiled = fixture.debugElement.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display title and content', () => {
+    expect(compiled.querySelector('.s4e-modal-header').textContent).toContain(title);
+    expect(compiled.querySelector('.s4e-modal-body').textContent).toContain(content);
+  });
+
+  // DOM TESTING
+  it('should call accept after clicking Accept', async () => {
+    let acceptSpy = jest.spyOn(component, 'dismiss');
+    fixture.debugElement.query(By.css('#accept_btn')).nativeElement.click();
+    expect(acceptSpy).toHaveBeenCalled();
+  });
+});

--- a/s4e-web/src/app/modal/components/alert-modal/alert-modal.component.ts
+++ b/s4e-web/src/app/modal/components/alert-modal/alert-modal.component.ts
@@ -1,0 +1,25 @@
+import {Component, Inject} from '@angular/core';
+import {ModalComponent} from '../../utils/modal/modal.component';
+import {ModalService} from '../../state/modal.service';
+import {MODAL_DEF} from '../../modal.providers';
+import {Modal} from '../../state/modal.model';
+import {isAlertModal} from './alert-modal.model';
+
+@Component({
+  selector: 'nts-alert-modal',
+  templateUrl: './alert-modal.component.html',
+  styleUrls: ['./alert-modal.component.scss']
+})
+export class AlertModalComponent extends ModalComponent {
+  title: string = '';
+  content: string = '';
+
+  constructor(modalService: ModalService, @Inject(MODAL_DEF) modal: Modal) {
+    super(modalService, modal.id);
+    if (!isAlertModal(modal)) {
+      throw new Error(`${modal} is not AlertModal!`);
+    }
+    this.title = modal.title;
+    this.content = modal.content;
+  }
+}

--- a/s4e-web/src/app/modal/components/alert-modal/alert-modal.model.ts
+++ b/s4e-web/src/app/modal/components/alert-modal/alert-modal.model.ts
@@ -1,0 +1,12 @@
+import {Modal} from '../../state/modal.model';
+
+export const ALERT_MODAL_ID = 'alert';
+
+export interface AlertModal extends Modal {
+  title: string,
+  content: string,
+}
+
+export function isAlertModal(obj: Modal): obj is AlertModal {
+  return obj.id === ALERT_MODAL_ID
+}

--- a/s4e-web/src/app/modal/components/confirm-modal/confirm-modal.component.html
+++ b/s4e-web/src/app/modal/components/confirm-modal/confirm-modal.component.html
@@ -1,0 +1,8 @@
+<s4e-generic-modal [buttonX]="false">
+  <div class="s4e-modal-header">{{ title }}</div>
+  <div class="s4e-modal-body">{{ content }}</div>
+  <div class="s4e-modal-footer">
+    <button class="button button--default" id="cancel_btn" (click)="dismiss()" i18n>Anuluj</button>
+    <button class="button button--primary" id="accept_btn" (click)="accept()" i18n>Ok</button>
+  </div>
+</s4e-generic-modal>

--- a/s4e-web/src/app/modal/components/confirm-modal/confirm-modal.component.spec.ts
+++ b/s4e-web/src/app/modal/components/confirm-modal/confirm-modal.component.spec.ts
@@ -1,0 +1,65 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ConfirmModalComponent} from './confirm-modal.component';
+import {By} from '@angular/platform-browser';
+import {ModalModule} from '../../modal.module';
+import {MODAL_DEF} from '../../modal.providers';
+import {createModal} from '../../state/modal.model';
+import {ALERT_MODAL_ID} from '../alert-modal/alert-modal.model';
+import {CONFIRM_MODAL_ID, ConfirmModal} from './confirm-modal.model';
+import {ModalService} from '../../state/modal.service';
+
+describe('ConfirmModalComponent', () => {
+  let component: ConfirmModalComponent;
+  let compiled: HTMLElement;
+  let service: ModalService;
+  let fixture: ComponentFixture<ConfirmModalComponent>;
+  const content = 'CNT';
+  const title = 'TITLE';
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ModalModule],
+      providers: [
+        {provide: MODAL_DEF, useValue: createModal({id: CONFIRM_MODAL_ID, size: 'sm', content, title} as ConfirmModal)}
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmModalComponent);
+    component = fixture.componentInstance;
+    service = TestBed.get(ModalService);
+    compiled = fixture.debugElement.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display title and content', () => {
+    expect(compiled.querySelector('.s4e-modal-header').textContent).toContain(title);
+    expect(compiled.querySelector('.s4e-modal-body').textContent).toContain(content);
+  });
+
+  it('should call dismiss(true) on accept', () => {
+    const spy = spyOn(component, 'dismiss').and.stub();
+    component.accept();
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  // DOM TESTING
+  it('should call dismiss after clicking Cancel', () => {
+    let dismissSpy = jest.spyOn(component, 'dismiss');
+    fixture.debugElement.query(By.css('#cancel_btn')).nativeElement.click();
+    expect(dismissSpy).toHaveBeenCalled();
+  });
+
+  // DOM TESTING
+  it('should call accept after clicking Accept', () => {
+    let acceptSpy = jest.spyOn(component, 'accept');
+    fixture.debugElement.query(By.css('#accept_btn')).nativeElement.click();
+    expect(acceptSpy).toHaveBeenCalled();
+  });
+});

--- a/s4e-web/src/app/modal/components/confirm-modal/confirm-modal.component.ts
+++ b/s4e-web/src/app/modal/components/confirm-modal/confirm-modal.component.ts
@@ -1,0 +1,29 @@
+import {Component, Inject} from '@angular/core';
+import {ModalComponent} from '../../utils/modal/modal.component';
+import {ModalService} from '../../state/modal.service';
+import {MODAL_DEF} from '../../modal.providers';
+import {Modal} from '../../state/modal.model';
+import {isConfirmModal} from './confirm-modal.model';
+
+@Component({
+  selector: 'nts-confirm-modal',
+  templateUrl: './confirm-modal.component.html',
+  styleUrls: ['./confirm-modal.component.scss']
+})
+export class ConfirmModalComponent extends ModalComponent<boolean> {
+  title: string = '';
+  content: string = '';
+
+  constructor(modalService: ModalService, @Inject(MODAL_DEF) modal: Modal) {
+    super(modalService, modal.id);
+    if (!isConfirmModal(modal)) {
+      throw new Error(`${modal} is not ConfirmModal!`);
+    }
+    this.title = modal.title;
+    this.content = modal.content;
+  }
+
+  accept() {
+    this.dismiss(true);
+  }
+}

--- a/s4e-web/src/app/modal/components/confirm-modal/confirm-modal.model.ts
+++ b/s4e-web/src/app/modal/components/confirm-modal/confirm-modal.model.ts
@@ -1,0 +1,12 @@
+import {Modal, ModalWithReturnValue} from '../../state/modal.model';
+
+export const CONFIRM_MODAL_ID = 'confirm';
+
+export interface ConfirmModal extends ModalWithReturnValue<boolean> {
+  title: string,
+  content: string,
+}
+
+export function isConfirmModal(obj: Modal): obj is ConfirmModal {
+  return obj.id === CONFIRM_MODAL_ID
+}

--- a/s4e-web/src/app/modal/components/dummy-modal/dummy-modal.component.html
+++ b/s4e-web/src/app/modal/components/dummy-modal/dummy-modal.component.html
@@ -1,0 +1,11 @@
+<s4e-generic-modal [buttonX]="true" [modalId]="registeredId">
+  <div class="s4e-modal-header">Dummy Component</div>
+  <div class="s4e-modal-body">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc eleifend sit amet lacus in luctus. Fusce et mi at odio
+    tristique porttitor. Nunc pretium, magna eget luctus rutrum, justo risus bibendum ex, vitae dignissim urna leo vel
+    tellus. Nam consequat tristique arcu eleifend suscipit. Duis dolor felis, luctus non bibendum et,
+  </div>
+  <div class="s4e-modal-footer">
+    <button class="button button--primary" type="submit" (click)="dismiss()" i18n>Ok</button>
+  </div>
+</s4e-generic-modal>

--- a/s4e-web/src/app/modal/components/dummy-modal/dummy-modal.component.spec.ts
+++ b/s4e-web/src/app/modal/components/dummy-modal/dummy-modal.component.spec.ts
@@ -1,0 +1,32 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DummyModalComponent } from './dummy-modal.component';
+import {ModalModule} from '../../modal.module';
+import {MODAL_DEF} from '../../modal.providers';
+import {createModal} from '../../state/modal.model';
+import {ALERT_MODAL_ID, AlertModal} from '../alert-modal/alert-modal.model';
+
+describe('DummyModalComponent', () => {
+  let component: DummyModalComponent;
+  let fixture: ComponentFixture<DummyModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ModalModule],
+      providers: [
+        {provide: MODAL_DEF, useValue: createModal({id: ALERT_MODAL_ID})}
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DummyModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/s4e-web/src/app/modal/components/dummy-modal/dummy-modal.component.ts
+++ b/s4e-web/src/app/modal/components/dummy-modal/dummy-modal.component.ts
@@ -1,0 +1,16 @@
+import {Component, Inject, OnInit, Optional} from '@angular/core';
+import {ModalComponent} from '../../utils/modal/modal.component';
+import {ModalService} from '../../state/modal.service';
+import {MODAL_DEF} from '../../modal.providers';
+import {Modal} from '../../state/modal.model';
+
+@Component({
+  selector: 's4e-dummy-modal',
+  templateUrl: './dummy-modal.component.html',
+  styleUrls: ['./dummy-modal.component.scss']
+})
+export class DummyModalComponent extends ModalComponent{
+  constructor(modalService: ModalService, @Inject(MODAL_DEF) modal: Modal) {
+    super(modalService, modal.id);
+  }
+}

--- a/s4e-web/src/app/modal/components/dummy-modal/dummy-modal.model.ts
+++ b/s4e-web/src/app/modal/components/dummy-modal/dummy-modal.model.ts
@@ -1,0 +1,1 @@
+export const DUMMY_MODAL_ID = 'dummy';

--- a/s4e-web/src/app/modal/components/dynamic-modal/dynamic-modal.component.html
+++ b/s4e-web/src/app/modal/components/dynamic-modal/dynamic-modal.component.html
@@ -1,0 +1,1 @@
+<ng-container #container></ng-container>

--- a/s4e-web/src/app/modal/components/dynamic-modal/dynamic-modal.component.spec.ts
+++ b/s4e-web/src/app/modal/components/dynamic-modal/dynamic-modal.component.spec.ts
@@ -1,0 +1,38 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {DynamicModalComponent} from './dynamic-modal.component';
+import {ModalModule} from '../../modal.module';
+import {createModal} from '../../state/modal.model';
+import {DUMMY_MODAL_ID} from '../dummy-modal/dummy-modal.model';
+import {DummyModalComponent} from '../dummy-modal/dummy-modal.component';
+
+describe('DynamicModalComponent', () => {
+  let component: DynamicModalComponent;
+  let fixture: ComponentFixture<DynamicModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ModalModule
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DynamicModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should create modal from definition', () => {
+    component.modal = createModal({id: DUMMY_MODAL_ID});
+    fixture.detectChanges();
+    expect(component.componentRef).toBeTruthy();
+    expect(component.componentRef.instance).toBeInstanceOf(DummyModalComponent);
+    expect((component.componentRef.instance as DummyModalComponent).registeredId).toEqual(DUMMY_MODAL_ID)
+  });
+});

--- a/s4e-web/src/app/modal/components/dynamic-modal/dynamic-modal.component.ts
+++ b/s4e-web/src/app/modal/components/dynamic-modal/dynamic-modal.component.ts
@@ -1,0 +1,74 @@
+import {
+  Component, ComponentFactoryResolver, ComponentRef, Inject, Injector, Input, OnDestroy, OnInit, Type, ViewChild,
+  ViewContainerRef, ViewEncapsulation
+} from '@angular/core';
+import {MODAL_DEF, MODAL_PROVIDER, ModalProviderEntry} from '../../modal.providers';
+import {Modal} from '../../state/modal.model';
+
+@Component({
+  selector: 's4e-dynamic-modal',
+  templateUrl: './dynamic-modal.component.html',
+  styleUrls: ['./dynamic-modal.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class DynamicModalComponent implements OnInit, OnDestroy {
+  private _modal: Modal|null = null;
+  private _component: Type<any>|null = null;
+  @Input() set modal(modal: Modal) {
+    const cmp = this.mapComponent(modal.id);
+    if (cmp == null || cmp === this._component) {
+      return;
+    }
+
+    if (this._component != null) {
+      this.componentRef.destroy();
+    }
+
+    this._component = cmp;
+    this._modal = modal;
+    let factory = this.componentFactoryResolver.resolveComponentFactory(this._component);
+    const injector: Injector = Injector.create(
+      {
+        providers: [{provide: MODAL_DEF, useValue: modal}],
+        parent: this.injector
+      });
+
+    this.componentRef = this.container.createComponent(factory, 0, injector);
+
+    if (this.componentRef == null) {
+      throw Error(`${cmp.toString()} was not created. Did you add it to 'entryComponents'?`);
+    }
+  }
+
+  @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
+  componentRef: ComponentRef<any>;
+
+  constructor(protected componentFactoryResolver: ComponentFactoryResolver,
+              @Inject(MODAL_PROVIDER) private modalProviders: ModalProviderEntry[],
+              private injector: Injector) {
+  }
+
+  ngOnInit() {
+  }
+
+  ngOnDestroy() {
+    /**
+     * :TODO: THIS IS HACK, as for angular version 5+ ngOnDestroy is called before animations
+     * have chance to finish, this hack postpones it for 5 seconds, which is a reasonable time
+     * for any UI animation to finish. This code should be rewritten after bug is fixed by angular
+     * team
+     */
+    setTimeout(() => {
+      if (this.componentRef) {
+        this.componentRef.destroy();
+        this.componentRef = null;
+      }
+    }, 5000);
+  }
+
+  private mapComponent(componentName: string): Type<any> {
+    const componentType = this.modalProviders.find(e => e.name === componentName);
+    if(!componentType) {throw new Error(`${componentName} has not been provided via MODAL_PROVIDER`)}
+    return componentType.component;
+  }
+}

--- a/s4e-web/src/app/modal/components/generic-modal/generic-modal.component.html
+++ b/s4e-web/src/app/modal/components/generic-modal/generic-modal.component.html
@@ -1,0 +1,17 @@
+<div class="modal-header">
+  <button *ngIf="buttonX !== false"
+          type="button"
+          class="close"
+          aria-hidden="true"
+          (click)="dismiss()">&times;</button>
+  <h4 class="modal-title" id="s4e-modal-label"><span>
+    <ng-content select=".s4e-modal-header"></ng-content>
+  </span></h4>
+</div>
+<div class="modal-body">
+  <ng-content select=".s4e-modal-body"></ng-content>
+</div>
+
+<div class="modal-footer">
+  <ng-content select=".s4e-modal-footer"></ng-content>
+</div>

--- a/s4e-web/src/app/modal/components/generic-modal/generic-modal.component.scss
+++ b/s4e-web/src/app/modal/components/generic-modal/generic-modal.component.scss
@@ -1,0 +1,24 @@
+:host {
+  background-color: white;
+  padding: 15px;
+  display: block;
+}
+
+.close {
+  position: absolute;
+  right: 0;
+  top: -5px;
+}
+
+.modal-header {
+  position: relative;
+  margin-bottom: 10px;
+
+  .modal-title {
+    margin-top: 4px;
+  }
+}
+
+.modal-body {
+
+}

--- a/s4e-web/src/app/modal/components/generic-modal/generic-modal.component.spec.ts
+++ b/s4e-web/src/app/modal/components/generic-modal/generic-modal.component.spec.ts
@@ -1,0 +1,87 @@
+import {async, ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {GenericModalComponent} from './generic-modal.component';
+import {ModalModule} from '../../modal.module';
+import {Component} from '@angular/core';
+import {ModalService} from '../../state/modal.service';
+import {By} from '@angular/platform-browser';
+
+@Component({
+  selector: 's4e-generic-mock-component',
+  template: `
+      <s4e-generic-modal [buttonX]="buttonX" [modalId]="registeredId" (close)="close()">
+          <div class="s4e-modal-header">Mock Component</div>
+          <div class="s4e-modal-body">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc eleifend sit amet lacus in luctus.
+          </div>
+          <div class="s4e-modal-footer">
+              <button class="button button--primary" type="submit" (click)="dismiss()" i18n>Ok</button>
+          </div>
+      </s4e-generic-modal>
+  `
+})
+export class GenericModalMockComponent {
+  buttonX = true;
+  registeredId = '123';
+  dismiss() {}
+  close() {}
+}
+
+describe('GenericModalComponent', () => {
+  let component: GenericModalMockComponent;
+  let service: ModalService;
+  let fixture: ComponentFixture<GenericModalMockComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ModalModule
+      ],
+      declarations: [
+        GenericModalMockComponent
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GenericModalMockComponent);
+    component = fixture.componentInstance;
+    service = TestBed.get(ModalService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('clicking X should call ModalService.hide', () => {
+    const spy = spyOn(service, 'hide').and.callThrough();
+    fixture.debugElement.query(By.css('button.close')).nativeElement.click();
+    expect(spy).toHaveBeenCalledWith(component.registeredId);
+  });
+
+  it('clicking X should call call (close)', () => {
+    const spy = spyOn(service, 'hide').and.callThrough();
+    fixture.debugElement.query(By.css('button.close')).nativeElement.click();
+    expect(spy).toHaveBeenCalledWith(component.registeredId);
+  });
+
+  it('clicking x should not call ModalService.hide if modalId is not defined', () => {
+    const spy = spyOn(component, 'close');
+    fixture.debugElement.query(By.css('button.close')).nativeElement.click();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('if buttonX is false x button should not be shown', () => {
+    component.buttonX = false;
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('button.close'))).toBeFalsy();
+  });
+
+  it('dismiss should call xclicked', (done) => {
+    const xclicked = () => done();
+
+    fixture.debugElement.query(By.css('s4e-generic-modal')).componentInstance.xclicked = xclicked;
+    fixture.debugElement.query(By.css('button.close')).nativeElement.click();
+  });
+});

--- a/s4e-web/src/app/modal/components/generic-modal/generic-modal.component.ts
+++ b/s4e-web/src/app/modal/components/generic-modal/generic-modal.component.ts
@@ -1,0 +1,34 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {ModalService} from '../../state/modal.service';
+
+@Component({
+  selector: 's4e-generic-modal',
+  templateUrl: './generic-modal.component.html',
+  styleUrls: ['./generic-modal.component.scss']
+})
+export class GenericModalComponent {
+  @Input() buttonX: boolean;
+  @Input() modalId: string|null;
+
+  /**
+   * This method will be executed when clicking x on the modal.
+   * By default it just calls calls ModalService.hide on the modal
+   *
+   * If you just want to be notified when modal is being closed use
+   * (close) output.
+   */
+  @Input() xclicked: () => void = () => {
+    if(this.modalId != null) {
+      this.modalService.hide(this.modalId);
+    }
+  };
+
+  @Output() close: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor(private modalService: ModalService) { }
+
+  dismiss() {
+    this.xclicked();
+    this.close.emit();
+  }
+}

--- a/s4e-web/src/app/modal/components/modal-outlet/modal-outlet.component.html
+++ b/s4e-web/src/app/modal/components/modal-outlet/modal-outlet.component.html
@@ -1,0 +1,15 @@
+<div *ngIf="(modals$ | async).length > 0" class="backdrop"></div>
+<div *ngFor="let modal of (modals$ | async);trackBy:getModalId; index as $index"
+     [attr.data-modal-id]="modal?.id"
+     [@listAnimation]="true"
+     class="modal"
+     [ngClass]="{fade: showAnimations}"
+     tabindex="-1" role="dialog">
+  <div *ngIf="(modals$ | async).length > 0" class="backdrop backdrop-transparent"></div>
+  <div class="modal-dialog"
+       [ngClass]="{'modal-sm': modal.size === 'sm', 'modal-lg': modal.size === 'lg', 'modal-md': modal.size === 'md', 'modal-full-screen': modal.size === 'fl'}">
+    <div class="modal-content">
+      <s4e-dynamic-modal [modal]="modal"></s4e-dynamic-modal>
+    </div>
+  </div>
+</div>

--- a/s4e-web/src/app/modal/components/modal-outlet/modal-outlet.component.scss
+++ b/s4e-web/src/app/modal/components/modal-outlet/modal-outlet.component.scss
@@ -1,0 +1,43 @@
+.backdrop {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: black;
+  opacity: 0.4;
+  z-index: 2;
+}
+
+.backdrop-transparent {
+  opacity: 0;
+  z-index: -1;
+}
+
+.modal {
+  position: absolute;
+  width: 100%;
+  z-index: 3;
+  tab-index: -1;
+  outline: none;
+  margin-top: 150px;
+}
+
+.modal-dialog {
+  margin-right: auto;
+  margin-left: auto;
+  z-index: 2;
+
+  &.modal-md {
+    width: 400px;
+  }
+  &.modal-lg {
+    width: 600px;
+  }
+  &.modal-sm {
+    width: 300px;
+  }
+  &.modal-fl {
+    width: 100%;
+  }
+}

--- a/s4e-web/src/app/modal/components/modal-outlet/modal-outlet.component.spec.ts
+++ b/s4e-web/src/app/modal/components/modal-outlet/modal-outlet.component.spec.ts
@@ -1,0 +1,27 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ModalOutletComponent} from './modal-outlet.component';
+import {ModalModule} from '../../modal.module';
+
+describe('ModalOutletComponent', () => {
+  let component: ModalOutletComponent;
+  let fixture: ComponentFixture<ModalOutletComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ModalModule
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ModalOutletComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/s4e-web/src/app/modal/components/modal-outlet/modal-outlet.component.ts
+++ b/s4e-web/src/app/modal/components/modal-outlet/modal-outlet.component.ts
@@ -1,0 +1,47 @@
+import {Component, ComponentFactoryResolver, Inject, OnInit, Type, ViewChild, ViewContainerRef} from '@angular/core';
+import {Observable} from 'rxjs';
+import {animate, state, style, transition, trigger} from '@angular/animations';
+import {environment} from '../../../../environments/environment';
+import {ModalService} from '../../state/modal.service';
+import {MODAL_PROVIDER, ModalProviderEntry} from '../../modal.providers';
+import {ModalQuery} from '../../state/modal.query';
+import {Modal} from '../../state/modal.model';
+
+const TRANSITION_DURATION = environment.production ? 150 : 0;
+
+@Component({
+  selector: 's4e-modal-outlet',
+  templateUrl: './modal-outlet.component.html',
+  styleUrls: ['./modal-outlet.component.scss'],
+  animations: [
+    trigger('listAnimation', [
+      state('true', style({opacity: 1.0})),
+      state('void', style({opacity: 0.0})),
+      transition('* => void', [ // each time the binding value changes
+        animate(TRANSITION_DURATION)
+      ]),
+    ])
+  ]
+})
+
+export class ModalOutletComponent implements OnInit {
+
+  test: boolean = false;
+
+  @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
+
+  modals$: Observable<Modal[]>;
+  public showAnimations: boolean = environment.production;
+
+  constructor(private componentFactoryResolver: ComponentFactoryResolver,
+              private modalService: ModalService,
+              private modalQuery: ModalQuery) {}
+
+  ngOnInit() {
+    this.modals$ = this.modalQuery.selectAll();
+  }
+
+  getModalId(modal: Modal) {
+    return modal.id;
+  }
+}

--- a/s4e-web/src/app/modal/modal.module.ts
+++ b/s4e-web/src/app/modal/modal.module.ts
@@ -1,0 +1,48 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ModalOutletComponent} from './components/modal-outlet/modal-outlet.component';
+import {DynamicModalComponent} from './components/dynamic-modal/dynamic-modal.component';
+import {makeModalProvider} from './modal.providers';
+import {DummyModalComponent} from './components/dummy-modal/dummy-modal.component';
+import {ModalService} from './state/modal.service';
+import {ModalQuery} from './state/modal.query';
+import {ModalStore} from './state/modal.store';
+import {AlertModalComponent} from './components/alert-modal/alert-modal.component';
+import {ConfirmModalComponent} from './components/confirm-modal/confirm-modal.component';
+import {GenericModalComponent} from './components/generic-modal/generic-modal.component';
+import {ALERT_MODAL_ID} from './components/alert-modal/alert-modal.model';
+import {CONFIRM_MODAL_ID} from './components/confirm-modal/confirm-modal.model';
+import {DUMMY_MODAL_ID} from './components/dummy-modal/dummy-modal.model';
+
+@NgModule({
+  declarations: [
+    DynamicModalComponent,
+    ModalOutletComponent,
+    DummyModalComponent,
+    AlertModalComponent,
+    ConfirmModalComponent,
+    GenericModalComponent
+  ],
+  imports: [
+    CommonModule
+  ],
+  exports: [
+    ModalOutletComponent,
+    GenericModalComponent,
+  ],
+  providers: [
+    makeModalProvider(DUMMY_MODAL_ID, DummyModalComponent),
+    makeModalProvider(ALERT_MODAL_ID, AlertModalComponent),
+    makeModalProvider(CONFIRM_MODAL_ID, ConfirmModalComponent),
+    ModalService,
+    ModalQuery,
+    ModalStore
+  ],
+  entryComponents: [
+    DummyModalComponent,
+    ConfirmModalComponent,
+    AlertModalComponent,
+  ]
+})
+export class ModalModule {
+}

--- a/s4e-web/src/app/modal/modal.providers.ts
+++ b/s4e-web/src/app/modal/modal.providers.ts
@@ -1,0 +1,13 @@
+import {InjectionToken, Provider, Type} from '@angular/core';
+import {Modal} from './state/modal.model';
+
+export interface ModalProviderEntry {
+  name: string,
+  component: Type<any>
+}
+
+export const MODAL_DEF = new InjectionToken<Modal>('MODAL_DEF');
+export const MODAL_PROVIDER = new InjectionToken<ModalProviderEntry>('MODAL_PROVIDER');
+export function makeModalProvider(name: string, component: Type<any>): Provider {
+  return {provide: MODAL_PROVIDER, multi: true, useValue: {name, component}};
+}

--- a/s4e-web/src/app/modal/state/modal.model.ts
+++ b/s4e-web/src/app/modal/state/modal.model.ts
@@ -1,0 +1,31 @@
+import {EntityState, guid} from '@datorama/akita';
+
+export type ModalSize = 'sm'|'md'|'lg'|'fl';
+
+export interface Modal {
+  id: string;
+  uuid: string;
+  size: ModalSize;
+}
+
+export interface ModalWithReturnValue<T> extends Modal{
+  returnValue: T;
+  hasReturnValue: true;
+}
+
+export function hasReturnValue<T>(value: Modal): value is ModalWithReturnValue<T> {
+  return (value as any).hasReturnValue == true;
+}
+
+export interface ModalState extends EntityState<Modal, string> {}
+
+/**
+ * A factory function that creates Modal
+ */
+export function createModal<T>(params: Partial<Modal> & {id: string}): Modal {
+  return {
+    uuid: guid(),
+    size: 'md',
+    ...params
+  };
+}

--- a/s4e-web/src/app/modal/state/modal.query.spec.ts
+++ b/s4e-web/src/app/modal/state/modal.query.spec.ts
@@ -1,0 +1,45 @@
+import {ModalQuery} from './modal.query';
+import {ModalStore} from './modal.store';
+import {TestBed} from '@angular/core/testing';
+import {ModalService} from './modal.service';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {DUMMY_MODAL_ID} from '../components/dummy-modal/dummy-modal.model';
+import {createModal} from './modal.model';
+import * as akita from '@datorama/akita';
+
+describe('ModalQuery', () => {
+  let service: ModalService;
+  let store: ModalStore;
+  let query: ModalQuery;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ModalService, ModalStore, ModalQuery],
+      imports: [HttpClientTestingModule]
+    });
+
+    service = TestBed.get(ModalService);
+    store = TestBed.get(ModalStore);
+    query = TestBed.get(ModalQuery);
+  });
+
+  it('should create an instance', () => {
+    expect(query).toBeTruthy();
+  });
+
+  it('should modalClosed$ work', (done) => {
+    const uuid = '1f176345b9';
+    spyOn(akita, 'guid').and.returnValue(uuid);
+    query.modalClosed$(DUMMY_MODAL_ID).subscribe(modal => {
+      expect(modal).toEqual({
+        id: DUMMY_MODAL_ID,
+        size: 'md',
+        uuid: uuid
+      });
+      done();
+    });
+
+    service.show(createModal({id: DUMMY_MODAL_ID}));
+    service.hide(DUMMY_MODAL_ID, true);
+  });
+});

--- a/s4e-web/src/app/modal/state/modal.query.ts
+++ b/s4e-web/src/app/modal/state/modal.query.ts
@@ -1,0 +1,25 @@
+import {Injectable} from '@angular/core';
+import {QueryEntity} from '@datorama/akita';
+import {ModalStore} from './modal.store';
+import {Modal, ModalState} from './modal.model';
+import {Observable} from 'rxjs';
+import {filter, map, pairwise, take} from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ModalQuery extends QueryEntity<ModalState, Modal> {
+  constructor(protected store: ModalStore) {
+    super(store);
+  }
+
+  modalClosed$(modalId: string): Observable<Modal> {
+    return this.selectEntity(modalId)
+      .pipe(
+        pairwise(),
+        filter(([prev, curr]) => curr == null && prev != null),
+        map(([prev, curr]) => prev),
+        take(1)
+      );
+  }
+}

--- a/s4e-web/src/app/modal/state/modal.service.spec.ts
+++ b/s4e-web/src/app/modal/state/modal.service.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ModalService } from './modal.service';
+import { ModalStore } from './modal.store';
+import {DUMMY_MODAL_ID} from '../components/dummy-modal/dummy-modal.model';
+import {ModalQuery} from './modal.query';
+import * as akita from '@datorama/akita';
+import {CONFIRM_MODAL_ID} from '../components/confirm-modal/confirm-modal.model';
+import {ModalWithReturnValue} from './modal.model';
+import {ALERT_MODAL_ID} from '../components/alert-modal/alert-modal.model';
+
+describe('ModalService', () => {
+  let service: ModalService;
+  let store: ModalStore;
+  let query: ModalQuery;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ModalService, ModalStore, ModalQuery],
+      imports: [ HttpClientTestingModule ]
+    });
+
+    service = TestBed.get(ModalService);
+    store = TestBed.get(ModalStore);
+    query = TestBed.get(ModalQuery);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should show modal', () => {
+    spyOn(akita, 'guid').and.returnValue('abcdefgh');
+    service.show({id: DUMMY_MODAL_ID});
+    expect(query.getAll()).toEqual([
+      {
+        id: DUMMY_MODAL_ID,
+        size: "md",
+        uuid: "abcdefgh",
+      }
+    ])
+  });
+
+  it('should show / hide modal', () => {
+    service.show({id: DUMMY_MODAL_ID});
+    service.hide(DUMMY_MODAL_ID);
+    expect(query.getAll()).toEqual([])
+  });
+
+  it('should hide and return value beforehand', (done) => {
+    service.show({id: CONFIRM_MODAL_ID, hasReturnValue: true} as ModalWithReturnValue<boolean>);
+    const returnValue = query.modalClosed$(CONFIRM_MODAL_ID);
+    returnValue.subscribe(modal => {
+      expect((modal as ModalWithReturnValue<boolean>).returnValue).toBe(true);
+      done();
+    });
+
+    service.hide(CONFIRM_MODAL_ID, true);
+  });
+
+  it('should alert work', (done) => {
+    const content = 'content';
+    const title = 'title';
+    const spy = spyOn(service, 'show').and.callThrough();
+    const r = service.alert(title, content);
+    expect(spy).toHaveBeenCalledWith({id: ALERT_MODAL_ID, size: 'sm', content, title});
+    service.hide(ALERT_MODAL_ID);
+    r.then(() => done())
+  });
+
+  it('should confirm work', (done) => {
+    const content = 'content';
+    const title = 'title';
+    const spy = spyOn(service, 'show').and.callThrough();
+    const r = service.confirm(title, content);
+    expect(spy).toHaveBeenCalledWith({id: CONFIRM_MODAL_ID, size: 'sm', content, title, hasReturnValue: true});
+    service.hide(CONFIRM_MODAL_ID, true);
+    r.then(val => {
+      expect(val).toBe(true);
+      done();
+    })
+  });
+});

--- a/s4e-web/src/app/modal/state/modal.service.ts
+++ b/s4e-web/src/app/modal/state/modal.service.ts
@@ -1,0 +1,44 @@
+import {Inject, Injectable} from '@angular/core';
+import { ModalStore } from './modal.store';
+import {createModal, hasReturnValue, Modal, ModalWithReturnValue} from './modal.model';
+import {ModalQuery} from './modal.query';
+import {DOCUMENT} from '@angular/common';
+import {ALERT_MODAL_ID, AlertModal, isAlertModal} from '../components/alert-modal/alert-modal.model';
+import {map, tap} from 'rxjs/operators';
+import {CONFIRM_MODAL_ID, ConfirmModal, isConfirmModal} from '../components/confirm-modal/confirm-modal.model';
+
+@Injectable({ providedIn: 'root' })
+export class ModalService {
+
+  constructor(private store: ModalStore,
+              @Inject(DOCUMENT) private document: Document,
+              private query: ModalQuery) {
+  }
+
+  hide<T=void>(modalId: string, returnValue?: T) {
+    const modal = this.query.getEntity(modalId);
+    if(modal == null) {return;}
+    if(hasReturnValue(modal) && returnValue != null) {
+      this.store.upsert(modalId, {...modal, returnValue} as ModalWithReturnValue<T>)
+    }
+
+    this.store.remove(modalId);
+  }
+
+  show(modal: Partial<Modal> & {id: string}) {
+    if(this.document.activeElement != null) {
+      (this.document.activeElement as HTMLElement).blur();
+    }
+    this.store.add(createModal(modal))
+  }
+
+  async alert(title: string, content: string): Promise<void> {
+    const modalRef = this.show({id: ALERT_MODAL_ID, size: 'sm', content, title} as AlertModal);
+    return this.query.modalClosed$(ALERT_MODAL_ID).pipe(map(() => {})).toPromise();
+  }
+
+  async confirm(title: string, content: string): Promise<boolean> {
+    const modalRef = this.show({id: CONFIRM_MODAL_ID, size: 'sm', content, title, hasReturnValue: true} as ConfirmModal);
+    return this.query.modalClosed$(CONFIRM_MODAL_ID).pipe(map(m => isConfirmModal(m) ? m.returnValue : false)).toPromise();
+  }
+}

--- a/s4e-web/src/app/modal/state/modal.store.spec.ts
+++ b/s4e-web/src/app/modal/state/modal.store.spec.ts
@@ -1,0 +1,14 @@
+import { ModalStore } from './modal.store';
+
+describe('ModalStore', () => {
+  let store: ModalStore;
+
+  beforeEach(() => {
+    store = new ModalStore();
+  });
+
+  it('should create an instance', () => {
+    expect(store).toBeTruthy();
+  });
+
+});

--- a/s4e-web/src/app/modal/state/modal.store.ts
+++ b/s4e-web/src/app/modal/state/modal.store.ts
@@ -1,0 +1,12 @@
+import {Injectable} from '@angular/core';
+import {EntityStore, StoreConfig} from '@datorama/akita';
+import {Modal, ModalState} from './modal.model';
+
+@Injectable({providedIn: 'root'})
+@StoreConfig({name: 'Modal'})
+export class ModalStore extends EntityStore<ModalState, Modal> {
+  constructor() {
+    super();
+  }
+}
+

--- a/s4e-web/src/app/modal/utils/modal/modal.component.spec.ts
+++ b/s4e-web/src/app/modal/utils/modal/modal.component.spec.ts
@@ -1,0 +1,58 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {ModalComponent} from './modal.component';
+import {ModalService} from '../../state/modal.service';
+import {ModalModule} from '../../modal.module';
+import {makeModalProvider} from '../../modal.providers';
+
+export const MODAL_ID = 'mock-modal';
+
+@Component({
+  selector: 'mock-modal',
+  template: '',
+  styles: []
+})
+class MockModalComponent extends ModalComponent {
+  constructor(modalService: ModalService) {
+    super(modalService, MODAL_ID);
+  }
+}
+
+describe('ModalComponent', () => {
+  let component: ModalComponent;
+  let fixture: ComponentFixture<ModalComponent>;
+  let service: ModalService;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MockModalComponent,
+      ],
+      imports: [
+        ModalModule
+      ],
+      providers: [
+        makeModalProvider(MODAL_ID, MockModalComponent)
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MockModalComponent);
+    service = TestBed.get(ModalService);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have working dismiss()', () => {
+    let spy = spyOn(service, 'hide');
+    component.dismiss();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(MODAL_ID, undefined);
+  });
+});

--- a/s4e-web/src/app/modal/utils/modal/modal.component.ts
+++ b/s4e-web/src/app/modal/utils/modal/modal.component.ts
@@ -1,0 +1,9 @@
+import {ModalService} from '../../state/modal.service';
+
+export class ModalComponent<ReturnType=void> {
+  public dismiss(returnValue?: ReturnType): void {
+    this.modalService.hide(this.registeredId, returnValue);
+  }
+
+  constructor(protected modalService: ModalService, public registeredId?: string) {}
+}

--- a/s4e-web/src/app/views/map-view/map.module.ts
+++ b/s4e-web/src/app/views/map-view/map.module.ts
@@ -11,7 +11,6 @@ import { MapComponent } from './map/map.component';
 import {OverlayQuery} from './state/overlay/overlay.query';
 import {OverlayService} from './state/overlay/overlay.service';
 import {OverlayStore} from './state/overlay/overlay.store';
-import {BsDropdownModule} from 'ngx-bootstrap';
 import { LegendComponent } from './legend/legend.component';
 import {LegendStore} from './state/legend/legend.store';
 import {LegendQuery} from './state/legend/legend.query';
@@ -43,7 +42,6 @@ import {SceneStore} from './state/scene/scene.store.service';
   ],
   imports: [
     ShareModule,
-    BsDropdownModule,
     BrowserAnimationsModule,
     OwlDateTimeModule,
     OwlMomentDateTimeModule,

--- a/s4e-web/src/scss/_modal.scss
+++ b/s4e-web/src/scss/_modal.scss
@@ -1,0 +1,6 @@
+.modal-footer {
+  display: grid;
+  > .s4e-modal-footer {
+    text-align: right;
+  }
+}

--- a/s4e-web/src/scss/styles.scss
+++ b/s4e-web/src/scss/styles.scss
@@ -6,6 +6,7 @@
 //@import "~bootstrap/scss/bootstrap";
 @import "~ng-pick-datetime/assets/style/picker.min.css";
 @import "datepicker";
+@import "modal";
 
 
 


### PR DESCRIPTION
## What is in this PR?

Modal Module, without styling (@abacz should get to it in the next week). This Module integrates with AkitaStore, so that modals can be persisted between reloads during development.

This module contains following components:

* ModalOutlet - responsible for creating and removing modals depending on the store's state
* ModalService, ModalQuery, ModalStore - Store integrations
* AlertModal - used as an alert modal service
* ConfirmModal - used as an confirm modal service
* GenericModalComponent - component containing all boilerplate template for modal (header, content, footer)
* DummyModalComponent - component which can be referenced by developers when developing new modals

## How to test?

There should be a new button in the bottom right corner, which will launch series of modals (first confirm, on accepting, alert, and lastly dummy modal)

![Screenshot 2019-11-28 at 17 01 52](https://user-images.githubusercontent.com/13235269/69820839-598f0080-1202-11ea-8230-cfb416fae951.png)

![Screenshot 2019-11-28 at 17 01 58](https://user-images.githubusercontent.com/13235269/69820395-4e87a080-1201-11ea-9ded-8a47345c7ad6.png)

![Screenshot 2019-11-28 at 17 02 03](https://user-images.githubusercontent.com/13235269/69820405-521b2780-1201-11ea-9038-8c959b7c1581.png)

## WIP

There is a couple of tests missing, but otherwise it is ready for review.

Closes #262