### PR TITLE
Update GeoServer to 1.2.0-GS2.16.2 and correct GS endpoint name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Possibility to set maven artifact version with properties [#356](https://github.com/cyfronet-fid/sat4envi/pull/356)
 - This changelog file [#355](https://github.com/cyfronet-fid/sat4envi/pull/355)
 
+### Changed
+
+- Update GeoServer image to 1.2.0-GS2.16.2 and use URL-correct S3Geotiff endpoint [#371](https://github.com/cyfronet-fid/sat4envi/pull/371)
 
 ### Fixed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minio123}
     command: server /data
   geoserver:
-    image: fiddev/geoserver:1.1.0-GS2.16.0
+    image: fiddev/geoserver:1.2.0-GS2.16.2
     volumes:
       - ./resources/geoserver/s3.properties:/opt/geoserver/s3.properties
       - ./tmp/geoserver-data:/opt/geoserver/data_dir

--- a/resources/geoserver/s3.properties
+++ b/resources/geoserver/s3.properties
@@ -1,3 +1,3 @@
-cyfro.s3.endpoint=http://minio:9000/
-cyfro.s3.user=minio
-cyfro.s3.password=minio123
+mailto.s3.endpoint=http://minio:9000/
+mailto.s3.user=minio
+mailto.s3.password=minio123

--- a/s4e-backend/src/main/resources/application-development.properties
+++ b/s4e-backend/src/main/resources/application-development.properties
@@ -7,7 +7,7 @@ geoserver.password=admin123
 geoserver.base-url=http://localhost:8080/geoserver/rest
 geoserver.outside-base-url=/wms
 geoserver.workspace=development
-geoserver.endpoint=cyfro
+geoserver.endpoint=mailto
 
 s3.access-key=minio
 s3.secret-key=minio123

--- a/s4e-backend/src/main/resources/application-production.properties
+++ b/s4e-backend/src/main/resources/application-production.properties
@@ -8,7 +8,7 @@ geoserver.password=admin123
 geoserver.base-url=http://localhost:8080/geoserver/rest
 geoserver.outside-base-url=/wms
 geoserver.workspace=development
-geoserver.endpoint=cyfro
+geoserver.endpoint=mailto
 
 s3.access-key=minio
 s3.secret-key=minio123

--- a/s4e-backend/src/test/resources/application-test.properties
+++ b/s4e-backend/src/test/resources/application-test.properties
@@ -9,7 +9,7 @@ geoserver.password=admin123
 geoserver.base-url=http://localhost:8080/geoserver/rest
 geoserver.outside-base-url=/wms
 geoserver.workspace=test
-geoserver.endpoint=cyfro
+geoserver.endpoint=mailto
 
 s3.access-key=minio
 s3.secret-key=minio123


### PR DESCRIPTION
The updated GeoServer uses a patched GeoTools version, so that
ImageMosaic+S3Geotiff works.

The endpoint is set to `mailto`, so that an s3geotiff location is a
correct URL, e.g. `mailto://bucket/key`. The protocol part here only
differentiates endpoint configurations, so it doesn't matter if the rest
isn't a correct email address.

Part of #371.