### PR TITLE
[#430] global error handling for http requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Add global error handling [#430](https://github.com/cyfronet-fid/sat4envi/issues/430)
 - UI Refactoring [#448](https://github.com/cyfronet-fid/sat4envi/issues/448)
 - Add /logout routing and clear storage on logout (inconsistent state of storage) [#445](https://github.com/cyfronet-fid/sat4envi/issues/445)
 - Synchronize scenes from S3 (s4-sync-1 dataset) [#439](https://github.com/cyfronet-fid/sat4envi/issues/439)

--- a/s4e-web/cypress/integration/error-handling.spec.ts
+++ b/s4e-web/cypress/integration/error-handling.spec.ts
@@ -1,0 +1,66 @@
+context('productNavigation', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('Should redirect to not found page', () => {
+    cy.visit('/test');
+    cy.url().should('contain', 'errors/404');
+
+    cy.server({
+      method: 'GET',
+      delay: 500,
+      status: 404,
+      response: {}
+    });
+    cy.route('/api/v1/products', { errors: 'Endpoint doesn\'t exists' });
+    cy.visit('/');
+    cy.url().should('contain', 'errors/404');
+  });
+
+  it('Should redirect to bad gateway page', () => {
+    cy.server({
+      method: 'GET',
+      delay: 500,
+      status: 502,
+      response: {}
+    });
+    cy.route('/api/v1/products', { errors: 'Bad Gateway 502' });
+    cy.visit('/');
+    cy.url().should('contain', 'errors/502');
+  });
+
+  it('Should redirect to internal server error page', () => {
+    cy.server({
+      method: 'GET',
+      delay: 500,
+      status: 500,
+      response: {}
+    });
+    cy.route('/api/v1/products', { errors: 'Server don\'t responded' });
+    cy.visit('/');
+    cy.url().should('contain', 'errors/500');
+  });
+
+  it('Should logout and provide to login page', () => {
+    cy.server({
+      method: 'GET',
+      delay: 500,
+      status: 403,
+      response: {}
+    });
+    cy.route('/api/v1/products', { errors: 'Access forbidden' });
+    cy.visit('/');
+    cy.url().should('contain', 'login');
+
+    cy.server({
+      method: 'GET',
+      delay: 500,
+      status: 401,
+      response: {}
+    });
+    cy.route('/api/v1/products', { errors: 'You\'re not authorized' });
+    cy.visit('/');
+    cy.url().should('contain', 'login');
+  });
+});

--- a/s4e-web/src/app/app.module.ts
+++ b/s4e-web/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { LogoutModule } from './views/logout/logout.module';
+import {LogoutModule} from './views/logout/logout.module';
 import {APP_INITIALIZER, LOCALE_ID, NgModule} from '@angular/core';
 import {HTTP_INTERCEPTORS} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
@@ -28,6 +28,7 @@ import {SettingsModule} from './views/settings/settings.module';
 import {ModalModule} from './modal/modal.module';
 import {S4EFormsModule} from './form/form.module';
 import {NotificationsModule} from 'notifications';
+import {ErrorsModule} from './errors/errors.module';
 
 registerLocaleData(localePl, 'pl');
 
@@ -42,7 +43,7 @@ export function initializeApp(configService: S4eConfig): () => Promise<any> {
   ],
   imports: [
     ...(environment.production ? [] : [AkitaNgDevtools.forRoot()]),
-    RouterModule.forRoot(appRoutes, {enableTracing: false }),
+    RouterModule.forRoot(appRoutes, {enableTracing: false}),
     ...ShareModule.modulesForRoot(),
     LoginModule,
     LogoutModule,
@@ -56,7 +57,8 @@ export function initializeApp(configService: S4eConfig): () => Promise<any> {
     SettingsModule,
     ModalModule,
     S4EFormsModule,
-    NotificationsModule.forRoot(environment.production)
+    NotificationsModule.forRoot(environment.production),
+    ErrorsModule
   ],
   providers: [
     S4eConfig,

--- a/s4e-web/src/app/app.routes.ts
+++ b/s4e-web/src/app/app.routes.ts
@@ -1,11 +1,12 @@
-import { LogoutComponent } from './views/logout/logout.component';
+import {LogoutComponent} from './views/logout/logout.component';
 import {Routes} from '@angular/router';
 import {LoginComponent} from './views/login/login.component';
 import {ResetPasswordComponent} from './views/reset-password/reset-password.component';
 import {RegisterComponent} from './views/register/register.component';
-import {IsNotLoggedIn, IsLoggedIn} from './utils/auth-guard/auth-guard.service';
+import {IsLoggedIn, IsNotLoggedIn} from './utils/auth-guard/auth-guard.service';
 import {ActivateComponent} from './views/activate/activate.component';
 import {activateMatcher} from './utils';
+import {HTTP_404_NOT_FOUND} from './errors/errors.model';
 
 export const appRoutes: Routes = [
   {
@@ -28,8 +29,12 @@ export const appRoutes: Routes = [
     matcher: activateMatcher,
     component: ActivateComponent
   }, {
-    path: '**',
+    path: '',
     redirectTo: '/map/products',
+    pathMatch: 'full'
+  }, {
+    path: '**',
+    redirectTo: `errors/${HTTP_404_NOT_FOUND}`,
     pathMatch: 'full',
-  },
+  }
 ];

--- a/s4e-web/src/app/common/dao.service.ts
+++ b/s4e-web/src/app/common/dao.service.ts
@@ -13,7 +13,7 @@ export abstract class Dao<T, S extends EntityState<T>, Store extends EntityStore
   fetch$(id: getIDType<S>, url?: string): Observable<T> {
     this.store.setLoading(true);
     this.store.setError(null);
-    const r =this.http.get<T>(`${url || this.url}/${id}`)
+    const r = this.http.get<T>(`${url || this.url}/${id}`)
       .pipe(
         finalize(() => this.store.setLoading(false)),
         tap(data => this.store.upsert(id, data)),

--- a/s4e-web/src/app/errors/errors.component.html
+++ b/s4e-web/src/app/errors/errors.component.html
@@ -1,0 +1,11 @@
+<div class="container">
+  <h2 class="title">{{ actualError.title }}</h2>
+  <h4 class="description">{{ actualError.description }}</h4>
+  <p>
+    <b><a routerLink="/">Return to main page</a></b>
+    <b *ngIf="!!back_link && back_link !== ''" >
+      <span>&nbsp; | &nbsp;</span>
+      <a routerLink="{{ back_link }}">Return to last page</a>
+    </b>
+  </p>
+</div>

--- a/s4e-web/src/app/errors/errors.component.scss
+++ b/s4e-web/src/app/errors/errors.component.scss
@@ -1,0 +1,19 @@
+.container {
+  min-width: 300px;
+  width: 50%;
+  padding: 10px;
+  margin: calc(50vh - 300px) auto;
+  background-color: smokewhite;
+  border-radius: 8px;
+  border: 2px solid #fc1303;
+  text-align: center;
+  line-height: 30px;
+}
+
+.title {
+  color: #fc1303;
+}
+
+.description {
+  color: lightgray;
+}

--- a/s4e-web/src/app/errors/errors.component.spec.ts
+++ b/s4e-web/src/app/errors/errors.component.spec.ts
@@ -1,0 +1,53 @@
+import { By } from '@angular/platform-browser';
+import { ParamMap } from '@angular/router/src/shared';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientModule } from '@angular/common/http';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ErrorsModule } from './errors.module';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErrorsComponent } from './errors.component';
+import { ReplaySubject, Observable, Subject } from 'rxjs';
+
+class ActivatedRouteStub {
+  paramMap: Subject<ParamMap> = new ReplaySubject(1);
+  queryParamMap: Subject<ParamMap> = new ReplaySubject(1);
+
+  constructor() {
+    this.paramMap.next(convertToParamMap({}));
+    this.queryParamMap.next(convertToParamMap({backLink: '/'}));
+  }
+}
+
+
+describe('ErrorComponent', () => {
+  let component: ErrorsComponent;
+  let fixture: ComponentFixture<ErrorsComponent>;
+  let route: ActivatedRouteStub;
+  const backLink = '/back-link';
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ ErrorsModule, HttpClientModule, RouterTestingModule ],
+      providers: [{provide: ActivatedRoute, useClass: ActivatedRouteStub}]
+    })
+    .compileComponents();
+    route = TestBed.get(ActivatedRoute);
+  }));
+
+  beforeEach(() => {
+    route.paramMap.next(convertToParamMap({errorCode: '404'}));
+    route.queryParamMap.next(convertToParamMap({backLink}));
+    fixture = TestBed.createComponent(ErrorsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display 404 error', () => {
+    expect(fixture.debugElement.query(By.css('.title')).nativeElement.textContent).toBe('Błąd 404: nie znaleziono poszukiwanej strony')
+  })
+});

--- a/s4e-web/src/app/errors/errors.component.ts
+++ b/s4e-web/src/app/errors/errors.component.ts
@@ -1,0 +1,61 @@
+import {untilDestroyed} from 'ngx-take-until-destroy';
+import {ActivatedRoute} from '@angular/router';
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR, HTTP_502_BAD_GATEWAY} from './errors.model';
+
+@Component({
+  selector: 's4e-errors',
+  templateUrl: './errors.component.html',
+  styleUrls: ['./errors.component.scss']
+})
+export class ErrorsComponent implements OnInit, OnDestroy {
+  public actualError = ErrorsComponent._getErrorBy(null);
+  public back_link?: string;
+
+  constructor(private _activatedRoute: ActivatedRoute) {
+  }
+
+  protected static _getErrorBy(code: number | null) {
+    switch (code) {
+      case HTTP_404_NOT_FOUND:
+        return {
+          title: 'Błąd 404: nie znaleziono poszukiwanej strony',
+          description: 'Strona, której szukasz nie istnieje, bądź została przeniesiona'
+        };
+      case HTTP_502_BAD_GATEWAY:
+        return {
+          title: 'Błąd 502: brak odpowiedzi serwera lub błędna odpowiedź',
+          description: 'Sprawdź swoje ustawienia przegladarki lub skontaktuj się z administratorem'
+        };
+      case HTTP_500_INTERNAL_SERVER_ERROR:
+        return {
+          title: 'Błąd 500: błąd po stronie serwera',
+          description: 'Skontaktuj się z administratorem w przypadku powtarzającej się awarii'
+        };
+      case null:
+      default:
+        return {
+          title: 'Wystąpił nieznany błąd',
+          description: 'Skontaktuj się z administratorem w przypadku powtarzającej się awarii'
+        };
+    }
+  }
+
+  ngOnInit() {
+    this._activatedRoute.paramMap
+      .pipe(untilDestroyed(this))
+      .subscribe((params) => {
+        const actualErrorCode = +params.get('errorCode');
+        this.actualError = ErrorsComponent._getErrorBy(actualErrorCode);
+      });
+
+    this._activatedRoute.queryParamMap
+      .pipe(untilDestroyed(this))
+      .subscribe((params) => {
+        this.back_link = params.get('back_link');
+      });
+  }
+
+  ngOnDestroy() {
+  }
+}

--- a/s4e-web/src/app/errors/errors.model.ts
+++ b/s4e-web/src/app/errors/errors.model.ts
@@ -1,0 +1,7 @@
+export const HTTP_401_UNAUTHORIZED = 401;
+export const HTTP_403_FORBIDDEN = 403;
+export const HTTP_404_BAD_REQUEST = 400;
+export const HTTP_101_TIMEOUT = 101;
+export const HTTP_404_NOT_FOUND = 404;
+export const HTTP_500_INTERNAL_SERVER_ERROR = 500;
+export const HTTP_502_BAD_GATEWAY = 502;

--- a/s4e-web/src/app/errors/errors.module.ts
+++ b/s4e-web/src/app/errors/errors.module.ts
@@ -1,0 +1,22 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ErrorsComponent} from './errors.component';
+import {RouterModule} from '@angular/router';
+
+@NgModule({
+  declarations: [ErrorsComponent],
+  imports: [
+    CommonModule,
+    RouterModule.forChild([
+      {
+        path: `errors/:errorCode`,
+        component: ErrorsComponent
+      }
+    ])
+  ],
+  exports: [
+    ErrorsComponent
+  ]
+})
+export class ErrorsModule {
+}

--- a/s4e-web/src/app/state/profile/profile.service.ts
+++ b/s4e-web/src/app/state/profile/profile.service.ts
@@ -1,13 +1,13 @@
-import { Injectable } from '@angular/core';
-import {HttpClient, HttpErrorResponse} from '@angular/common/http';
-import { ProfileStore } from './profile.store';
-import {Observable, of, pipe, throwError} from 'rxjs';
+import {Injectable} from '@angular/core';
+import {ProfileStore} from './profile.store';
+import {Observable, of} from 'rxjs';
 import {Profile} from './profile.model';
 import {catchError, shareReplay, tap} from 'rxjs/operators';
 import {SessionQuery} from '../session/session.query';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {HttpClient} from '@angular/common/http';
+import {catchErrorAndHandleStore} from '../../common/store.util';
 
-@Injectable({ providedIn: 'root' })
+@Injectable({providedIn: 'root'})
 export class ProfileService {
 
   constructor(private store: ProfileStore,
@@ -15,8 +15,8 @@ export class ProfileService {
               private http: HttpClient) {
   }
 
-  get$(): Observable<Profile|null> {
-    if(localStorage.getItem('token') == null) {
+  get$(): Observable<Profile | null> {
+    if (localStorage.getItem('token') == null) {
       return of(null);
     }
 
@@ -35,8 +35,10 @@ export class ProfileService {
 
   resetPassword(oldPassword: string, newPassword: string): void {
     this.store.setLoading(true);
-    this.http.post('/api/v1/password-change', {oldPassword, newPassword})
-      .pipe(catchErrorAndHandleStore(this.store))
+    this.http.post(
+      '/api/v1/password-change',
+      {oldPassword, newPassword}
+    ).pipe(catchErrorAndHandleStore(this.store))
       .subscribe(() => this.store.setLoading(false));
   }
 }

--- a/s4e-web/src/app/state/session/session.service.ts
+++ b/s4e-web/src/app/state/session/session.service.ts
@@ -1,17 +1,22 @@
-import { NotificationService } from 'notifications';
-import { SessionQuery } from './session.query';
+import {NotificationService} from 'notifications';
+import {SessionQuery} from './session.query';
+import {ERROR_INTERCEPTOR_CODES_TO_SKIP} from '../../utils/error-interceptor/error.helper';
 import {Injectable} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {SessionStore} from './session.store';
 import {finalize, switchMap, tap} from 'rxjs/operators';
 import {Router} from '@angular/router';
-import {action, resetStores, akitaConfig, persistState} from '@datorama/akita';
+import {action, resetStores} from '@datorama/akita';
 import {LoginRequestResponse} from './session.model';
 import {S4eConfig} from '../../utils/initializer/config.service';
 import {ProfileService} from '../profile/profile.service';
+import {HTTP_502_BAD_GATEWAY, HTTP_404_BAD_REQUEST, HTTP_401_UNAUTHORIZED} from '../../errors/errors.model';
+import {catchErrorAndHandleStore} from '../../common/store.util';
+
 
 @Injectable({providedIn: 'root'})
 export class SessionService {
+  private _backLink: string;
 
   constructor(private sessionStore: SessionStore,
               private sessionQuery: SessionQuery,
@@ -20,6 +25,10 @@ export class SessionService {
               private profileService: ProfileService,
               private CONFIG: S4eConfig,
               private _notificationService: NotificationService) {
+  }
+
+  set back_link(back_link: string) {
+    this._backLink = back_link;
   }
 
   init() {
@@ -51,13 +60,15 @@ export class SessionService {
   @action('login')
   login(email: string, password: string) {
     this.sessionStore.setLoading(true);
-
-    this.http.post<LoginRequestResponse>(`${this.CONFIG.apiPrefixV1}/login`, {email: email, password: password})
+    this.http.post<LoginRequestResponse>(`${this.CONFIG.apiPrefixV1}/login`, {email, password},
+      {headers: {[ERROR_INTERCEPTOR_CODES_TO_SKIP]: `${HTTP_404_BAD_REQUEST},${HTTP_401_UNAUTHORIZED}`} })
       .pipe(
+        catchErrorAndHandleStore(this.sessionStore),
         tap(data => this.setToken(data.token, data.email)),
         switchMap(data => this.profileService.get$()),
         finalize(() => this.sessionStore.setLoading(false))
-      ).subscribe(data => {this.router.navigate(['/']);});
+      )
+      .subscribe(data => this._navigateToApplication());
   }
 
   @action('logout')
@@ -69,5 +80,13 @@ export class SessionService {
       });
       this.router.navigateByUrl('login');
     }
+  }
+
+  private _navigateToApplication(): void {
+    !!this._backLink && this._backLink !== ''
+      ? this.router.navigateByUrl(this._backLink)
+      : this.router.navigate(['/']);
+
+    delete (this._backLink);
   }
 }

--- a/s4e-web/src/app/utils/error-interceptor/error.helper.ts
+++ b/s4e-web/src/app/utils/error-interceptor/error.helper.ts
@@ -1,0 +1,118 @@
+import {HttpErrorResponse, HttpEvent, HttpHandler, HttpRequest} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {HTTP_502_BAD_GATEWAY, HTTP_404_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR} from '../../errors/errors.model';
+
+export const ERROR_INTERCEPTOR_CODES_TO_SKIP = 'Error-Interceptor-Codes-To-Skip';
+export const ERROR_INTERCEPTOR_CODES_TO_HANDLE = 'Error-Interceptor-Codes-To-Handle';
+export const ERROR_INTERCEPTOR_SKIP_HEADER = 'Error-Interceptor-Skip-Header';
+export const ERROR_INTERCEPTOR_HANDLE_ALL_HEADER = 'Error-Interceptor-Handle-All-Header';
+
+// this is an option which can be passed to http.get / http.post etc.
+export const HANDLE_ALL_ERRORS = {headers: {[ERROR_INTERCEPTOR_HANDLE_ALL_HEADER]: ERROR_INTERCEPTOR_HANDLE_ALL_HEADER}};
+
+export const DEFAULT_SKIP_CODES = {
+  POST: [HTTP_404_BAD_REQUEST.toString(), HTTP_500_INTERNAL_SERVER_ERROR.toString(), HTTP_502_BAD_GATEWAY.toString()],
+  PUT: [HTTP_404_BAD_REQUEST.toString(), HTTP_500_INTERNAL_SERVER_ERROR.toString(), HTTP_502_BAD_GATEWAY.toString()]
+};
+
+export class HttpErrorHelper {
+
+  public static isServerSideError(error: HttpErrorResponse): boolean {
+    return error instanceof HttpErrorResponse;
+  }
+
+  public static isClientSideError(error: HttpErrorResponse): boolean {
+    return error instanceof HttpErrorResponse && error.error instanceof ErrorEvent;
+  }
+
+  public static skipErrorCode(error: HttpErrorResponse, request: HttpRequest<any>): boolean {
+    return request.headers.has(ERROR_INTERCEPTOR_CODES_TO_SKIP)
+      && request.headers.get(ERROR_INTERCEPTOR_CODES_TO_SKIP).length > 0
+      && request.headers.get(ERROR_INTERCEPTOR_CODES_TO_SKIP).split(',').map(errorCode => +errorCode).includes(error.status);
+  }
+
+  public static handleErrorCode(error: HttpErrorResponse, request: HttpRequest<any>): boolean {
+    return request.headers.has(ERROR_INTERCEPTOR_HANDLE_ALL_HEADER)
+      || (request.headers.has(ERROR_INTERCEPTOR_CODES_TO_HANDLE)
+      && request.headers.get(ERROR_INTERCEPTOR_CODES_TO_HANDLE).length > 0
+      && error.status in request.headers.get(ERROR_INTERCEPTOR_CODES_TO_HANDLE).split(',').map(errorCode => +errorCode)
+      || !request.headers.has(ERROR_INTERCEPTOR_CODES_TO_HANDLE));
+  }
+
+  public static hasSkipHeader(request: HttpRequest<any>): boolean {
+    return request.headers.has(ERROR_INTERCEPTOR_SKIP_HEADER);
+  }
+
+  public static handledHttpEvent(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(
+      request.clone({
+        headers: request.headers
+          .delete(ERROR_INTERCEPTOR_SKIP_HEADER)
+          .delete(ERROR_INTERCEPTOR_CODES_TO_SKIP)
+          .delete(ERROR_INTERCEPTOR_CODES_TO_HANDLE)
+          .delete(ERROR_INTERCEPTOR_HANDLE_ALL_HEADER)
+      })
+    );
+  }
+
+  /**
+   * Only one header amongst
+   * (ERROR_INTERCEPTOR_CODES_TO_HANDLE,
+   * ERROR_INTERCEPTOR_CODES_TO_SKIP,
+   * ERROR_INTERCEPTOR_CODES_TO_HANDLE,
+   * ERROR_INTERCEPTOR_HANDLE_ALL_HEADER)
+   *
+   * can be used
+   *
+   * @param request
+   */
+  static hasMutuallyExclusiveOptions(request: HttpRequest<any>) {
+    let optionsCount = 0;
+    if (request.headers.has(ERROR_INTERCEPTOR_CODES_TO_HANDLE)) {
+      ++optionsCount;
+    }
+    if (request.headers.has(ERROR_INTERCEPTOR_CODES_TO_SKIP)) {
+      ++optionsCount;
+    }
+    if (request.headers.has(ERROR_INTERCEPTOR_SKIP_HEADER)) {
+      ++optionsCount;
+    }
+    if (request.headers.has(ERROR_INTERCEPTOR_HANDLE_ALL_HEADER)) {
+      ++optionsCount;
+    }
+
+    return optionsCount > 1;
+  }
+
+  static skipHandling(error: HttpErrorResponse, request: HttpRequest<any>) {
+    if(request.headers.has(ERROR_INTERCEPTOR_HANDLE_ALL_HEADER)) {
+      return false;
+    }
+    if(HttpErrorHelper.hasSkipHeader(request)) {
+      return true;
+    }
+    if (HttpErrorHelper.skipErrorCode(error, request)) {
+      return true;
+    }
+    if (HttpErrorHelper.handleErrorCode(error, request)) {
+      return false;
+    }
+    return false;
+  }
+
+  static hasAnyOption(request: HttpRequest<any>) {
+    return request.headers.has(ERROR_INTERCEPTOR_CODES_TO_HANDLE)
+      || request.headers.has(ERROR_INTERCEPTOR_CODES_TO_SKIP)
+      || request.headers.has(ERROR_INTERCEPTOR_SKIP_HEADER)
+      || request.headers.has(ERROR_INTERCEPTOR_HANDLE_ALL_HEADER);
+  }
+
+  static addDefaultHeaders(request: HttpRequest<any>): HttpRequest<any> {
+    if (!HttpErrorHelper.hasAnyOption(request)) {
+      request = request.clone({
+        headers: request.headers.append(ERROR_INTERCEPTOR_CODES_TO_SKIP, DEFAULT_SKIP_CODES[request.method] || [])
+      });
+    }
+    return request;
+  }
+}

--- a/s4e-web/src/app/utils/error-interceptor/error.interceptor.spec.ts
+++ b/s4e-web/src/app/utils/error-interceptor/error.interceptor.spec.ts
@@ -1,13 +1,45 @@
+import {RouterTestingModule} from '@angular/router/testing';
 import {ErrorInterceptor} from './error.interceptor';
+import {TestBed} from '@angular/core/testing';
+import {HttpClientTestingModule, HttpTestingController, TestRequest} from '@angular/common/http/testing';
+import {HTTP_INTERCEPTORS, HttpClient} from '@angular/common/http';
+import {Router} from '@angular/router';
+import {catchError} from 'rxjs/operators';
+import {of} from 'rxjs';
 
-describe('ErrorInterceptor', function () {
-  const interceptor = new ErrorInterceptor();
+describe('ErrorInterceptor', () => {
+  let errorInterceptor: ErrorInterceptor;
+  let httpController: HttpTestingController;
+  let http: HttpClient;
+  let router: Router;
 
-  it('should map to error.message', () => {
-    // :TODO add test
+  const url = `/api1/newTest`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        ErrorInterceptor,
+        {provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true}
+      ]
+    });
+    router = TestBed.get(Router);
+    spyOn(router, 'navigate').and.stub();
+
+    errorInterceptor = TestBed.get(ErrorInterceptor);
+    httpController = TestBed.get(HttpTestingController);
+    http = TestBed.get(HttpClient);
   });
 
-  it('should map to statusText', () => {
-    // :TODO add test
+  it('Should handle client/server error', async () => {
+    const r = http.get(url).pipe(catchError(error => of(error))).toPromise();
+    const request: TestRequest = httpController.expectOne(url);
+    request.flush({}, {status: 500, statusText: 'Server Error'});
+
+    expect((await r).status).toBe(500);
+    expect((await r).message).toBe(`Http failure response for ${url}: 500 Server Error`);
+
+    httpController.verify();
+    expect(router.navigate).toHaveBeenCalled();
   });
 });

--- a/s4e-web/src/app/utils/error-interceptor/error.interceptor.ts
+++ b/s4e-web/src/app/utils/error-interceptor/error.interceptor.ts
@@ -1,24 +1,91 @@
-import { Injectable } from '@angular/core';
-import {HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpErrorResponse} from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import {Injectable} from '@angular/core';
+import {HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
+import {Observable, throwError} from 'rxjs';
+import {catchError, filter, finalize, map, pairwise} from 'rxjs/operators';
+import {Router, RoutesRecognized} from '@angular/router';
+import {
+  HTTP_101_TIMEOUT,
+  HTTP_401_UNAUTHORIZED,
+  HTTP_403_FORBIDDEN,
+  HTTP_404_BAD_REQUEST,
+  HTTP_404_NOT_FOUND,
+  HTTP_500_INTERNAL_SERVER_ERROR,
+  HTTP_502_BAD_GATEWAY
+} from '../../errors/errors.model';
+import {HttpErrorHelper} from './error.helper';
+import {NotificationService} from 'notifications';
+
 
 @Injectable({
   providedIn: 'root',
 })
 export class ErrorInterceptor implements HttpInterceptor {
-  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    return next.handle(request).pipe(catchError((error: HttpErrorResponse) => {
-      // switch(error.status) {
-      //   case 400: {
-      //     break;
-      //   }
-      //   default: {
-      //
-      //   }
-      // }
-      // const error = (error.error && error.error.message) || error.statusText;
-      return throwError(error);
-    }));
+  private _backLink: string;
+
+  constructor(
+    private _router: Router,
+    private _notificationService: NotificationService
+  ) {
+    this._router.events
+      .pipe(
+        filter(event => event instanceof RoutesRecognized),
+        pairwise(),
+        map((event: [RoutesRecognized, RoutesRecognized]) => event[0].url)
+      )
+      .subscribe((lastUrl: string) => this._backLink = '/' + lastUrl);
   }
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    request = HttpErrorHelper.addDefaultHeaders(request);
+
+    return next.handle(request)
+      .pipe(
+        catchError((error: HttpErrorResponse) => {
+          if (HttpErrorHelper.hasMutuallyExclusiveOptions(request)) {
+            console.error('HTTP request has mutually exclusive options, make sure that only one skip header is provided');
+          } else if (!HttpErrorHelper.skipHandling(error, request)) {
+            if (HttpErrorHelper.isClientSideError(error)) {
+              // this is client side unexpected error, generally this should not happen
+              console.error(error.message);
+            } else if (HttpErrorHelper.isServerSideError(error)) {
+              return throwError(error).pipe(finalize(() => this._handleServerError(error)));
+            }
+          }
+          return throwError(error);
+        })
+      );
+  }
+
+  private _handleServerError = (error: HttpErrorResponse) => {
+    switch (error.status) {
+      case HTTP_403_FORBIDDEN:
+      case HTTP_401_UNAUTHORIZED:
+        this._notificationService.addGeneral({
+          type: 'error',
+          content: 'Wystąpił błąd: Nie jesteś zalogowany lub twoja sesja się przedawniła'
+        });
+        this._router.navigate(['login'], {queryParams: {back_link: this._backLink}});
+        break;
+      case HTTP_101_TIMEOUT:
+      case HTTP_404_BAD_REQUEST:
+        this._notificationService.addGeneral({
+          type: 'error',
+          content: 'Wystąpił błąd: Nieprawidłowe zapytanie lub zbyt długi czas oczekiwania na odpowiedź serwera'
+        });
+        break;
+      case HTTP_404_NOT_FOUND:
+        this._router.navigate(['errors', error.status]);
+        break;
+      case HTTP_502_BAD_GATEWAY:
+      case HTTP_500_INTERNAL_SERVER_ERROR:
+        this._router.navigate(['errors', error.status], {queryParams: {back_link: this._backLink}});
+        break;
+      default:
+        this._notificationService.addGeneral({
+          type: 'error',
+          content: `Wystąpił nieznany błąd: ${error.status}, w przypadku dalszego występowania skontaktuj się z administratorem`
+        });
+        break;
+    }
+  };
 }

--- a/s4e-web/src/app/utils/initializer/config.service.ts
+++ b/s4e-web/src/app/utils/initializer/config.service.ts
@@ -1,8 +1,8 @@
-import {Injectable, InjectionToken, Provider} from '@angular/core';
+import {Injectable} from '@angular/core';
 import {IConfiguration, IRemoteConfiguration} from '../../app.configuration';
 import {map, tap} from 'rxjs/operators';
 import {HttpClient} from '@angular/common/http';
-import {combineLatest, of} from 'rxjs';
+import {combineLatest} from 'rxjs';
 import {ProfileService} from '../../state/profile/profile.service';
 
 @Injectable()
@@ -34,7 +34,7 @@ export class S4eConfig implements IConfiguration {
     this.userLocalStorageKey = 'user';
     this.generalErrorKey = '__general__';
     this.maxZoom = 12;
-    this.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    this.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
 
   loadConfiguration(): Promise<IRemoteConfiguration> {

--- a/s4e-web/src/app/views/activate/state/activate.service.ts
+++ b/s4e-web/src/app/views/activate/state/activate.service.ts
@@ -1,7 +1,6 @@
-import {Inject, Injectable} from '@angular/core';
+import {Injectable} from '@angular/core';
 import {action} from '@datorama/akita';
 import {HttpClient, HttpErrorResponse} from '@angular/common/http';
-
 import {ActivateStore} from './activate.store';
 import {Router} from '@angular/router';
 import {delay, finalize} from 'rxjs/operators';

--- a/s4e-web/src/app/views/login/login.component.html
+++ b/s4e-web/src/app/views/login/login.component.html
@@ -26,7 +26,10 @@
       <form (ngSubmit)="login()" [formGroup]="form" autocomplete="off">
         <h2 class="content__header" i18n>Logowanie</h2>
         <div class="alert alert-danger" *ngIf="error$ | async">
-          {{(error$ | async)?.message || 'Nieoczekiwany błąd'}}
+          <ng-container [ngSwitch]="(error$ | async).status">
+            <ng-container *ngSwitchCase="401">Niepoprawny login / hasło</ng-container>
+            <ng-container *ngSwitchDefault>Nieoczekiwany błąd</ng-container>
+          </ng-container>
         </div>
 
         <div class="alert alert-danger" *ngIf="form.errors">

--- a/s4e-web/src/app/views/login/login.component.ts
+++ b/s4e-web/src/app/views/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, OnInit } from '@angular/core';
+import {Component, ViewEncapsulation} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@ng-stack/forms';
 import {AkitaNgFormsManager} from '@datorama/akita-ng-forms-manager';
 import {FormState} from '../../state/form/form.model';
@@ -6,7 +6,7 @@ import {validateAllFormFields} from '../../utils/miscellaneous/miscellaneous';
 import {SessionQuery} from '../../state/session/session.query';
 import {SessionService} from '../../state/session/session.service';
 import {LoginFormState} from '../../state/session/session.model';
-import {Router} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {GenericFormComponent} from '../../utils/miscellaneous/generic-form.component';
 
 @Component({
@@ -19,8 +19,15 @@ export class LoginComponent extends GenericFormComponent<SessionQuery, LoginForm
   constructor(fm: AkitaNgFormsManager<FormState>,
               router: Router,
               private sessionService: SessionService,
-              private sessionQuery: SessionQuery) {
+              private sessionQuery: SessionQuery,
+              private _activatedRoute: ActivatedRoute
+  ) {
     super(fm, router, sessionQuery, 'login');
+
+    this._activatedRoute.queryParamMap
+      .subscribe((queryParams) => {
+        this.sessionService.back_link = queryParams.get('back_link');
+      });
   }
 
   ngOnInit() {
@@ -36,7 +43,9 @@ export class LoginComponent extends GenericFormComponent<SessionQuery, LoginForm
   login() {
     validateAllFormFields(this.form, {formKey: this.formKey, fm: this.fm});
 
-    if (!this.form.valid) { return; }
+    if (!this.form.valid) {
+      return;
+    }
 
     this.sessionService.login(this.form.controls.login.value, this.form.controls.password.value);
   }

--- a/s4e-web/src/app/views/logout/logout.component.spec.ts
+++ b/s4e-web/src/app/views/logout/logout.component.spec.ts
@@ -1,11 +1,10 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { SessionService } from './../../state/session/session.service';
-import { RouterTestingModule } from '@angular/router/testing';
-import { LogoutModule } from './logout.module';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { LogoutComponent } from './logout.component';
-import { TestingConfigProvider } from 'src/app/app.configuration.spec';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {SessionService} from '../../state/session/session.service';
+import {RouterTestingModule} from '@angular/router/testing';
+import {LogoutModule} from './logout.module';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {LogoutComponent} from './logout.component';
+import {TestingConfigProvider} from '../../app.configuration.spec';
 
 describe('LogoutComponent', () => {
   let component: LogoutComponent;
@@ -20,7 +19,7 @@ describe('LogoutComponent', () => {
       ],
       providers: [TestingConfigProvider]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/s4e-web/src/app/views/logout/logout.component.ts
+++ b/s4e-web/src/app/views/logout/logout.component.ts
@@ -1,12 +1,13 @@
-import { SessionService } from './../../state/session/session.service';
-import { Component, OnInit } from '@angular/core';
+import {SessionService} from '../../state/session/session.service';
+import {Component, OnInit} from '@angular/core';
 
 @Component({
   template: ''
 })
 export class LogoutComponent implements OnInit {
 
-  constructor(private _sessionService: SessionService) {}
+  constructor(private _sessionService: SessionService) {
+  }
 
   ngOnInit() {
     this._sessionService.logout();

--- a/s4e-web/src/app/views/logout/logout.module.ts
+++ b/s4e-web/src/app/views/logout/logout.module.ts
@@ -1,8 +1,7 @@
-import { CommonStateModule } from './../../state/common-state.module';
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { LogoutComponent } from './logout.component';
-import { SessionService } from 'src/app/state/session/session.service';
+import {CommonStateModule} from '../../state/common-state.module';
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {LogoutComponent} from './logout.component';
 
 @NgModule({
   declarations: [LogoutComponent],
@@ -12,4 +11,5 @@ import { SessionService } from 'src/app/state/session/session.service';
   ],
   exports: [LogoutComponent]
 })
-export class LogoutModule { }
+export class LogoutModule {
+}

--- a/s4e-web/src/app/views/map-view/state/overlay/overlay.service.ts
+++ b/s4e-web/src/app/views/map-view/state/overlay/overlay.service.ts
@@ -1,12 +1,12 @@
 import {Injectable} from '@angular/core';
 import {OverlayStore} from './overlay.store';
 import {OverlayResponse, OverlayType} from './overlay.model';
-import {finalize, map} from 'rxjs/operators';
+import {map} from 'rxjs/operators';
 import {S4eConfig} from '../../../../utils/initializer/config.service';
 import {OverlayQuery} from './overlay.query';
 import {HttpClient} from '@angular/common/http';
 import {action} from '@datorama/akita';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {catchErrorAndHandleStore} from '../../../../common/store.util';
 
 /**
  * This is stub service which will be responsible for getting overlay data

--- a/s4e-web/src/app/views/map-view/state/scene/scene.service.ts
+++ b/s4e-web/src/app/views/map-view/state/scene/scene.service.ts
@@ -10,7 +10,7 @@ import {ProductStore} from '../product/product.store';
 import {applyTransaction} from '@datorama/akita';
 import {map} from 'rxjs/operators';
 import {Product} from '../product/product.model';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {catchErrorAndHandleStore} from '../../../../common/store.util';
 
 @Injectable({providedIn: 'root'})
 export class SceneService {
@@ -29,9 +29,9 @@ export class SceneService {
     this.http.get<Scene[]>(`${this.CONFIG.apiPrefixV1}/products/${product.id}/scenes`, {
       params: {date: date, tz: this.CONFIG.timezone}
     }).pipe(
-        catchErrorAndHandleStore(this.store),
-        map(entities => entities.map(s => ({...s, layerName: product.layerName})))
-      )
+      catchErrorAndHandleStore(this.store),
+      map(entities => entities.map(s => ({...s, layerName: product.layerName})))
+    )
       .subscribe((entities) => applyTransaction(() => {
         this.store.set(entities);
         if (this.sceneQuery.getCount() > 0) {

--- a/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.service.ts
+++ b/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.service.ts
@@ -1,14 +1,13 @@
-import { Injectable } from '@angular/core';
-import { ID } from '@datorama/akita';
-import { HttpClient } from '@angular/common/http';
-import { SentinelSearchStore } from './sentinel-search.store';
-import {createSentinelSearchResult, SentinelSearchResult} from './sentinel-search.model';
-import {Observable, of} from 'rxjs';
+import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {SentinelSearchStore} from './sentinel-search.store';
+import {createSentinelSearchResult} from './sentinel-search.model';
+import {of} from 'rxjs';
 import {SentinelSearchQuery} from './sentinel-search.query';
 import {delay, finalize} from 'rxjs/operators';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {catchErrorAndHandleStore} from '../../../../common/store.util';
 
-@Injectable({ providedIn: 'root' })
+@Injectable({providedIn: 'root'})
 export class SentinelSearchService {
 
   constructor(private store: SentinelSearchStore,
@@ -40,7 +39,7 @@ export class SentinelSearchService {
       catchErrorAndHandleStore(this.store),
       finalize(() => this.store.setLoading(false))
     )
-    .subscribe(data => this.store.set(data))
+      .subscribe(data => this.store.set(data));
   }
 
   getSentinels() {
@@ -51,6 +50,6 @@ export class SentinelSearchService {
       delay(250),
       catchErrorAndHandleStore(this.store)
     )
-    .subscribe(data => this.store.update(state => ({...state, sentinels: data})))
+      .subscribe(data => this.store.update(state => ({...state, sentinels: data})));
   }
 }

--- a/s4e-web/src/app/views/map-view/state/view-configuration/view-configuration.service.ts
+++ b/s4e-web/src/app/views/map-view/state/view-configuration/view-configuration.service.ts
@@ -2,12 +2,12 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {ViewConfigurationStore} from './view-configuration.store';
 import {ViewConfiguration} from './view-configuration.model';
-import {catchError, finalize, map, shareReplay} from 'rxjs/operators';
+import {finalize, map, shareReplay} from 'rxjs/operators';
 import {S4eConfig} from '../../../../utils/initializer/config.service';
-import {Observable, throwError} from 'rxjs';
+import {Observable} from 'rxjs';
 import {IPageableResponse} from '../../../../state/pagable.model';
 import {ViewConfigurationQuery} from './view-configuration.query';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {catchErrorAndHandleStore} from '../../../../common/store.util';
 
 @Injectable({providedIn: 'root'})
 export class ViewConfigurationService {
@@ -21,6 +21,7 @@ export class ViewConfigurationService {
   add$(viewConfiguration: ViewConfiguration): Observable<boolean> {
     this.store.setError(null);
     this.store.setLoading(true);
+
     const r = this.http.post<ViewConfiguration>(`${this.config.apiPrefixV1}/saved-views`, viewConfiguration)
       .pipe(
         map(r => true),
@@ -36,11 +37,10 @@ export class ViewConfigurationService {
     this.store.setLoading(true);
     this.http.delete(`${this.config.apiPrefixV1}/saved-views/${uuid}`, {
       headers: {'Content-Type': 'application/json'}
-    })
-      .pipe(
-        catchErrorAndHandleStore(this.store),
-        finalize(() => this.store.setLoading(false))
-      )
+    }).pipe(
+      catchErrorAndHandleStore(this.store),
+      finalize(() => this.store.setLoading(false))
+    )
       .subscribe(() => this.store.remove(uuid));
   }
 
@@ -49,11 +49,9 @@ export class ViewConfigurationService {
     this.store.setLoading(true);
     this.http.get<IPageableResponse<ViewConfiguration>>(`${this.config.apiPrefixV1}/saved-views`, {
       headers: {'Content-Type': 'application/json'}
-    })
-      .pipe(
-        catchErrorAndHandleStore(this.store),
-        finalize(() => this.store.setLoading(false))
-      )
-      .subscribe(data => this.store.set(data.content));
+    }).pipe(
+      finalize(() => this.store.setLoading(false)),
+      catchErrorAndHandleStore(this.store),
+    ).subscribe(data => this.store.set(data.content));
   }
 }

--- a/s4e-web/src/app/views/map-view/zk/configuration/state/configuration.service.ts
+++ b/s4e-web/src/app/views/map-view/zk/configuration/state/configuration.service.ts
@@ -2,13 +2,12 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {ConfigurationStore} from './configuration.store';
 import {Configuration, ConfigurationState, ShareConfigurationRequest} from './configuration.model';
-import {finalize, map, shareReplay, catchError} from 'rxjs/operators';
+import {catchError, finalize, map, shareReplay} from 'rxjs/operators';
 import {ConfigurationQuery} from './configuration.query';
 import {S4eConfig} from '../../../../../utils/initializer/config.service';
 import {Dao} from '../../../../../common/dao.service';
-import {Observable, of} from 'rxjs';
 import {NotificationService} from 'notifications';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {Observable, of} from 'rxjs';
 
 @Injectable({providedIn: 'root'})
 export class ConfigurationService extends Dao<Configuration, ConfigurationState, ConfigurationStore> {
@@ -22,6 +21,7 @@ export class ConfigurationService extends Dao<Configuration, ConfigurationState,
 
   shareConfiguration(conf: ShareConfigurationRequest): Observable<boolean> {
     this.store.setLoading(true);
+
     const r = this.http.post<void>(`${this.config.apiPrefixV1}/share-link`, conf)
       .pipe(
         map(r => {

--- a/s4e-web/src/app/views/register/state/register.service.ts
+++ b/s4e-web/src/app/views/register/state/register.service.ts
@@ -21,6 +21,7 @@ export class RegisterService {
    */
   register(email: string, password: string, recaptcha: string) {
     this.registerStore.setLoading(true);
+
     this.http.post(`${this.CONFIG.apiPrefixV1}/register`, {email, password}, {params: {'g-recaptcha-response': recaptcha}})
       .pipe(delay(1000), finalize(() => this.registerStore.setLoading(false)))
       .subscribe(data => {

--- a/s4e-web/src/app/views/settings/groups/state/group.service.ts
+++ b/s4e-web/src/app/views/settings/groups/state/group.service.ts
@@ -3,13 +3,13 @@ import {HttpClient} from '@angular/common/http';
 import {GroupStore} from './group.store';
 import {IPageableResponse} from '../../../../state/pagable.model';
 import {Institution} from '../../state/institution.model';
-import {catchError, combineAll, finalize, map, tap} from 'rxjs/operators';
+import {finalize, map} from 'rxjs/operators';
 import {GroupQuery} from './group.query';
 import {S4eConfig} from '../../../../utils/initializer/config.service';
 import {Group, GroupForm} from './group.model';
-import {combineLatest, forkJoin, Observable, of, throwError} from 'rxjs';
+import {forkJoin, Observable} from 'rxjs';
 import {Person} from '../../people/state/person.model';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {catchErrorAndHandleStore} from '../../../../common/store.util';
 
 @Injectable({providedIn: 'root'})
 export class GroupService {
@@ -44,9 +44,10 @@ export class GroupService {
 
   create$(instSlug: string, value: GroupForm) {
     this.store.setLoading(true);
+
     return this.http.post<Group>(`${this.config.apiPrefixV1}/institutions/${instSlug}/groups`, {
       ...value,
-      membersEmails: value.membersEmails._
+      membersEmails: value.membersEmails._,
     }).pipe(
       finalize(() => this.store.setLoading(false)),
       catchErrorAndHandleStore(this.store)
@@ -57,10 +58,10 @@ export class GroupService {
     this.store.setLoading(true);
     return forkJoin([
       this.http.get<Group>(`${this.config.apiPrefixV1}/institutions/${instSlug}/groups/${groupSlug}`),
-      this.http.get<{members: Person[]}>(`${this.config.apiPrefixV1}/institutions/${instSlug}/groups/${groupSlug}/members`)
+      this.http.get<{ members: Person[] }>(`${this.config.apiPrefixV1}/institutions/${instSlug}/groups/${groupSlug}/members`)
     ]).pipe(
-        finalize(() => this.store.setLoading(false)),
-        catchErrorAndHandleStore(this.store),
+      finalize(() => this.store.setLoading(false)),
+      catchErrorAndHandleStore(this.store),
       map(([group, users]) => ({
         name: group.name,
         description: '',

--- a/s4e-web/src/app/views/settings/people/state/person.service.ts
+++ b/s4e-web/src/app/views/settings/people/state/person.service.ts
@@ -2,11 +2,10 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {PersonStore} from './person.store';
 import {S4eConfig} from '../../../../utils/initializer/config.service';
-import {catchError, finalize} from 'rxjs/operators';
-import {DEFAULT_GROUP_NAME, DEFAULT_GROUP_SLUG, Person, PersonForm} from './person.model';
-import {Observable, of, throwError} from 'rxjs';
-import {Group, GroupForm} from '../../groups/state/group.model';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {Observable} from 'rxjs';
+import {finalize} from 'rxjs/operators';
+import {DEFAULT_GROUP_SLUG, Person, PersonForm} from './person.model';
+import {catchErrorAndHandleStore} from '../../../../common/store.util';
 
 @Injectable({providedIn: 'root'})
 export class PersonService {
@@ -20,19 +19,21 @@ export class PersonService {
     this.store.setError(null);
     this.http.get<{ members: Person[] }>(`${this.config.apiPrefixV1}/institutions/${institutionSlug}/groups/${DEFAULT_GROUP_SLUG}/members`)
       .pipe(
-        catchErrorAndHandleStore(this.store),
-        finalize(() => this.store.setLoading(false))
+        finalize(() => this.store.setLoading(false)),
+        catchErrorAndHandleStore(this.store)
       )
       .subscribe(data => this.store.set(data.members));
   }
+
   create$(institutionSlug: string, value: PersonForm): Observable<Person> {
     this.store.setLoading(true);
 
-    value = {...value, groupSlugs: [...value.groupSlugs._, 'default']};
-
-    return this.http.post<Person>(`${this.config.apiPrefixV1}/institutions/${institutionSlug}/users`, value).pipe(
-      finalize(() => this.store.setLoading(false)),
-      catchErrorAndHandleStore(this.store)
+    return this.http.post<Person>(
+      `${this.config.apiPrefixV1}/institutions/${institutionSlug}/users`,
+      {...value, groupSlugs: [...value.groupSlugs._, 'default']}
+    ).pipe(
+      catchErrorAndHandleStore(this.store),
+      finalize(() => this.store.setLoading(false))
     );
   }
 }

--- a/s4e-web/src/app/views/settings/profile/profile.component.ts
+++ b/s4e-web/src/app/views/settings/profile/profile.component.ts
@@ -1,14 +1,14 @@
-import { ProfileQuery } from './../../../state/profile/profile.query';
-import { ProfileService } from './../../../state/profile/profile.service';
-import {Component, OnInit} from '@angular/core';
+import {ProfileQuery} from '../../../state/profile/profile.query';
+import {ProfileService} from '../../../state/profile/profile.service';
+import {Component} from '@angular/core';
 import {SessionQuery} from '../../../state/session/session.query';
 import {Observable} from 'rxjs';
-import { FormGroup, FormControl, Validators } from '@ng-stack/forms';
-import { GenericFormComponent } from 'src/app/utils/miscellaneous/generic-form.component';
-import { PasswordChangeFormState } from 'src/app/state/profile/profile.model';
-import { AkitaNgFormsManager } from '@datorama/akita-ng-forms-manager';
-import { Router } from '@angular/router';
-import { FormState } from 'src/app/state/form/form.model';
+import {FormControl, FormGroup, Validators} from '@ng-stack/forms';
+import {GenericFormComponent} from 'src/app/utils/miscellaneous/generic-form.component';
+import {PasswordChangeFormState} from 'src/app/state/profile/profile.model';
+import {AkitaNgFormsManager} from '@datorama/akita-ng-forms-manager';
+import {Router} from '@angular/router';
+import {FormState} from 'src/app/state/form/form.model';
 
 @Component({
   selector: 's4e-profile',
@@ -26,7 +26,6 @@ export class ProfileComponent extends GenericFormComponent<ProfileQuery, Passwor
     private _profileService: ProfileService,
     private _profileQuery: ProfileQuery,
     private _sessionQuery: SessionQuery
-
   ) {
     super(fm, router, _profileQuery, 'resetPassword');
   }

--- a/s4e-web/src/app/views/settings/state/institution.service.ts
+++ b/s4e-web/src/app/views/settings/state/institution.service.ts
@@ -1,5 +1,4 @@
 import {Injectable} from '@angular/core';
-import {ID} from '@datorama/akita';
 import {HttpClient} from '@angular/common/http';
 import {InstitutionStore} from './institution.store';
 import {Institution} from './institution.model';
@@ -9,11 +8,10 @@ import {InstitutionQuery} from './institution.query';
 import {IPageableResponse} from '../../../state/pagable.model';
 import {ActivatedRoute, Router} from '@angular/router';
 import {combineLatest, Observable} from 'rxjs';
-import { catchErrorAndHandleStore } from 'src/app/common/store.util';
+import {catchErrorAndHandleStore} from '../../../common/store.util';
 
 @Injectable({providedIn: 'root'})
 export class InstitutionService {
-
   constructor(private store: InstitutionStore,
               private s4EConfig: S4eConfig,
               private query: InstitutionQuery,


### PR DESCRIPTION
Global error handling, catch beneath errors. Each of them is handled differently

ERROR_CODE_UNAUTHORIZED = 401;
ERROR_CODE_FORBIDDEN = 403;

Should navigate to `/login` page with notification:
`Wystąpił błąd: Nie jesteś zalogowany lub twoja sesja się przedawniła`

---
ERROR_CODE_BAD_REQUEST = 400;
ERROR_CODE_TIMEOUT = 101;

Should show notification with message:
`Wystąpił błąd: Nieprawidłowe zapytanie lub zbyt długi czas oczekiwania na odpowiedź serwera`

---
ERROR_CODE_NOT_FOUND = 404;

Should navigate to `/errors/404` page

---
ERROR_CODE_INTERNAL_SERVER_ERROR = 500;
ERROR_CODE_BAD_GATEWAY = 502;

Should navigate to `/errors/500` or `/errors/502` page, with a possibility to return to the last page (that was visited)

---

**UPDATE** (@michal-szostak): There are some exceptions to the rule for POSTS in most places (in all forms) there is no default notification for error `400` as it is handled by the form itself.

For manual testing I recommend this chrome extension: https://chrome.google.com/webstore/detail/interceptor/enenfaicdcfgcnjmiigcjbmlbaoapnen?hl=en

It is not perfect but it can mock ajax responses in the browser, which enables easy error checking without having to mess with the server setup.
