### PR TITLE
[#311] HTML email templates

### DIFF
--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -27,6 +27,7 @@
         <slugify.version>2.4</slugify.version>
         <springdoc-openapi.version>1.2.25</springdoc-openapi.version>
         <awssdk.version>2.10.44</awssdk.version>
+        <commons-email.version>1.5</commons-email.version>
     </properties>
 
     <dependencies>
@@ -72,6 +73,12 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-email</artifactId>
+            <version>${commons-email.version}</version>
         </dependency>
 
         <dependency>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/LoggingMailSender.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/LoggingMailSender.java
@@ -2,21 +2,14 @@ package pl.cyfronet.s4e;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.mail.util.MimeMessageParser;
 import org.springframework.context.annotation.Profile;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailParseException;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.stereotype.Component;
 
-import javax.mail.Address;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Profile("development")
 @Component
@@ -25,27 +18,25 @@ public class LoggingMailSender extends JavaMailSenderImpl {
     @Override
     protected void doSend(MimeMessage[] mimeMessages, Object[] originalMessages) throws MailException {
         for (val mimeMessage: mimeMessages) {
-            try {
-                log.info(messageToString(mimeMessage));
-            } catch (MessagingException | IOException e) {
-                throw new MailParseException(e);
-            }
+            log.info(messageToString(mimeMessage));
         }
     }
 
-    protected static String messageToString(MimeMessage mimeMessage) throws MessagingException, IOException {
-        return "\n" +
-                "To: "+getRecipientsString(mimeMessage)+"\n"+
-                "Subject: "+mimeMessage.getSubject()+"\n"+
-                mimeMessage.getContent();
-    }
-
-    private static String getRecipientsString(MimeMessage mimeMessage) throws MessagingException {
-            Address[] recipients = mimeMessage.getRecipients(Message.RecipientType.TO);
-            List<String> addresses = Arrays.stream(recipients)
-                    .map(rec -> (InternetAddress) rec)
-                    .map(addr -> addr.getAddress())
-                    .collect(Collectors.toList());
-            return String.join(",", addresses);
+    private static String messageToString(MimeMessage mimeMessage) {
+        try {
+            MimeMessageParser parser = new MimeMessageParser(mimeMessage).parse();
+            StringBuilder sb = new StringBuilder();
+            sb.append("\nTO: ").append(parser.getTo());
+            sb.append("\nSUBJECT: ").append(parser.getSubject());
+            if (parser.hasPlainContent()) {
+                sb.append("\nPLAIN TEXT:\n").append(parser.getPlainContent());
+            }
+            if (parser.hasHtmlContent()) {
+                sb.append("\nHTML TEXT:\n").append(parser.getHtmlContent());
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new MailParseException(e);
+        }
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/EmailVerificationListener.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/EmailVerificationListener.java
@@ -64,9 +64,10 @@ public class EmailVerificationListener {
         Context ctx = new Context(event.getLocale());
         ctx.setVariable("email", appUser.getEmail());
 
-        String content = templateEngine.process("account-activated.txt", ctx);
+        String plainText = templateEngine.process("account-activated.txt", ctx);
+        String htmlText = templateEngine.process("account-activated.html", ctx);
 
-        mailService.sendEmail(recipientAddress, subject, content);
+        mailService.sendEmail(recipientAddress, subject, plainText, htmlText);
     }
 
     private void sendConfirmationEmail(AppUser appUser, Locale locale) {
@@ -80,8 +81,9 @@ public class EmailVerificationListener {
         ctx.setVariable("email", appUser.getEmail());
         ctx.setVariable("activationUrl", activationUrl);
 
-        String content = templateEngine.process("confirm-email.txt", ctx);
+        String plainText = templateEngine.process("confirm-email.txt", ctx);
+        String htmlText = templateEngine.process("confirm-email.html", ctx);
 
-        mailService.sendEmail(recipientAddress, subject, content);
+        mailService.sendEmail(recipientAddress, subject, plainText, htmlText);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/GroupListener.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/GroupListener.java
@@ -38,9 +38,10 @@ public class GroupListener {
         ctx.setVariable("groupName", group.getName());
         ctx.setVariable("institutionName", group.getInstitution().getName());
 
-        String content = templateEngine.process("group-add-member.txt", ctx);
+        String plainText = templateEngine.process("group-add-member.txt", ctx);
+        String htmlText = templateEngine.process("group-add-member.html", ctx);
 
-        mailService.sendEmail(recipientAddress, subject, content);
+        mailService.sendEmail(recipientAddress, subject, plainText, htmlText);
     }
 
     @Async
@@ -56,23 +57,25 @@ public class GroupListener {
         ctx.setVariable("groupName", group.getName());
         ctx.setVariable("institutionName", group.getInstitution().getName());
 
-        String content = templateEngine.process("group-remove-member.txt", ctx);
+        String plainText = templateEngine.process("group-remove-member.txt", ctx);
+        String htmlText = templateEngine.process("group-remove-member.html", ctx);
 
-        mailService.sendEmail(recipientAddress, subject, content);
+        mailService.sendEmail(recipientAddress, subject, plainText, htmlText);
     }
 
     @Async
     @EventListener
     public void handle(OnShareLinkEvent event) {
-
         String subject = messageSource.getMessage("email.link-share.subject", null, event.getLocale());
         Context ctx = new Context(event.getLocale());
         ctx.setVariable("email", event.getUser().getEmail());
         ctx.setVariable("link", urlDomain + event.getLink());
-        String content = templateEngine.process("share-link.txt", ctx);
+
+        String plainText = templateEngine.process("share-link.txt", ctx);
+        String htmlText = templateEngine.process("share-link.html", ctx);
 
         for (String recipientAddress : event.getEmails()) {
-            mailService.sendEmail(recipientAddress, subject, content);
+            mailService.sendEmail(recipientAddress, subject, plainText, htmlText);
         }
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/PasswordListener.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/PasswordListener.java
@@ -38,8 +38,9 @@ public class PasswordListener {
         Context ctx = new Context(event.getLocale());
         ctx.setVariable("resetPasswordUrl", resetPasswordUrl);
 
-        String content = templateEngine.process("password-reset.txt", ctx);
+        String plainText = templateEngine.process("password-reset.txt", ctx);
+        String htmlText = templateEngine.process("password-reset.html", ctx);
 
-        mailService.sendEmail(recipientAddress, subject, content);
+        mailService.sendEmail(recipientAddress, subject, plainText, htmlText);
     }
 }

--- a/s4e-backend/src/main/resources/mail/account-activated.html
+++ b/s4e-backend/src/main/resources/mail/account-activated.html
@@ -1,0 +1,8 @@
+<p>Dzień dobry!</p>
+
+<p>Twoje konto '[( ${email} )]' zostało aktywowane.</p>
+
+<p>
+Pozdrawiamy,<br/>
+Zespół sat4envi
+</p>

--- a/s4e-backend/src/main/resources/mail/confirm-email.html
+++ b/s4e-backend/src/main/resources/mail/confirm-email.html
@@ -1,0 +1,11 @@
+<p>Dzień dobry!</p>
+
+<p>
+    Twoje konto '[( ${email} )]' zostało utworzone.
+    Wejdź w [( ${activationUrl} )] aby potwierdzić adres email i aktywować konto.
+</p>
+
+<p>
+Pozdrawiamy,<br/>
+Zespół sat4envi
+</p>

--- a/s4e-backend/src/main/resources/mail/group-add-member.html
+++ b/s4e-backend/src/main/resources/mail/group-add-member.html
@@ -1,0 +1,8 @@
+<p>Dzień dobry!</p>
+
+<p>Zostałeś dodany do grupy [( ${groupName} )] w instytucji [( ${institutionName} )].</p>
+
+<p>
+Pozdrawiamy,<br/>
+Zespół sat4envi
+</p>

--- a/s4e-backend/src/main/resources/mail/group-remove-member.html.html
+++ b/s4e-backend/src/main/resources/mail/group-remove-member.html.html
@@ -1,0 +1,8 @@
+<p>Dzień dobry!</p>
+
+<p>Zostałeś usunięty z grupy [( ${groupName} )] w instytucji [( ${institutionName} )].</p>
+
+<p>
+Pozdrawiamy,<br/>
+Zespół sat4envi
+</p>

--- a/s4e-backend/src/main/resources/mail/password-reset.html
+++ b/s4e-backend/src/main/resources/mail/password-reset.html
@@ -1,0 +1,8 @@
+<p>Dzień dobry!</p>
+
+<p>Wejdź w [( ${resetPasswordUrl} )] aby ustawić nowe hasło.</p>
+
+<p>
+Pozdrawiamy,<br/>
+Zespół sat4envi
+</p>

--- a/s4e-backend/src/main/resources/mail/share-link.html
+++ b/s4e-backend/src/main/resources/mail/share-link.html
@@ -1,0 +1,8 @@
+<p>Dzień dobry!</p>
+
+<p>Użytkownik [( ${email} )] wysłał Ci link do widoku, aby go otworzyć kliknij w [( ${link} )].</p>
+
+<p>
+Pozdrawiamy,<br/>
+Zespół sat4envi
+</p>

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/listener/EmailVerificationListenerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/listener/EmailVerificationListenerTest.java
@@ -68,7 +68,7 @@ class EmailVerificationListenerTest {
 
         listener.handle(new OnResendRegistrationTokenEvent(appUser, null));
 
-        verify(mailService).sendEmail(eq(appUser.getEmail()), any(), any());
+        verify(mailService).sendEmail(eq(appUser.getEmail()), any(), any(), any());
     }
 
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/listener/GroupListenerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/listener/GroupListenerTest.java
@@ -36,12 +36,12 @@ public class GroupListenerTest {
                 .build();
 
         listener.handle(new OnShareLinkEvent(appUser, "this/is/link", List.of(), null));
-        verify(mailService, times(0)).sendEmail(any(), any(), any());
+        verify(mailService, times(0)).sendEmail(any(), any(), any(), any());
 
         listener.handle(new OnShareLinkEvent(appUser, "this/is/link", List.of("some@email.pl"), null));
-        verify(mailService, times(1)).sendEmail(any(), any(), any());
+        verify(mailService, times(1)).sendEmail(any(), any(), any(), any());
 
         listener.handle(new OnShareLinkEvent(appUser, "this/is/link", List.of("some@email.pl", "some2@email.pl"), null));
-        verify(mailService, times(3)).sendEmail(any(), any(), any());
+        verify(mailService, times(3)).sendEmail(any(), any(), any(), any());
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/listener/PasswordListenerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/listener/PasswordListenerTest.java
@@ -46,6 +46,6 @@ public class PasswordListenerTest {
 
         listener.handle(new OnPasswordResetTokenEmailEvent(appUser, null));
 
-        verify(mailService).sendEmail(eq(appUser.getEmail()), any(), any());
+        verify(mailService).sendEmail(eq(appUser.getEmail()), any(), any(), any());
     }
 }


### PR DESCRIPTION
Add HTML counterparts of plain-text email-templates.

Modify the LoggingMailSender to handle multipart messages.
To omit implementing MIME logic, I use Apache Commons Email library.

Closes: #311.