### PR TITLE
[#435] Notifications for share configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The most recent changes are on top, in each type of changes category.
 
 - SceneAcceptor driven by files from S3 [#160](https://github.com/cyfronet-fid/sat4envi/issues/160)
 - Notifications module [#423](https://github.com/cyfronet-fid/sat4envi/issues/423)
+- Notification for successful share configuration [#435](https://github.com/cyfronet-fid/sat4envi/issues/435)
 
 ### Changed
 

--- a/s4e-web/package.json
+++ b/s4e-web/package.json
@@ -41,6 +41,13 @@
     ],
     "transform": {
       "(?!<rootDir>/node_modules)/.*\\.js$": "babel-jest"
+    },
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist"
+    ],
+    "moduleNameMapper": {
+      "^notifications$": "<rootDir>/projects/notifications/src/public_api.ts",
+      "^notifications/(.*)$": "<rootDir>/projects/notifications/src/$1"
     }
   },
   "babelOptions": {

--- a/s4e-web/projects/notifications/src/lib/components/general-notification/general-notification.component.spec.ts
+++ b/s4e-web/projects/notifications/src/lib/components/general-notification/general-notification.component.spec.ts
@@ -1,5 +1,4 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-
 import {GeneralNotificationComponent} from './general-notification.component';
 import {By} from '@angular/platform-browser';
 import {createGeneralNotification, GeneralNotification} from '../../state/notification.model';

--- a/s4e-web/src/app/views/map-view/zk/configuration/state/configuration.service.ts
+++ b/s4e-web/src/app/views/map-view/zk/configuration/state/configuration.service.ts
@@ -7,11 +7,13 @@ import {ConfigurationQuery} from './configuration.query';
 import {S4eConfig} from '../../../../../utils/initializer/config.service';
 import {Dao} from '../../../../../common/dao.service';
 import {Observable, of} from 'rxjs';
+import {NotificationService} from 'notifications';
 
 @Injectable({providedIn: 'root'})
 export class ConfigurationService extends Dao<Configuration, ConfigurationState, ConfigurationStore> {
   constructor(store: ConfigurationStore,
               http: HttpClient,
+              private notifications: NotificationService,
               private config: S4eConfig,
               private query: ConfigurationQuery) {
     super(http, `${config.apiPrefixV1}/configurations`, store);
@@ -22,6 +24,10 @@ export class ConfigurationService extends Dao<Configuration, ConfigurationState,
     const r = this.http.post<void>(`${this.config.apiPrefixV1}/share-link`, conf)
       .pipe(
         map(r => {
+          this.notifications.addGeneral({
+            type: 'success',
+            content: `Link został wysłany na adres ${conf.emails.join(', ')}`
+          });
           return true;
         }), catchError(error => {
           this.store.setError(error);

--- a/s4e-web/src/tsconfig.spec.json
+++ b/s4e-web/src/tsconfig.spec.json
@@ -17,6 +17,9 @@
   "files": [
     "polyfills.ts"
   ],
+  "modulePathIgnorePatterns": [
+    "projects/notifications"
+  ],
   "include": [
     "**/*.spec.ts",
     "**/*.d.ts"


### PR DESCRIPTION
## What is in this PR?

* Fix notification in jest tests (this is important, importing anything from `notifications` module in tests crashed them) it is fixed now
* Add notification for successful share configuration

## How does it look?

<img width="1392" alt="スクリーンショット 2020-04-28 23 48 20" src="https://user-images.githubusercontent.com/13235269/80541184-fff65200-89aa-11ea-8d98-b522aa1a5a92.png">

Closes: #435