### PR TITLE
[#337] Selecting search result should change map

### DIFF
--- a/s4e-web/cypress/integration/product-navigation.spec.ts
+++ b/s4e-web/cypress/integration/product-navigation.spec.ts
@@ -30,4 +30,17 @@ context('productNavigation', () => {
     //   expect(networkrequests.length).to.eq(1);
     // })
   });
+
+  it('should search places', () => {
+    cy.get('.search__input').type('warsz');
+    cy.get('.searchResults', {timeout: 10000}).should('be.visible');
+    cy.get('.searchresult__container > ul > :nth-child(1)').as('searchResult');
+    cy.get('@searchResult').should('contain', 'Warszawa');
+    cy.get('@searchResult').get('.type').should('contain', 'miasto');
+    cy.get('@searchResult').get('.voivodeship').should('contain', 'mazowieckie');
+    cy.get('@searchResult').click();
+    cy.get('.searchResults').should('not.visible');
+    cy.get('.reset_search_button').click();
+    cy.get('.search__input').should('have.value', '');
+  });
 });

--- a/s4e-web/src/app/views/map-view/map-view.component.scss
+++ b/s4e-web/src/app/views/map-view/map-view.component.scss
@@ -1,5 +1,9 @@
 @import "../../../scss/variables";
 
+#map {
+  left: 360px;
+}
+
 .zk-options {
   position: absolute;
   right: 10px;
@@ -31,11 +35,9 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  position: absolute;
-  left: 0;
   z-index: 2;
   padding: 15px;
-  overflow-x: scroll;
+  box-sizing: padding-box;
 
   .switch {
     margin: -15px;
@@ -66,31 +68,6 @@
     }
   }
 }
-
-//.login {
-//  padding: 40px 15px 10px 15px;
-//  margin-top: auto;
-//  align-self: center;
-//  text-align: center;
-//  background: $color-white;
-//  position: fixed;
-//  bottom: 0;
-//  width: 360px;
-//  box-shadow: 0 -2px 10px rgba(0,0,0,0.2);
-//
-//  a:not(.button) {
-//    color: $color-grey;
-//    text-transform: uppercase;
-//    font-weight: bold;
-//    font-size: 0.75rem;
-//  }
-//
-//  li {
-//    margin-bottom: $space-xlarge;
-//    font-weight: 400;
-//  }
-//}
-
 
 .dropdown_button {
   width: 50px;

--- a/s4e-web/src/app/views/map-view/map-view.component.ts
+++ b/s4e-web/src/app/views/map-view/map-view.component.ts
@@ -85,7 +85,6 @@ export class MapViewComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.userIsZK$ = this.profileQuery.selectMemberZK();
-    this.selectedLocation$ = this.searchResultsQuery.selectLocation();
     this.loading$ = this.mapQuery.selectLoading();
     this.currentTimelineDate$ = this.productQuery.selectSelectedDate();
     this.activeScene$ = this.sceneQuery.selectActive();

--- a/s4e-web/src/app/views/map-view/map/map.component.scss
+++ b/s4e-web/src/app/views/map-view/map/map.component.scss
@@ -1,7 +1,7 @@
 #map {
   position: absolute;
   top: 0;
-  left: 0;
+  left: 390px;
   width: 100%;
   bottom: 0;
   z-index: 0;

--- a/s4e-web/src/app/views/map-view/search-results/search-results.component.html
+++ b/s4e-web/src/app/views/map-view/search-results/search-results.component.html
@@ -1,6 +1,5 @@
 <div class="searchResult">
-
-  <div [hidden]="!loading">
+  <div [hidden]="!loading" class="searchResult__loader">
     <fa-icon [icon]="['fas', 'spinner']" [spin]="true"></fa-icon>
     <span class="search__loading" i18n>Wczytywanie wyników</span>
   </div>

--- a/s4e-web/src/app/views/map-view/search-results/search-results.component.scss
+++ b/s4e-web/src/app/views/map-view/search-results/search-results.component.scss
@@ -1,5 +1,8 @@
 @import "../../../../scss/variables";
 
+.searchResult__loader {
+  padding: 0 15px;
+}
 
 .searchResult__item {
   height: 20px;
@@ -19,17 +22,10 @@
 
 
 .searchResult {
-  padding: 10px;
-  border-radius: $border-radius-default;
-
-  fa-icon {
-    margin-right: $space-xsmall;
-  }
-
   ul {
     li {
-      margin-bottom: $space-xsmall;
-      padding: $space-xsmall $space-xsmall 1px $space-xsmall;
+      padding: $space-xsmall $space-default;
+      font-size: 0.938rem;
 
       &:last-child {
         margin-bottom: 0;
@@ -48,14 +44,10 @@
       }
 
       &:hover {
-        border-radius: $border-radius-default;
         background: $color-grey-primary;
         cursor: pointer;
-        padding-left: $space-small;
       }
     }
-
-
   }
 }
 

--- a/s4e-web/src/app/views/map-view/state/map/map.model.ts
+++ b/s4e-web/src/app/views/map-view/state/map/map.model.ts
@@ -1,11 +1,6 @@
 import {S4eConfig} from '../../../../utils/initializer/config.service';
 import {InjectorModule} from '../../../../common/injector.module';
 
-export const ZOOM_LEVELS = {
-  'miasto': 10,
-  'wieś': 12
-};
-
 export interface ViewPosition {
   centerCoordinates: [number, number];
   zoomLevel: number;

--- a/s4e-web/src/app/views/map-view/state/search-results/search-results.service.spec.ts
+++ b/s4e-web/src/app/views/map-view/state/search-results/search-results.service.spec.ts
@@ -5,6 +5,8 @@ import {SearchResultsStore} from './search-results.store';
 import {SearchResultsQuery} from './search-results.query';
 import {TestingConfigProvider} from '../../../../app.configuration.spec';
 import {AkitaGuidService} from './guid.service';
+import {InjectorModule} from '../../../../common/injector.module';
+import {RouterTestingModule} from '@angular/router/testing';
 
 
 describe('SearchResultsService', () => {
@@ -17,7 +19,7 @@ describe('SearchResultsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [SearchResultsService, SearchResultsStore, SearchResultsQuery, TestingConfigProvider, AkitaGuidService],
-      imports: [HttpClientTestingModule]
+      imports: [InjectorModule, HttpClientTestingModule, RouterTestingModule]
     });
 
     http = TestBed.get(HttpTestingController);

--- a/s4e-web/src/app/views/map-view/state/search-results/search-results.service.ts
+++ b/s4e-web/src/app/views/map-view/state/search-results/search-results.service.ts
@@ -9,11 +9,13 @@ import {PageSearchResult} from '../../../../utils/state.types';
 import {MapService} from '../map/map.service';
 import proj4 from 'proj4';
 import {ViewPosition} from '../map/map.model';
+import {SearchResultsQuery} from './search-results.query';
 
 @Injectable({providedIn: 'root'})
 export class SearchResultsService {
 
   constructor(private store: SearchResultsStore,
+              private query: SearchResultsQuery,
               private guidGenerationService: AkitaGuidService,
               private mapService: MapService,
               private http: HttpClient,
@@ -54,5 +56,11 @@ export class SearchResultsService {
       zoomLevel: this.getZoomLevel(searchResult.type)
     } as ViewPosition);
     this.store.update({selectedLocation: searchResult, isOpen: false});
+  }
+
+  setFirstAsSelectedPlace() {
+    if(this.query.getAll().length) {
+      this.setSelectedPlace(this.query.getAll()[0]);
+    }
   }
 }

--- a/s4e-web/src/app/views/map-view/view-manager/view-manager.component.html
+++ b/s4e-web/src/app/views/map-view/view-manager/view-manager.component.html
@@ -9,6 +9,12 @@
       <img src="../../../../assets/images/ico_magnifying.svg" alt="Search icon" i18n-alt/>
     </button>
   </section>
+  <s4e-search-results *ngIf="searchResultsOpen$ | async"
+                      [searchResults]="searchResults$ | async"
+                      [loading]="searchResultsLoading$ | async"
+                      (placeSelected)="navigateToPlace($event)"
+                      class="searchResults">
+  </s4e-search-results>
 
   <s4e-product-picker class="section"
                       caption="Produkty"
@@ -26,12 +32,7 @@
                       (itemSelected)="selectOverlay($event)">
   </s4e-product-picker>
 
-  <s4e-search-results *ngIf="searchResultsOpen$ | async"
-                      [searchResults]="searchResults$ | async"
-                      [loading]="searchResultsLoading$ | async"
-                      (placeSelected)="navigateToPlace($event)"
-                      class="searchResults">
-  </s4e-search-results>
+
 </ng-container>
 <ng-template #loadingRef>
   <div class="loading loading--form">

--- a/s4e-web/src/app/views/map-view/view-manager/view-manager.component.html
+++ b/s4e-web/src/app/views/map-view/view-manager/view-manager.component.html
@@ -5,7 +5,7 @@
     <button class="reset_search_button" (click)="resetSelectedLocation()">
       <fa-icon [icon]="['fas', 'times']"></fa-icon>
     </button>
-    <button class="search__button">
+    <button class="search__button" (click)="selectFirstResult()">
       <img src="../../../../assets/images/ico_magnifying.svg" alt="Search icon" i18n-alt/>
     </button>
   </section>

--- a/s4e-web/src/app/views/map-view/view-manager/view-manager.component.scss
+++ b/s4e-web/src/app/views/map-view/view-manager/view-manager.component.scss
@@ -7,6 +7,7 @@
     border-radius: $border-radius-default;
     margin-bottom: $space-xlarge;
     display: block;
+    position: relative;
 
     &.search {
       background: #fff;
@@ -18,7 +19,7 @@
 
       .search__input {
         width: 100%;
-        font-size: 0.875rem;
+        font-size: 0.938rem;
 
         &::placeholder {
           font-style: italic;
@@ -50,12 +51,13 @@
 }
 
 .searchResults {
-  position: absolute;
-  background: #ffffff;
-  opacity: 0.9;
-  border-radius: 5px;
-  left: 400px;
-  top: 15px;
+  padding: 10px 0;
+  background: $color-white;
+  border-radius: 0 0 $border-radius-default $border-radius-default;
+  border-top: 1px solid $color-grey-secondary;
+  top: 104px;
   z-index: 10;
-  width: max-content;
+  position: absolute;
+  width: calc(100% - 30px);
+  box-shadow: $shadow-primary;
 }

--- a/s4e-web/src/app/views/map-view/view-manager/view-manager.component.ts
+++ b/s4e-web/src/app/views/map-view/view-manager/view-manager.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {IUILayer} from '../state/common.model';
 import {FormControl} from '@ng-stack/forms';
 import {SearchResult} from '../state/search-results/search-result.model';
@@ -68,7 +68,6 @@ export class ViewManagerComponent implements OnInit, OnDestroy{
   }
 
   resetSelectedLocation() {
-    this.navigateToPlace(null);
     this.searchForPlaces('');
     this.searchFc.setValue('');
   }
@@ -90,5 +89,9 @@ export class ViewManagerComponent implements OnInit, OnDestroy{
 
   navigateToPlace(place: SearchResult) {
     this.searchResultsService.setSelectedPlace(place);
+  }
+
+  selectFirstResult() {
+    this.searchResultsService.setFirstAsSelectedPlace()
   }
 }


### PR DESCRIPTION
* Update map store on selection

Selected search result is saved to `StateSearchResults.selectedLocation` but map is observing `Map.view` which is not changed.
In this PR I added Map.view update to `setSelectedPlace` which works but is not very clean - `SearchResultsService` has to known about projection and zoom level mapping.