### PR TITLE
Extend "Get user profile" endpoint with extra data

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/AppUserResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/AppUserResponse.java
@@ -13,6 +13,8 @@ public class AppUserResponse {
     private String email;
     private String name;
     private String surname;
+    private boolean admin;
+    private boolean memberZK;
     private Set<UserRoleResponse> roles;
 
     public static AppUserResponse of(AppUser user) {
@@ -20,6 +22,8 @@ public class AppUserResponse {
                 .email(user.getEmail())
                 .name(user.getName())
                 .surname(user.getSurname())
+                .memberZK(user.isMemberZK())
+                .admin(user.isAdmin())
                 .roles(user.getRoles().stream().map(UserRoleResponse::of).collect(Collectors.toSet()))
                 .build();
     }

--- a/s4e-web/src/app/state/profile/profile.model.ts
+++ b/s4e-web/src/app/state/profile/profile.model.ts
@@ -1,0 +1,26 @@
+import {Role} from '../session/session.model';
+
+export interface Profile {
+  email: string;
+  name: string;
+  surname: string;
+  roles: Role[];
+  memberZK: boolean;
+  admin: boolean;
+}
+
+export interface ProfileState extends Profile {
+  loggedIn: boolean;
+}
+
+export function createInitialState(): ProfileState {
+  return {
+    email: '',
+    name: '',
+    loggedIn: false,
+    roles: [],
+    surname: '',
+    memberZK: false,
+    admin: false
+  };
+}

--- a/s4e-web/src/app/state/profile/profile.query.spec.ts
+++ b/s4e-web/src/app/state/profile/profile.query.spec.ts
@@ -1,0 +1,68 @@
+import {ProfileQuery} from './profile.query';
+import {async, TestBed} from '@angular/core/testing';
+import {CommonStateModule} from '../common-state.module';
+import {take} from 'rxjs/operators';
+import {ProfileStore} from './profile.store';
+
+describe('ProfileQuery', () => {
+  let query: ProfileQuery;
+  let store: ProfileStore;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [CommonStateModule],
+    });
+
+    query = TestBed.get(ProfileQuery);
+    store = TestBed.get(ProfileStore);
+  }));
+
+  it('should create an instance', () => {
+    expect(query).toBeTruthy();
+  });
+
+  it('should selectMemberZK', () => {
+    const spy = spyOn(query, 'select').and.returnValue(true);
+    query.selectMemberZK();
+    expect(spy).toHaveBeenCalledWith('memberZK');
+  });
+
+  function canSeeInstitutions$(): Promise<boolean> {
+    return query.selectCanSeeInstitutions().pipe(take(1)).toPromise();
+  }
+
+  it('should resolve to true if user is admin', async () => {
+    store.update({admin: true});
+    expect(await canSeeInstitutions$()).toBeTruthy();
+  });
+
+  it('should resolve to true if user has INST_ADMIN role in group', async () => {
+    store.update({roles: [{groupSlug: 'gr', institutionSlug: 'inst', role: 'INST_ADMIN'}]});
+    expect(await canSeeInstitutions$()).toBeTruthy();
+  });
+
+  it('should resolve to true if user has GROUP_MANAGER role in group', async () => {
+    store.update({roles: [{groupSlug: 'gr', institutionSlug: 'inst', role: 'GROUP_MANAGER'}]});
+    expect(await canSeeInstitutions$()).toBeTruthy();
+  });
+
+  it('should resolve to true if user has INST_MANAGER role in group', async () => {
+    store.update({roles: [{groupSlug: 'gr', institutionSlug: 'inst', role: 'INST_MANAGER'}]});
+    expect(await canSeeInstitutions$()).toBeTruthy();
+  });
+
+  it('should resolve to false if user has no managerial role', async () => {
+    store.update({roles: [{groupSlug: 'gr', institutionSlug: 'inst', role: 'GROUP_MEMBER'}]});
+    expect(await canSeeInstitutions$()).toBeFalsy();
+  });
+
+  it('should not resolve to true if user has at least one managerial role in group', async () => {
+    store.update({
+      roles: [
+        {groupSlug: 'gr', institutionSlug: 'inst', role: 'GROUP_MEMBER'},
+        {groupSlug: 'gr2', institutionSlug: 'inst2', role: 'GROUP_MANAGER'}
+      ]
+    });
+    expect(await canSeeInstitutions$()).toBeTruthy();
+  });
+});

--- a/s4e-web/src/app/state/profile/profile.query.ts
+++ b/s4e-web/src/app/state/profile/profile.query.ts
@@ -1,0 +1,23 @@
+import {Injectable} from '@angular/core';
+import {Query} from '@datorama/akita';
+import {ProfileStore} from './profile.store';
+import {ProfileState} from './profile.model';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+@Injectable({providedIn: 'root'})
+export class ProfileQuery extends Query<ProfileState> {
+
+  constructor(protected store: ProfileStore) {
+    super(store);
+  }
+
+  public selectMemberZK(): Observable<boolean> {
+    return this.select('memberZK');
+  }
+
+  public selectCanSeeInstitutions(): Observable<boolean> {
+    return this.select().pipe(map(state => state.admin ||
+      state.roles.find(role => ['INST_ADMIN', 'INST_MANAGER', 'GROUP_MANAGER'].includes(role.role)) != null));
+  }
+}

--- a/s4e-web/src/app/state/profile/profile.service.spec.ts
+++ b/s4e-web/src/app/state/profile/profile.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ProfileService } from './profile.service';
+import { ProfileStore } from './profile.store';
+
+describe('ProfileService', () => {
+  let profileService: ProfileService;
+  let profileStore: ProfileStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ProfileService, ProfileStore],
+      imports: [ HttpClientTestingModule ]
+    });
+
+    profileService = TestBed.get(ProfileService);
+    profileStore = TestBed.get(ProfileStore);
+  });
+
+  it('should be created', () => {
+    expect(profileService).toBeDefined();
+  });
+
+});

--- a/s4e-web/src/app/state/profile/profile.service.ts
+++ b/s4e-web/src/app/state/profile/profile.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import {HttpClient, HttpErrorResponse} from '@angular/common/http';
+import { ProfileStore } from './profile.store';
+import {Observable, of, pipe} from 'rxjs';
+import {Profile} from './profile.model';
+import {catchError, shareReplay, tap} from 'rxjs/operators';
+import {SessionQuery} from '../session/session.query';
+import {SessionService} from '../session/session.service';
+
+@Injectable({ providedIn: 'root' })
+export class ProfileService {
+
+  constructor(private store: ProfileStore,
+              private sessionQuery: SessionQuery,
+              private http: HttpClient) {
+  }
+
+  get$(): Observable<Profile|null> {
+    if(localStorage.getItem('token') == null) {
+      return of(null);
+    }
+
+    const r = this.http.get<Profile>('/api/v1/users/me').pipe(tap(
+      profile => this.store.update({...profile, loggedIn: true})
+    ), catchError(() => {
+      localStorage.removeItem('token');
+      localStorage.removeItem('email');
+      return of(null);
+    }), shareReplay(1));
+
+    r.subscribe();
+
+    return r;
+  }
+}

--- a/s4e-web/src/app/state/profile/profile.store.spec.ts
+++ b/s4e-web/src/app/state/profile/profile.store.spec.ts
@@ -1,0 +1,14 @@
+import { ProfileStore } from './profile.store';
+
+describe('ProfileStore', () => {
+  let store: ProfileStore;
+
+  beforeEach(() => {
+    store = new ProfileStore();
+  });
+
+  it('should create an instance', () => {
+    expect(store).toBeTruthy();
+  });
+
+});

--- a/s4e-web/src/app/state/profile/profile.store.ts
+++ b/s4e-web/src/app/state/profile/profile.store.ts
@@ -1,0 +1,14 @@
+import {Injectable} from '@angular/core';
+import {Store, StoreConfig} from '@datorama/akita';
+import {createInitialState, ProfileState} from './profile.model';
+
+@Injectable({ providedIn: 'root' })
+@StoreConfig({ name: 'Profile' })
+export class ProfileStore extends Store<ProfileState> {
+
+  constructor() {
+    super(createInitialState());
+  }
+
+}
+

--- a/s4e-web/src/app/state/session/session.model.ts
+++ b/s4e-web/src/app/state/session/session.model.ts
@@ -5,9 +5,9 @@ export interface LoginFormState {
 }
 
 export interface Role {
-  role: string,
-  institution: number|null,
-  group: number|null,
+  role: 'INST_ADMIN'|'INST_MANAGER'|'GROUP_MANAGER'|'GROUP_MEMBER',
+  institutionSlug: string|null,
+  groupSlug: string|null,
 }
 
 export interface Session {

--- a/s4e-web/src/app/state/session/session.query.ts
+++ b/s4e-web/src/app/state/session/session.query.ts
@@ -14,7 +14,7 @@ export class SessionQuery extends Query<Session> {
   }
 
   isLoggedIn(): boolean {
-    return this.getValue().token != null;
+    return localStorage.getItem('token') != null;
   }
 
   isLoggedIn$(): Observable<boolean> {
@@ -22,7 +22,7 @@ export class SessionQuery extends Query<Session> {
   }
 
   getToken(): string|null {
-    return this.getValue().token;
+    return localStorage.getItem('token');
   }
 
   isInitialized() {

--- a/s4e-web/src/app/utils/auth-guard/auth-guard.service.spec.ts
+++ b/s4e-web/src/app/utils/auth-guard/auth-guard.service.spec.ts
@@ -1,21 +1,68 @@
-import { TestBed, inject } from '@angular/core/testing';
-import { IsLoggedIn } from './auth-guard.service';
-import {HttpClientTestingModule} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import {IsLoggedIn, IsNotLoggedIn} from './auth-guard.service';
 import {RouterTestingModule} from '@angular/router/testing';
-import {ReactiveFormsModule} from '@angular/forms';
 import {SessionQuery} from '../../state/session/session.query';
+import {Component} from '@angular/core';
+import {Router} from '@angular/router';
 
-describe('IsLoggedIn', () => {
-  let service: IsLoggedIn;
+@Component({selector: 'neutral', template: ''})
+class NeutralComponent {}
+
+@Component({selector: 'sub', template: ''})
+class SubComponent {}
+
+@Component({selector: 'login', template: ''})
+class LoginComponent {}
+
+describe('IsLoggedIn & IsNotLoggedIn', () => {
+  let router: Router;
+  let query: SessionQuery;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, HttpClientTestingModule, RouterTestingModule.withRoutes([])],
-      providers: [IsLoggedIn, SessionQuery]
+      declarations: [SubComponent, LoginComponent, NeutralComponent],
+      imports: [RouterTestingModule.withRoutes(
+        [
+          {path: 'map/products', component: NeutralComponent},
+          {path: 'login', canActivate: [IsNotLoggedIn], component: LoginComponent},
+          {path: 'sub', canActivate: [IsLoggedIn], component: SubComponent}
+        ]
+      )],
+      providers: [IsLoggedIn, IsNotLoggedIn, SessionQuery],
     });
-    service = TestBed.get(IsLoggedIn);
+    router = TestBed.get(Router);
+    query = TestBed.get(SessionQuery);
+  });
+  describe('IsLoggedIn', () => {
+    it('should create', () => {
+      expect(TestBed.get(IsLoggedIn)).toBeTruthy();
+    });
+
+    it('should let in if user is logged in', async () => {
+      spyOn(query, 'isLoggedIn').and.returnValue(true);
+      expect(await router.navigate(['/sub'])).toBeTruthy();
+    });
+
+    it('should redirect to root if user is not logged in', async () => {
+      spyOn(query, 'isLoggedIn').and.returnValue(false);
+      expect(await router.navigate(['/sub'])).toBeFalsy();
+      expect(router.isActive('/login', true)).toBeTruthy();
+    });
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  describe('IsNotLoggedIn', () => {
+    it('should create', () => {
+      expect(TestBed.get(IsNotLoggedIn)).toBeTruthy();
+    });
+
+    it('should redirect to root if user is logged in', async () => {
+      spyOn(query, 'isLoggedIn').and.returnValue(true);
+      expect(await router.navigate(['/login'])).toBeFalsy();
+      expect(router.isActive('/map/products', true)).toBeTruthy();
+    });
+
+    it('should let user if he/she is not logged in', async () => {
+      spyOn(query, 'isLoggedIn').and.returnValue(false);
+      expect(await router.navigate(['/login'])).toBeTruthy();
+    });
   });
 });

--- a/s4e-web/src/app/utils/auth-guard/auth-guard.service.ts
+++ b/s4e-web/src/app/utils/auth-guard/auth-guard.service.ts
@@ -1,23 +1,17 @@
 import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '@angular/router';
-import {Observable} from 'rxjs';
+import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
 import {SessionQuery} from '../../state/session/session.query';
 
 @Injectable({providedIn: 'root'})
 export class IsLoggedIn implements CanActivate {
-
-  constructor(protected sessionQuery: SessionQuery, protected router: Router) {
-  }
+  constructor(protected sessionQuery: SessionQuery, protected router: Router) {}
 
   canActivate(next: ActivatedRouteSnapshot,
-              state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
-    const isLoggedIn: boolean = this.sessionQuery.isLoggedIn();
-
-    if (!isLoggedIn) {
-      this.router.navigate(['/login']);
+              state: RouterStateSnapshot): UrlTree | boolean {
+    if (!this.sessionQuery.isLoggedIn()) {
+      return this.router.parseUrl('/login');
     }
-
-    return isLoggedIn;
+    return true;
   }
 }
 
@@ -26,14 +20,10 @@ export class IsLoggedIn implements CanActivate {
 export class IsNotLoggedIn extends IsLoggedIn implements CanActivate {
 
   canActivate(next: ActivatedRouteSnapshot,
-              state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
-
-    const isLoggedIn: boolean = this.sessionQuery.isLoggedIn();
-
-    if (isLoggedIn) {
-      this.router.navigate(['/']);
+              state: RouterStateSnapshot): UrlTree | boolean {
+    if (this.sessionQuery.isLoggedIn()) {
+      return this.router.parseUrl('/map/products');
     }
-
-    return !isLoggedIn;
+    return true
   }
 }

--- a/s4e-web/src/app/utils/initializer/config.service.ts
+++ b/s4e-web/src/app/utils/initializer/config.service.ts
@@ -2,6 +2,8 @@ import {Injectable, InjectionToken, Provider} from '@angular/core';
 import {IConfiguration, IRemoteConfiguration} from '../../app.configuration';
 import {map, tap} from 'rxjs/operators';
 import {HttpClient} from '@angular/common/http';
+import {combineLatest, of} from 'rxjs';
+import {ProfileService} from '../../state/profile/profile.service';
 
 @Injectable()
 export class S4eConfig implements IConfiguration {
@@ -18,7 +20,7 @@ export class S4eConfig implements IConfiguration {
   userLocalStorageKey: string;
   generalErrorKey: string;
 
-  constructor(private http: HttpClient) {
+  constructor(private http: HttpClient, private profileService: ProfileService) {
   }
 
   init(config: IRemoteConfiguration) {
@@ -36,8 +38,11 @@ export class S4eConfig implements IConfiguration {
   }
 
   loadConfiguration(): Promise<IRemoteConfiguration> {
-    return this.http.get<IRemoteConfiguration>(`api/v1/config`).pipe(
-      tap(config => this.init(config))
+    return combineLatest([
+      this.http.get<IRemoteConfiguration>(`api/v1/config`).pipe(tap(config => this.init(config))),
+      this.profileService.get$()
+    ]).pipe(
+      map(([configuration, profile]) => configuration)
     ).toPromise();
   }
 }

--- a/s4e-web/src/app/views/map-view/map-view.component.html
+++ b/s4e-web/src/app/views/map-view/map-view.component.html
@@ -57,7 +57,7 @@
 >
 </s4e-map>
 
-<ng-container *ngIf="userLoggedIn$ | async">
+<ng-container *ngIf="userIsZK$ | async">
   <button (click)="toggleZKOptions()" id="zk-options-button" class="zk_dropdown_button">
   </button>
   <ng-container *ngIf="showZKOptions$ | async">

--- a/s4e-web/src/app/views/map-view/map-view.component.spec.ts
+++ b/s4e-web/src/app/views/map-view/map-view.component.spec.ts
@@ -5,10 +5,12 @@ import {TestingConfigProvider} from '../../app.configuration.spec';
 import {RouterTestingModule} from '@angular/router/testing';
 import {By} from '@angular/platform-browser';
 import {MapService} from './state/map/map.service';
-import {SessionStore} from '../../state/session/session.store';
+import {ProfileStore} from '../../state/profile/profile.store';
+
 
 describe('MapViewComponent', () => {
   let component: MapViewComponent;
+  let profileStore: ProfileStore;
   let fixture: ComponentFixture<MapViewComponent>;
 
   beforeEach(async(() => {
@@ -17,6 +19,7 @@ describe('MapViewComponent', () => {
       providers: [TestingConfigProvider]
     })
       .compileComponents();
+    profileStore = TestBed.get(ProfileStore);
   }));
 
   beforeEach(() => {
@@ -30,9 +33,21 @@ describe('MapViewComponent', () => {
   });
 
   describe('ZK Options', () => {
+    it('should not show #zk-options-button if user is not memberZK', () => {
+      profileStore.update({memberZK: false});
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#zk-options-button'))).toBeNull();
+    });
+
+    it('should show #zk-options-button if user is not memberZK', () => {
+      profileStore.update({memberZK: true});
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#zk-options-button'))).not.toBeNull();
+    });
+
     it('clicking #zk-options-button should show options', () => {
       // log in user
-      (TestBed.get(SessionStore) as SessionStore).update({token: 'valid'});
+      profileStore.update({memberZK: true});
       fixture.detectChanges();
       fixture.debugElement.query(By.css('#zk-options-button')).nativeElement.click();
       fixture.detectChanges();
@@ -41,7 +56,7 @@ describe('MapViewComponent', () => {
 
     it('clicking .zk__dropdown__close should toggleZKOptions(false)', () => {
       // log in user
-      (TestBed.get(SessionStore) as SessionStore).update({token: 'valid'});
+      profileStore.update({memberZK: true});
       fixture.detectChanges();
       fixture.debugElement.query(By.css('#zk-options-button')).nativeElement.click();
       fixture.detectChanges();
@@ -55,10 +70,6 @@ describe('MapViewComponent', () => {
       const spy = spyOn(service, 'toggleZKOptions');
       component.toggleZKOptions();
       expect(spy).toHaveBeenCalledWith(true);
-    });
-
-    it('should not show zk-options-button if user is not logged in', () => {
-      expect(fixture.debugElement.query(By.css('#zk-options-button'))).toBeFalsy();
     });
   });
 });

--- a/s4e-web/src/app/views/map-view/map-view.component.ts
+++ b/s4e-web/src/app/views/map-view/map-view.component.ts
@@ -23,6 +23,7 @@ import {SceneQuery} from './state/scene/scene.query.service';
 import {MapComponent} from './map/map.component';
 import {ModalService} from '../../modal/state/modal.service';
 import {REPORT_MODAL_ID, ReportModal} from './report-modal/report-modal.model';
+import {ProfileQuery} from '../../state/profile/profile.query';
 
 @Component({
   selector: 's4e-map-view',
@@ -44,9 +45,10 @@ export class MapViewComponent implements OnInit {
   public availableDates$: Observable<string[]>;
   public showZKOptions$: Observable<boolean>;
   public selectedLocation$: Observable<SearchResult | null>;
+  public userIsZK$: Observable<boolean>;
   @ViewChild('map', {read: MapComponent}) mapComponent: MapComponent;
 
-  constructor(private mapService: MapService,
+  constructor(public mapService: MapService,
               private mapQuery: MapQuery,
               private overlayQuery: OverlayQuery,
               private overlayService: OverlayService,
@@ -60,10 +62,12 @@ export class MapViewComponent implements OnInit {
               private legendService: LegendService,
               private searchResultsQuery: SearchResultsQuery,
               private modalService: ModalService,
+              private profileQuery: ProfileQuery,
               private CONFIG: S4eConfig) {
   }
 
   ngOnInit(): void {
+    this.userIsZK$ = this.profileQuery.selectMemberZK();
     this.selectedLocation$ = this.searchResultsQuery.selectLocation();
     this.loading$ = this.mapQuery.selectLoading();
     this.currentTimelineDate$ = this.productQuery.selectSelectedDate();

--- a/s4e-web/src/app/views/settings/guards/is-manager/is-manager.guard.spec.ts
+++ b/s4e-web/src/app/views/settings/guards/is-manager/is-manager.guard.spec.ts
@@ -1,0 +1,53 @@
+import {TestBed} from '@angular/core/testing';
+import {IsManagerGuard} from './is-manager.guard';
+import {Component} from '@angular/core';
+import {Router} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+import {ProfileQuery} from '../../../../state/profile/profile.query';
+import {ProfileStore} from '../../../../state/profile/profile.store';
+import {of} from 'rxjs';
+
+
+@Component({selector: 'neutral', template: ''})
+class NeutralComponent {
+}
+
+@Component({selector: 'restricted', template: ''})
+class RestrictedComponent {
+}
+
+describe('IsManagerGuard', () => {
+  let router: Router;
+  let query: ProfileQuery;
+  let store: ProfileStore;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [NeutralComponent, RestrictedComponent],
+      imports: [RouterTestingModule.withRoutes(
+        [
+          {path: 'settings/profile', component: NeutralComponent},
+          {path: 'restricted', canActivate: [IsManagerGuard], component: RestrictedComponent}
+        ]
+      )],
+      providers: [IsManagerGuard, ProfileQuery, ProfileStore],
+    });
+    router = TestBed.get(Router);
+    store = TestBed.get(ProfileStore);
+    query = TestBed.get(ProfileQuery);
+  });
+
+  it('should create', () => {
+    expect(TestBed.get(IsManagerGuard)).toBeTruthy();
+  });
+
+  it('should allow if selectCanSeeInstitutions resolves true', async () => {
+    spyOn(query, 'selectCanSeeInstitutions').and.returnValue(of(true));
+    expect(await router.navigate(['/restricted'])).toBeTruthy();
+  });
+
+  it('should return redirect if selectCanSeeInstitutions resolves false', async () => {
+    spyOn(query, 'selectCanSeeInstitutions').and.returnValue(of(false));
+    expect(await router.navigate(['/restricted'])).toBeFalsy();
+    expect(await router.isActive('settings/profile', true));
+  });
+});

--- a/s4e-web/src/app/views/settings/guards/is-manager/is-manager.guard.ts
+++ b/s4e-web/src/app/views/settings/guards/is-manager/is-manager.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import {CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router, UrlTree} from '@angular/router';
+import { Observable } from 'rxjs';
+import {ProfileQuery} from '../../../../state/profile/profile.query';
+import {map, take} from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class IsManagerGuard implements CanActivate {
+  constructor(private profileQuery: ProfileQuery, private router: Router) {
+  }
+
+  canActivate(
+    next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean|UrlTree> | Promise<boolean|UrlTree> | boolean|UrlTree {
+    return this.profileQuery.selectCanSeeInstitutions().pipe(take(1),
+      map(manager => manager ? true : this.router.parseUrl('/settings/profile')))
+  }
+}

--- a/s4e-web/src/app/views/settings/settings.component.html
+++ b/s4e-web/src/app/views/settings/settings.component.html
@@ -1,10 +1,10 @@
 <div class="container">
   <nav class="navigation">
     <ul class="navigation__list">
-      <li routerLinkActive="active"><a [routerLink]="['./dashboard']" queryParamsHandling="merge" i18n>Dashboard</a></li>
-      <li routerLinkActive="active"><a [routerLink]="['./groups']" queryParamsHandling="merge" i18n>Grupy</a></li>
-      <li routerLinkActive="active"><a [routerLink]="['./people']" queryParamsHandling="merge" i18n>Ludzie</a></li>
-      <li routerLinkActive="active"><a [routerLink]="['./institution']" queryParamsHandling="merge" i18n>Profil Instytucji</a></li>
+      <li *ngIf="showInstitutions$ | async" routerLinkActive="active"><a [routerLink]="['./dashboard']" queryParamsHandling="merge" i18n>Dashboard</a></li>
+      <li *ngIf="showInstitutions$ | async" routerLinkActive="active"><a [routerLink]="['./groups']" queryParamsHandling="merge" i18n>Grupy</a></li>
+      <li *ngIf="showInstitutions$ | async" routerLinkActive="active"><a [routerLink]="['./people']" queryParamsHandling="merge" i18n>Ludzie</a></li>
+      <li *ngIf="showInstitutions$ | async" routerLinkActive="active"><a [routerLink]="['./institution']" queryParamsHandling="merge" i18n>Profil Instytucji</a></li>
       <li routerLinkActive="active"><a [routerLink]="['./profile']" queryParamsHandling="merge" i18n>Twój profil</a></li>
     </ul>
     <section class="login">

--- a/s4e-web/src/app/views/settings/settings.component.ts
+++ b/s4e-web/src/app/views/settings/settings.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import {SessionService} from '../../state/session/session.service';
+import {Observable} from 'rxjs';
+import {ProfileQuery} from '../../state/profile/profile.query';
 
 @Component({
   selector: 's4e-settings',
@@ -7,10 +9,12 @@ import {SessionService} from '../../state/session/session.service';
   styleUrls: ['./settings.component.scss']
 })
 export class SettingsComponent implements OnInit {
+  showInstitutions$: Observable<boolean>;
 
-  constructor(private sessionService: SessionService) { }
+  constructor(private sessionService: SessionService, private profileQuery: ProfileQuery) { }
 
   ngOnInit() {
+    this.showInstitutions$ = this.profileQuery.selectCanSeeInstitutions();
   }
 
   logout() {

--- a/s4e-web/src/app/views/settings/settings.routes.ts
+++ b/s4e-web/src/app/views/settings/settings.routes.ts
@@ -14,6 +14,7 @@ import {untilDestroyed} from 'ngx-take-until-destroy';
 import {InstitutionService} from './state/institution.service';
 import {InstitutionQuery} from './state/institution.query';
 import {Injectable} from '@angular/core';
+import {IsManagerGuard} from './guards/is-manager/is-manager.guard';
 
 export const settingsRoutes: Routes = [
   {
@@ -24,6 +25,7 @@ export const settingsRoutes: Routes = [
       {
         path: 'dashboard',
         component: DashboardComponent,
+        canActivate: [IsManagerGuard]
       },
       {
         path: 'profile',
@@ -32,26 +34,32 @@ export const settingsRoutes: Routes = [
       {
         path: 'groups',
         component: GroupListComponent,
+        canActivate: [IsManagerGuard]
       },
       {
         path: 'groups/:groupSlug',
         component: GroupFormComponent,
+        canActivate: [IsManagerGuard]
       },
       {
         path: 'institution',
-        component: InstitutionProfileComponent
+        component: InstitutionProfileComponent,
+        canActivate: [IsManagerGuard]
       },
       {
         path: 'people',
-        component: PersonListComponent
+        component: PersonListComponent,
+        canActivate: [IsManagerGuard]
       },
       {
         path: 'people/add',
-        component: PersonFormComponent
+        component: PersonFormComponent,
+        canActivate: [IsManagerGuard]
       },
       {
         path: 'people/:email',
-        component: PersonFormComponent
+        component: PersonFormComponent,
+        canActivate: [IsManagerGuard]
       },
       {
         path: '**',


### PR DESCRIPTION
## What is in this PR?

Hide institutions management in settings for users who have management roles, hide ZK dropdown for users who have `memberZK` flag

![image](https://user-images.githubusercontent.com/13235269/72361113-3a382e00-36f1-11ea-83ef-d4946c2cb543.png)

![image](https://user-images.githubusercontent.com/13235269/72361133-43c19600-36f1-11ea-8982-da59c162539a.png)

## How to test?

* Create user who have `memberZK` flag and log in, dropdown should be visible.
* Navigate to settings with user without any group roles - only profile should be visible
* Navigate to settings with user with management group role - all options should be available