### PR TITLE
[#378] Update GeoServer image to 1.3.0-GS2.16.2, which has JNDI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update GeoServer image to 1.3.0-GS2.16.2, which includes JNDI and removes JDBCConfig support [#378](https://github.com/cyfronet-fid/sat4envi/pull/378)
 - Update db image to postgis/postgis:12-3.0-alpine and use Postgis hibernate dialect [#371](https://github.com/cyfronet-fid/sat4envi/pull/371)
 - Update GeoServer image to 1.2.0-GS2.16.2 and use URL-correct S3Geotiff endpoint [#371](https://github.com/cyfronet-fid/sat4envi/pull/371)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minio123}
     command: server /data
   geoserver:
-    image: fiddev/geoserver:1.2.0-GS2.16.2
+    image: fiddev/geoserver:1.3.0-GS2.16.2
     volumes:
       - ./resources/geoserver/s3.properties:/opt/geoserver/s3.properties
       - ./tmp/geoserver-data:/opt/geoserver/data_dir
@@ -48,7 +48,9 @@ services:
       - net
     environment:
       GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD:-admin123}
-      JDBCCONFIG_ENABLED: "false"
+      JNDI_URL: ${GEOSERVER_JNDI_URL:-jdbc:postgresql://db:5432/sat4envi}
+      JNDI_USERNAME: ${GEOSERVER_JNDI_USERNAME:-sat4envi}
+      JNDI_PASSWORD: ${GEOSERVER_JNDI_PASSWORD:-sat4envi}
   db:
     image: postgis/postgis:12-3.0-alpine
     ports:


### PR DESCRIPTION
@kmarszalek: take this into account when pushing IM to GS

@wziajka: there will be new properties in production: GEOSERVER_JNDI_*

Closes: #378.