### PR TITLE
[#321] Add extra share link fields

### DIFF
--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -85,6 +85,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ShareLinkController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ShareLinkController.java
@@ -6,23 +6,20 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import pl.cyfronet.s4e.bean.AppUser;
 import pl.cyfronet.s4e.controller.request.ShareLinkRequest;
 import pl.cyfronet.s4e.event.OnShareLinkEvent;
-import pl.cyfronet.s4e.ex.NotFoundException;
-import pl.cyfronet.s4e.security.AppUserDetails;
-import pl.cyfronet.s4e.service.AppUserService;
 
 import javax.validation.Valid;
+import java.util.Base64;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
@@ -34,25 +31,27 @@ import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 @PreAuthorize("isAuthenticated()")
 public class ShareLinkController {
     private final ApplicationEventPublisher eventPublisher;
-    private final AppUserService appUserService;
 
     @Operation(
             summary = "Share link",
             description =
-                    "Send email with shared linked for user of ZK to access"
+                    "Send email with shared link for user of ZK to access"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Operation successful", content = @Content),
-            @ApiResponse(responseCode = "403", description = "Not authenticated", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
+            @ApiResponse(responseCode = "403", description = "Not authenticated", content = @Content)
     })
     @PostMapping("/share-link")
     @PreAuthorize("isZKMember()")
-    public ResponseEntity<?> shareLink(@RequestBody @Valid ShareLinkRequest request) throws NotFoundException {
-        AppUserDetails appUserDetails = (AppUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        AppUser appUser = appUserService.findByEmailWithRolesAndGroupsAndInstitution(appUserDetails.getUsername())
-                .orElseThrow(() -> new NotFoundException("User not found for email: '" + appUserDetails.getUsername() + "'"));
-        eventPublisher.publishEvent(new OnShareLinkEvent(appUser, request.getLink(), request.getEmails(), LocaleContextHolder.getLocale()));
-        return ResponseEntity.ok().build();
+    public void shareLink(@RequestBody @Valid ShareLinkRequest request) {
+        String requesterEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        val shareRequest = OnShareLinkEvent.Request.builder()
+                .caption(request.getCaption())
+                .description(request.getDescription())
+                .thumbnail(Base64.getDecoder().decode(request.getThumbnail()))
+                .path(request.getPath())
+                .emails(request.getEmails())
+                .build();
+        eventPublisher.publishEvent(new OnShareLinkEvent(requesterEmail, shareRequest, LocaleContextHolder.getLocale()));
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/ShareLinkRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/ShareLinkRequest.java
@@ -1,17 +1,33 @@
 package pl.cyfronet.s4e.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
+import pl.cyfronet.s4e.controller.validation.Base64;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 @Data
 @Builder
 public class ShareLinkRequest {
+    @NotBlank
+    private String caption;
+
+    @NotBlank
+    private String description;
+
     @NotEmpty
-    private String link;
+    @Base64
+    @Schema(required = true, format = "base64")
+    private String thumbnail;
+
+    @NotBlank
+    @Schema(required = true, description = "The link to share. Relative path with a leading slash", example = "/some/path?param=42")
+    private String path;
+
     @NotEmpty
     private List<@Email String> emails;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/event/OnShareLinkEvent.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/event/OnShareLinkEvent.java
@@ -1,25 +1,34 @@
 package pl.cyfronet.s4e.event;
 
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Value;
 import org.springframework.context.ApplicationEvent;
-import pl.cyfronet.s4e.bean.AppUser;
 
 import java.util.List;
 import java.util.Locale;
 
 @Getter
 public class OnShareLinkEvent extends ApplicationEvent {
-    private final AppUser user;
-    private final String link;
-    private final List<String> emails;
+    @Value
+    @Builder
+    public static class Request {
+        String caption;
+        String description;
+        byte[] thumbnail;
+        String path;
+        List<String> emails;
+    }
+
+    private final String requesterEmail;
+    private final Request request;
     private final Locale locale;
 
-    public OnShareLinkEvent(AppUser appUser, String link, List<String> emails, Locale locale) {
-        super(appUser);
+    public OnShareLinkEvent(String requesterEmail, Request request, Locale locale) {
+        super(requesterEmail);
 
-        this.user = appUser;
-        this.link = link;
-        this.emails = emails;
+        this.requesterEmail = requesterEmail;
+        this.request = request;
         this.locale = locale;
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/MailService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/MailService.java
@@ -13,7 +13,7 @@ import javax.mail.internet.MimeMessage;
 @RequiredArgsConstructor
 @Slf4j
 public class MailService {
-    private interface Modifier {
+    public interface Modifier {
         void modify(MimeMessageHelper helper) throws MessagingException;
     }
 
@@ -27,7 +27,7 @@ public class MailService {
         });
     }
 
-    private void sendEmail(Modifier modifier) {
+    public void sendEmail(Modifier modifier) {
         try {
             MimeMessage message = javaMailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true);

--- a/s4e-backend/src/main/resources/mail/share-link.html
+++ b/s4e-backend/src/main/resources/mail/share-link.html
@@ -1,6 +1,11 @@
 <p>Dzień dobry!</p>
 
-<p>Użytkownik [( ${email} )] wysłał Ci link do widoku, aby go otworzyć kliknij w [( ${link} )].</p>
+<p>Użytkownik [( ${email} )] wysłał Ci link do widoku, aby go otworzyć kliknij w [( ${url} )].</p>
+
+<p>
+Tytuł: [( ${caption} )]<br/>
+Opis: [( ${description} )]
+</p>
 
 <p>
 Pozdrawiamy,<br/>

--- a/s4e-backend/src/main/resources/mail/share-link.txt
+++ b/s4e-backend/src/main/resources/mail/share-link.txt
@@ -1,6 +1,9 @@
 Dzień dobry!
 
-Użytkownik [( ${email} )] wysłał Ci link do widoku, aby go otworzyć kliknij w [( ${link} )] .
+Użytkownik [( ${email} )] wysłał Ci link do widoku, aby go otworzyć kliknij w [( ${url} )].
+
+Tytuł: [( ${caption} )]
+Opis: [( ${description} )]
 
 Pozdrawiamy,
 Zespół sat4envi

--- a/s4e-backend/src/main/resources/messages_pl_PL.properties
+++ b/s4e-backend/src/main/resources/messages_pl_PL.properties
@@ -9,4 +9,4 @@ email.account-activated.subject=Konto aktywowane
 email.password-reset.subject=Reset hasła
 email.group-add.subject=Dodanie do grupy
 email.group-remove.subject=Usunięcie z grupy
-email.link-share.subject=Udostępnienie linku do widoku
+email.share-link.subject=Udostępnienie linku do widoku

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ShareLinkControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ShareLinkControllerTest.java
@@ -1,0 +1,136 @@
+package pl.cyfronet.s4e.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.store.MailFolder;
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.GreenMail;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.mail.util.MimeMessageParser;
+import org.awaitility.Durations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.GreenMailSupplier;
+import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.TestResourceHelper;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.controller.request.ShareLinkRequest;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+
+import javax.mail.internet.MimeMessage;
+import java.util.List;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
+
+@AutoConfigureMockMvc
+@BasicTest
+@Slf4j
+public class ShareLinkControllerTest {
+    private static final String IMAGE_PNG_PATH = "classpath:images/image.png";
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TestResourceHelper testResourceHelper;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    @Value("${mail.urlDomain}")
+    private String urlDomain;
+
+    private AppUser appUser;
+
+    private GreenMail greenMail;
+
+    @BeforeEach
+    public void beforeEach() {
+        testDbHelper.clean();
+
+        appUser = appUserRepository.save(AppUser.builder()
+                .email("get@profile.com")
+                .name("Get")
+                .surname("Profile")
+                .password("{noop}password")
+                .enabled(true)
+                .memberZK(true)
+                .build());
+
+        greenMail = new GreenMailSupplier().get();
+        greenMail.start();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        greenMail.stop();
+        testDbHelper.clean();
+    }
+
+    @Test
+    public void shouldShareLink() throws Exception {
+        val request = ShareLinkRequest.builder()
+                .caption("Some caption")
+                .description("Yet another description")
+                .path("/some/path?hehe=tralala")
+                .thumbnail(testResourceHelper.getAsStringInBase64(IMAGE_PNG_PATH))
+                .emails(List.of("some-1@email.pl", "some-2@email.pl"))
+                .build();
+
+        MailFolder inbox1 = getInbox(greenMail, greenMail.setUser("some-1@email.pl", ""));
+        MailFolder inbox2 = getInbox(greenMail, greenMail.setUser("some-2@email.pl", ""));
+
+        mockMvc.perform(post(API_PREFIX_V1 + "/share-link")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request))
+                .with(jwtBearerToken(appUser, objectMapper)))
+                .andExpect(status().isOk());
+
+        // Email sending handler is executed in @Async method so allow it to run
+        await().atMost(Durations.ONE_SECOND)
+                .until(() -> inbox1.getMessageCount() == 1 && inbox2.getMessageCount() == 1);
+
+        MimeMessageParser parser1 = getParserForFirstMail(inbox1);
+        assertThat(parser1.getPlainContent(), containsString(request.getCaption()));
+        assertThat(parser1.getPlainContent(), containsString(request.getDescription()));
+        assertThat(parser1.getPlainContent(), containsString(urlDomain + request.getPath()));
+        assertThat(parser1.getAttachmentList().size(), is(equalTo(1)));
+        assertThat(parser1.getAttachmentList().get(0).getContentType(), is(equalTo("image/png")));
+
+        MimeMessageParser parser2 = getParserForFirstMail(inbox2);
+        assertThat(parser2.getPlainContent(), containsString(request.getCaption()));
+        assertThat(parser2.getPlainContent(), containsString(request.getDescription()));
+        assertThat(parser2.getPlainContent(), containsString(urlDomain + request.getPath()));
+        assertThat(parser2.getAttachmentList().size(), is(equalTo(1)));
+        assertThat(parser2.getAttachmentList().get(0).getContentType(), is(equalTo("image/png")));
+    }
+
+    public static MimeMessageParser getParserForFirstMail(MailFolder inbox) throws Exception {
+        MimeMessage mimeMessage = inbox.getMessages().get(0).getMimeMessage();
+        return new MimeMessageParser(mimeMessage).parse();
+    }
+
+    public static MailFolder getInbox(GreenMail greenMail, GreenMailUser mailUser) throws FolderException {
+        return greenMail.getManagers().getImapHostManager().getInbox(mailUser);
+    }
+}


### PR DESCRIPTION
Add caption, description and thumbnail fields to `/share-link` endpoint.
Also, rename link to path.

Rework the way the request parameters are handled and passed to the
event listener.

Exclude an unnecessary junit-vintage dependency from
spring-boot-starter-test.

Closes: #321.