### PR TITLE
[#341] Image resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Thumbnail scaling before POSTing in share view and save view [#341](https://github.com/cyfronet-fid/sat4envi/pull/367/files)
 - PDF Report generation [#345](https://github.com/cyfronet-fid/sat4envi/pull/345)
 - Timezone support for s4e-web [#363](https://github.com/cyfronet-fid/sat4envi/pull/363)
 - DisplayName field to Product and appropriate view [#365](https://github.com/cyfronet-fid/sat4envi/pull/365)

--- a/s4e-web/package-lock.json
+++ b/s4e-web/package-lock.json
@@ -9675,9 +9675,9 @@
       }
     },
     "jest-canvas-mock": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.0.0-beta.1.tgz",
-      "integrity": "sha512-OwUcVnJc0qXUxt+ADSWbADVHUTt5wOmOIqL9N22mXCFclQXcLGPB/CeM3Wnu1eZcRWGE2aGHk5RqbH9qznJhEQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.2.0.tgz",
+      "integrity": "sha512-DcJdchb7eWFZkt6pvyceWWnu3lsp5QWbUeXiKgEMhwB3sMm5qHM1GQhDajvJgBeiYpgKcojbzZ53d/nz6tXvJw==",
       "dev": true,
       "requires": {
         "cssfontparser": "^1.2.1",

--- a/s4e-web/package.json
+++ b/s4e-web/package.json
@@ -97,7 +97,7 @@
     "downloads-folder": "^1.0.2",
     "factory.ts": "^0.4.5",
     "jest": "^24.5.0",
-    "jest-canvas-mock": "^2.0.0-beta.1",
+    "jest-canvas-mock": "^2.2.0",
     "jest-marbles": "^2.3.1",
     "ts-node": "~5.0.1",
     "tslint": "~5.9.1",

--- a/s4e-web/src/app/utils/miscellaneous/miscellaneous.spec.ts
+++ b/s4e-web/src/app/utils/miscellaneous/miscellaneous.spec.ts
@@ -1,9 +1,10 @@
-import {disableEnableForm} from './miscellaneous';
+import {disableEnableForm, resizeImage} from './miscellaneous';
 import {async, TestBed} from '@angular/core/testing';
 import {InjectorModule} from '../../common/injector.module';
 import {Injector} from '@angular/core';
 import {TestingConfigProvider} from '../../app.configuration.spec';
 import {FormControl, FormGroup} from '@ng-stack/forms';
+import {DOCUMENT} from '@angular/common';
 
 export interface FS {
   login: string;

--- a/s4e-web/src/app/views/map-view/zk/save-config-modal/save-config-modal.component.html
+++ b/s4e-web/src/app/views/map-view/zk/save-config-modal/save-config-modal.component.html
@@ -5,7 +5,7 @@
       <aside>
         <strong i18n>Podgląd widoku konfiguracji</strong>
         <div #reportTemplate class="report-template">
-          <img id="map-miniature" [src]="viewConfig.thumbnail" width="200" />
+          <img id="map-miniature" [src]="viewConfig.thumbnail" />
         </div>
       </aside>
       <div class="form">

--- a/s4e-web/src/scss/_modal.scss
+++ b/s4e-web/src/scss/_modal.scss
@@ -42,12 +42,11 @@
       margin-bottom: $space-small;
       border-radius: $border-radius-default;
       width: 275px;
-      height: 239px;
 
       > #map-miniature {
-        object-fit: cover;
+        //object-fit: cover;
         width: 100%;
-        height: 100%;
+        //height: 100%;
       }
     }
   }


### PR DESCRIPTION
## What is in this PR?

The images in save view and share view are now being resized as per #341 specification.
This means that they all have uniform size (which will make them show better on the saved views modal, as well as require less bandwidth and storage space.

## How does it look like?

![image](https://user-images.githubusercontent.com/13235269/74955085-66d41980-5404-11ea-9c26-09b7fd22b1dc.png)


Closes: #341