### PR TITLE
[#202] Audit selected entitites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Audit selected entities [#158](https://github.com/cyfronet-fid/sat4envi/issues/158)
+
 ### Changed
 
 ### Fixed

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppRole.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppRole.java
@@ -5,14 +5,17 @@ public enum AppRole {
      * Institution admin, can add child institution, can add institution admin for child institution
      */
     INST_ADMIN,
+
     /**
      * Institution manager, can add/edit group, add user, add user role, can edit institution
      */
     INST_MANAGER,
+
     /**
      * Group manager, can edit group, add user, add/edit user role
      */
     GROUP_MANAGER,
+
     /**
      * Group member, can read group items
      */

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
@@ -1,6 +1,7 @@
 package pl.cyfronet.s4e.bean;
 
 import lombok.*;
+import pl.cyfronet.s4e.bean.audit.CreationAndModificationAudited;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -16,7 +17,7 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class AppUser {
+public class AppUser extends CreationAndModificationAudited {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
@@ -21,6 +21,7 @@ public class AppUser {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include
     private Long id;
+
     @NotEmpty
     @Column(unique = true)
     @EqualsAndHashCode.Include

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/EmailVerification.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/EmailVerification.java
@@ -1,7 +1,9 @@
 package pl.cyfronet.s4e.bean;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -14,14 +16,19 @@ import java.time.LocalDateTime;
 @Entity
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class EmailVerification {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @OneToOne(optional = false)
     private AppUser appUser;
+
     @NotEmpty
     private String token;
+
     @NotNull
     private LocalDateTime expiryTimestamp;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Institution.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Institution.java
@@ -2,6 +2,7 @@ package pl.cyfronet.s4e.bean;
 
 import lombok.*;
 import org.hibernate.annotations.NaturalId;
+import pl.cyfronet.s4e.bean.audit.CreationAndModificationAudited;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -15,7 +16,7 @@ import javax.validation.constraints.NotEmpty;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "institution", uniqueConstraints = @UniqueConstraint(columnNames = {"name", "slug"}))
-public class Institution {
+public class Institution extends CreationAndModificationAudited {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Legend.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Legend.java
@@ -9,14 +9,19 @@ import java.io.Serializable;
 import java.util.Map;
 
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Legend implements Serializable {
     private String type;
+
     private String url;
+
     private Map<String,String> leftDescription;
+
     private Map<String,String> rightDescription;
+
     private Map<String,String> topMetric;
+
     private Map<String,String> bottomMetric;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/PRGOverlay.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/PRGOverlay.java
@@ -1,7 +1,9 @@
 package pl.cyfronet.s4e.bean;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -10,17 +12,23 @@ import javax.validation.constraints.NotEmpty;
 @Table(name = "prg_overlay")
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PRGOverlay {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @NotEmpty
     private String name;
+
     /**
      * Must be set to match with the featureTypes in the PRG zip. It will also be the layer name
      */
     private String featureType;
+
     @ManyToOne
     private SldStyle sldStyle;
+
     private boolean created;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/PasswordReset.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/PasswordReset.java
@@ -1,7 +1,9 @@
 package pl.cyfronet.s4e.bean;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -14,14 +16,19 @@ import java.time.LocalDateTime;
 @Entity
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PasswordReset {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @OneToOne(optional = false)
     private AppUser appUser;
+
     @NotEmpty
     private String token;
+
     @NotNull
     private LocalDateTime expiryTimestamp;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Place.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Place.java
@@ -1,27 +1,39 @@
 package pl.cyfronet.s4e.bean;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @Entity
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Place {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @NotEmpty
     private String name;
+
     @NotEmpty
     private String type;
+
     @NotNull
     private double latitude;
+
     @NotNull
     private double longitude;
+
     @NotEmpty
     private String voivodeship;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Product.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Product.java
@@ -1,9 +1,6 @@
 package pl.cyfronet.s4e.bean;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
@@ -20,6 +17,8 @@ import java.util.Set;
 @Entity
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Product {
     @Id

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Product.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Product.java
@@ -2,6 +2,7 @@ package pl.cyfronet.s4e.bean;
 
 import lombok.*;
 import org.hibernate.annotations.Type;
+import pl.cyfronet.s4e.bean.audit.CreationAndModificationAudited;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -20,7 +21,7 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class Product {
+public class Product extends CreationAndModificationAudited {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Scene.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Scene.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.*;
 import org.hibernate.annotations.Type;
 import org.locationtech.jts.geom.Geometry;
+import pl.cyfronet.s4e.bean.audit.CreationAndModificationAudited;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Scene {
+public class Scene extends CreationAndModificationAudited {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Scene.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Scene.java
@@ -1,9 +1,7 @@
 package pl.cyfronet.s4e.bean;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import lombok.Builder;
-import lombok.Data;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.Type;
 import org.locationtech.jts.geom.Geometry;
 
@@ -18,6 +16,8 @@ import java.time.LocalDateTime;
 @Entity
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Scene {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Schema.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Schema.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import pl.cyfronet.s4e.bean.audit.CreationAudited;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -14,7 +15,7 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Schema {
+public class Schema extends CreationAudited {
     public enum Type {
         SCENE, METADATA;
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/SldStyle.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/SldStyle.java
@@ -1,7 +1,9 @@
 package pl.cyfronet.s4e.bean;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -12,11 +14,15 @@ import javax.validation.constraints.NotEmpty;
 @Entity
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SldStyle {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @NotEmpty
     private String name;
+
     private boolean created;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/UserRole.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/UserRole.java
@@ -1,6 +1,7 @@
 package pl.cyfronet.s4e.bean;
 
 import lombok.*;
+import pl.cyfronet.s4e.bean.audit.CreationAudited;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -12,7 +13,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Table(name = "user_role", uniqueConstraints = @UniqueConstraint(columnNames = {"role", "app_user_id", "inst_group_id"}))
-public class UserRole {
+public class UserRole extends CreationAudited {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/UserRole.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/UserRole.java
@@ -1,9 +1,6 @@
 package pl.cyfronet.s4e.bean;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -11,8 +8,10 @@ import javax.validation.constraints.NotNull;
 @Entity
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@Table(name = "user_role",uniqueConstraints = @UniqueConstraint(columnNames = {"role", "app_user_id", "inst_group_id"}))
+@Table(name = "user_role", uniqueConstraints = @UniqueConstraint(columnNames = {"role", "app_user_id", "inst_group_id"}))
 public class UserRole {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/WMSOverlay.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/WMSOverlay.java
@@ -1,6 +1,9 @@
 package pl.cyfronet.s4e.bean;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -10,12 +13,17 @@ import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class WMSOverlay {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @NotEmpty
     private String name;
+
     @NotEmpty
     private String url;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/audit/CreationAndModificationAudited.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/audit/CreationAndModificationAudited.java
@@ -1,0 +1,20 @@
+package pl.cyfronet.s4e.bean.audit;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class CreationAndModificationAudited extends CreationAudited {
+    @LastModifiedDate
+    private LocalDateTime lastModifiedAt;
+
+    @LastModifiedBy
+    private String lastModifiedBy;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/audit/CreationAudited.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/audit/CreationAudited.java
@@ -1,0 +1,23 @@
+package pl.cyfronet.s4e.bean.audit;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class CreationAudited {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    private String createdBy;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/PersistenceConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/PersistenceConfig.java
@@ -1,0 +1,26 @@
+package pl.cyfronet.s4e.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.security.Principal;
+import java.util.Objects;
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class PersistenceConfig {
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Objects::nonNull)
+                .filter(Authentication::isAuthenticated)
+                .map(Principal::getName);
+    }
+}

--- a/s4e-backend/src/main/resources/db/migration/V33__add_auditing_columns.sql
+++ b/s4e-backend/src/main/resources/db/migration/V33__add_auditing_columns.sql
@@ -1,0 +1,32 @@
+ALTER TABLE app_user
+    ADD COLUMN created_at TIMESTAMP,
+    ADD COLUMN created_by VARCHAR,
+    ADD COLUMN last_modified_at TIMESTAMP,
+    ADD COLUMN last_modified_by VARCHAR;
+
+ALTER TABLE institution
+    ADD COLUMN created_at TIMESTAMP,
+    ADD COLUMN created_by VARCHAR,
+    ADD COLUMN last_modified_at TIMESTAMP,
+    ADD COLUMN last_modified_by VARCHAR;
+
+ALTER TABLE user_role
+    ADD COLUMN created_at TIMESTAMP,
+    ADD COLUMN created_by VARCHAR;
+
+ALTER TABLE schema
+    ADD COLUMN created_at TIMESTAMP,
+    ADD COLUMN created_by VARCHAR;
+
+ALTER TABLE product
+    ADD COLUMN created_at TIMESTAMP,
+    ADD COLUMN created_by VARCHAR,
+    ADD COLUMN last_modified_at TIMESTAMP,
+    ADD COLUMN last_modified_by VARCHAR;
+
+ALTER TABLE scene
+    ADD COLUMN created_at TIMESTAMP,
+    ADD COLUMN created_by VARCHAR,
+    ADD COLUMN last_modified_at TIMESTAMP,
+    ADD COLUMN last_modified_by VARCHAR;
+

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/db/AuditingTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/db/AuditingTest.java
@@ -1,0 +1,121 @@
+package pl.cyfronet.s4e.db;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@BasicTest
+public class AuditingTest {
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    @BeforeEach
+    public void beforeEach() {
+        testDbHelper.clean();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void shouldRecordSave() {
+        String creator = "someOther@guy.pl";
+        authenticateAs(creator);
+
+        LocalDateTime beforeSave = LocalDateTime.now();
+
+        AppUser appUser = saveAppUser("test@some.pl");
+
+        LocalDateTime afterSave = LocalDateTime.now();
+
+        assertThat(appUser.getCreatedAt(), isInRange(beforeSave, afterSave));
+        assertThat(appUser.getCreatedBy(), is(equalTo(creator)));
+        assertThat(appUser.getLastModifiedAt(), isInRange(beforeSave, afterSave));
+        assertThat(appUser.getLastModifiedBy(), is(equalTo(creator)));
+    }
+
+    @Test
+    public void shouldRecordSaveIfUnauthenticated() {
+        LocalDateTime beforeSave = LocalDateTime.now();
+
+        AppUser appUser = saveAppUser("test@some.pl");
+
+        LocalDateTime afterSave = LocalDateTime.now();
+
+        assertThat(appUser.getCreatedAt(), isInRange(beforeSave, afterSave));
+        assertThat(appUser.getCreatedBy(), is(nullValue()));
+        assertThat(appUser.getLastModifiedAt(), isInRange(beforeSave, afterSave));
+        assertThat(appUser.getLastModifiedBy(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldRecordUpdate() {
+        String userEmail = "test@some.pl";
+        String creator = "some@guy.pl";
+        String modifier = "someOther@guy.pl";
+        authenticateAs(creator);
+        saveAppUser(userEmail);
+        authenticateAs(modifier);
+
+        LocalDateTime beforeModification = LocalDateTime.now();
+
+        AppUser appUser = updateAppUser(userEmail);
+
+        LocalDateTime afterModification = LocalDateTime.now();
+
+        assertThat(appUser.getCreatedAt(), is(lessThan(beforeModification)));
+        assertThat(appUser.getCreatedBy(), is(equalTo(creator)));
+        assertThat(appUser.getLastModifiedAt(), isInRange(beforeModification, afterModification));
+        assertThat(appUser.getLastModifiedBy(), is(equalTo(modifier)));
+    }
+
+    private AppUser saveAppUser(String email) {
+        return appUserRepository.save(createAppUser(email));
+    }
+
+    private AppUser updateAppUser(String email) {
+        AppUser appUser = appUserRepository.findByEmail(email).get();
+        appUser.setName(appUser.getName() + " changed");
+        return appUserRepository.save(appUser);
+    }
+
+    private Matcher<LocalDateTime> isInRange(LocalDateTime start, LocalDateTime end) {
+        return is(allOf(greaterThan(start), lessThan(end)));
+    }
+
+    private AppUser createAppUser(String email) {
+        return AppUser.builder()
+                .email(email)
+                .name("Name")
+                .surname("Surname")
+                .password("someHash")
+                .build();
+    }
+
+    private void authenticateAs(String name) {
+        Authentication auth = mock(Authentication.class);
+        when(auth.isAuthenticated()).thenReturn(true);
+        when(auth.getName()).thenReturn(name);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}


### PR DESCRIPTION
Schema and UserRole don't have modification auditing, because they are immutable by design.

In the Audited.*By fields, I only optionally log user's name, providing looser coupling, allowing for user deletion, for example.

So far, the auditable fields are not reflected in the API responses. We may not need it, or want to expose it to all parties.

Closes: #202.