### PR TITLE
[#445] Add /logout routing and clear storage on logout (inconsistent state of storage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.sublime-workspace
 
 # IDE - VSCode
+/s4e-web/.vscode
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
@@ -41,3 +42,4 @@ testem.log
 .DS_Store
 Thumbs.db
 /tmp
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Add /logout routing and clear storage on logout (inconsistent state of storage) [#445](https://github.com/cyfronet-fid/sat4envi/issues/445)
 - Synchronize scenes from S3 (s4-sync-1 dataset) [#439](https://github.com/cyfronet-fid/sat4envi/issues/439)
 - Audit selected entities [#158](https://github.com/cyfronet-fid/sat4envi/issues/158)
 

--- a/s4e-web/.gitignore
+++ b/s4e-web/.gitignore
@@ -18,4 +18,3 @@
 /cypress/videos
 /dist
 /.angulardoc.json
-

--- a/s4e-web/cypress/integration/profile.spec.ts
+++ b/s4e-web/cypress/integration/profile.spec.ts
@@ -3,51 +3,54 @@
 context('Profile', () => {
   // IMPORTANT!!! This test can't be done due to bug with login and logout
   // TODO uncomment after reparation of up mentioned issue
-  // it('Should change password', () => {
-  //   // log in
-  //   cy.visit('/login');
-  //   cy.fixture('users/zkMember.json').as('zkMember')
-  //     .then((zkMember) => {
-  //       cy.get('#login-login').type(zkMember.email);
-  //       cy.get('#login-password').type(zkMember.password);
-  //       cy.get('button[type="submit"]').click();
-  //     });
+  it('Should change password', () => {
+    // log in
+    cy.visit('/login');
+    cy.fixture('users/zkMember.json').as('zkMember')
+      .then((zkMember) => {
+        cy.get('#login-login').type(zkMember.email);
+        cy.get('#login-password').type(zkMember.password);
+        cy.get('button[type="submit"]').click();
+      });
+    cy.location('pathname').should('eq', '/map/products');
 
-  //   // go to settings profile
-  //   cy.location('pathname').should('eq', '/map/products');
-  //   cy.get('#user-login-button').should('be.visible').click();
-  //   cy.get('a').should('be.visible').contains('Ustawienia').click();
+    // go to settings profile
+    cy.get('#user-login-button').should('be.visible').click();
+    cy.get('a').should('be.visible').contains('Ustawienia').click();
+    cy.location('pathname').should('eq', '/settings/profile');
 
-  //   cy.fixture('users/zkMember.json').as('zkMember')
-  //     .then((zkMember) => {
-  //       cy.get('#old-password').type(zkMember.password);
-  //       cy.get('#new-password').type(zkMember.password.toUpperCase());
-  //       cy.get('button[type="submit"]').click();
-  //     });
+    cy.fixture('users/zkMember.json').as('zkMember')
+      .then((zkMember) => {
+        cy.get('#old-password').type(zkMember.password);
+        cy.get('#new-password').type(zkMember.password.toUpperCase());
+        cy.get('button[type="submit"]').click();
+        cy.wait(1000);
+      });
 
-  //   // logout
-  //   cy.get('.login a').click();
+    // logout
+    cy.get('.login a').click();
+    cy.location('pathname').should('eq', '/login');
 
-  //   // log in with new password
-  //   cy.location('pathname').should('eq', '/login');
-  //   cy.fixture('users/zkMember.json').as('zkMember')
-  //     .then((zkMember) => {
-  //       cy.get('#login-login').type(zkMember.email);
-  //       cy.get('#login-password').type(zkMember.password.toUpperCase());
-  //       cy.get('button[type="submit"]').click();
-  //     });
+    // log in with new password
+    cy.fixture('users/zkMember.json').as('zkMember')
+      .then((zkMember) => {
+        cy.get('#login-login').type(zkMember.email);
+        cy.get('#login-password').type(zkMember.password.toUpperCase());
+        cy.get('button[type="submit"]').click();
+        cy.wait(1000);
+      });
+    cy.location('pathname').should('eq', '/map/products');
 
-  //   // Reset password to default
-  //   cy.location('pathname').should('eq', '/map/products');
-  //   cy.get('#user-login-button').should('be.visible').click();
-  //   cy.get('a').should('be.visible').contains('Ustawienia').click();
+    // Reset password to default
+    cy.get('#user-login-button').should('be.visible').click();
+    cy.get('a').should('be.visible').contains('Ustawienia').click();
+    cy.location('pathname').should('eq', '/settings/profile');
 
-  //   cy.visit('/settings/profile');
-  //   cy.fixture('users/zkMember.json').as('zkMember')
-  //     .then((zkMember) => {
-  //       cy.get('#old-password').type(zkMember.password.toUpperCase());
-  //       cy.get('#new-password').type(zkMember.password);
-  //       cy.get('button[type="submit"]').click();
-  //     });
-  // });
+    cy.fixture('users/zkMember.json').as('zkMember')
+      .then((zkMember) => {
+        cy.get('#old-password').type(zkMember.password.toUpperCase());
+        cy.get('#new-password').type(zkMember.password);
+        cy.get('button[type="submit"]').click();
+      });
+  });
 });

--- a/s4e-web/projects/notifications/src/lib/state/notification.store.ts
+++ b/s4e-web/projects/notifications/src/lib/state/notification.store.ts
@@ -5,6 +5,8 @@ import {Notification, NotificationState} from './notification.model';
 @Injectable({ providedIn: 'root' })
 @StoreConfig({ name: 'Notification' })
 export class NotificationStore extends EntityStore<NotificationState, Notification> {
-  constructor() { super(); }
+  constructor() {
+    super();
+  }
 }
 

--- a/s4e-web/src/app/app.module.ts
+++ b/s4e-web/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { LogoutModule } from './views/logout/logout.module';
 import {APP_INITIALIZER, LOCALE_ID, NgModule} from '@angular/core';
 import {HTTP_INTERCEPTORS} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
@@ -44,10 +45,11 @@ export function initializeApp(configService: S4eConfig): () => Promise<any> {
     RouterModule.forRoot(appRoutes, {enableTracing: false }),
     ...ShareModule.modulesForRoot(),
     LoginModule,
+    LogoutModule,
     RegisterModule,
     ActivateModule,
     ResetPasswordModule,
-    CommonStateModule.forRoot(),
+    CommonStateModule,
     MapModule,
     ProfileModule,
     InjectorModule,

--- a/s4e-web/src/app/app.routes.ts
+++ b/s4e-web/src/app/app.routes.ts
@@ -1,8 +1,9 @@
+import { LogoutComponent } from './views/logout/logout.component';
 import {Routes} from '@angular/router';
 import {LoginComponent} from './views/login/login.component';
 import {ResetPasswordComponent} from './views/reset-password/reset-password.component';
 import {RegisterComponent} from './views/register/register.component';
-import {IsNotLoggedIn} from './utils/auth-guard/auth-guard.service';
+import {IsNotLoggedIn, IsLoggedIn} from './utils/auth-guard/auth-guard.service';
 import {ActivateComponent} from './views/activate/activate.component';
 import {activateMatcher} from './utils';
 
@@ -11,6 +12,10 @@ export const appRoutes: Routes = [
     path: 'login',
     component: LoginComponent,
     canActivate: [IsNotLoggedIn]
+  }, {
+    path: 'logout',
+    component: LogoutComponent,
+    canActivate: [IsLoggedIn]
   }, {
     path: 'register',
     component: RegisterComponent,

--- a/s4e-web/src/app/state/common-state.module.ts
+++ b/s4e-web/src/app/state/common-state.module.ts
@@ -7,16 +7,10 @@ import {SessionService} from './session/session.service';
   declarations: [],
   imports: [
     CommonModule
+  ],
+  providers: [
+    SessionQuery,
+    SessionService,
   ]
 })
-export class CommonStateModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CommonStateModule,
-      providers: [
-        SessionQuery,
-        SessionService,
-      ]
-    };
-  }
-}
+export class CommonStateModule {}

--- a/s4e-web/src/app/state/session/session.service.ts
+++ b/s4e-web/src/app/state/session/session.service.ts
@@ -1,9 +1,11 @@
+import { NotificationService } from 'notifications';
+import { SessionQuery } from './session.query';
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {SessionStore} from './session.store';
 import {finalize, switchMap, tap} from 'rxjs/operators';
 import {Router} from '@angular/router';
-import {action, resetStores} from '@datorama/akita';
+import {action, resetStores, akitaConfig, persistState} from '@datorama/akita';
 import {LoginRequestResponse} from './session.model';
 import {S4eConfig} from '../../utils/initializer/config.service';
 import {ProfileService} from '../profile/profile.service';
@@ -12,10 +14,12 @@ import {ProfileService} from '../profile/profile.service';
 export class SessionService {
 
   constructor(private sessionStore: SessionStore,
+              private sessionQuery: SessionQuery,
               private http: HttpClient,
               private router: Router,
               private profileService: ProfileService,
-              private CONFIG: S4eConfig) {
+              private CONFIG: S4eConfig,
+              private _notificationService: NotificationService) {
   }
 
   init() {
@@ -60,8 +64,12 @@ export class SessionService {
 
   @action('logout')
   logout() {
-    this.setToken(null, null);
-    resetStores();
-    this.router.navigate(['/login']);
+    if (this.sessionQuery.isLoggedIn()) {
+      this.setToken(null, null);
+      resetStores({
+        exclude: ['Notification']
+      });
+      this.router.navigateByUrl('login');
+    }
   }
 }

--- a/s4e-web/src/app/views/login/login.component.html
+++ b/s4e-web/src/app/views/login/login.component.html
@@ -48,13 +48,13 @@
             <input class="form-control" formControlName="password" id="login-password" type="password">
             <ul s4e-form-error [control]="form.controls.password"></ul>
           </li>
-          <li class="form__element form__checkbox">
+          <!-- <li class="form__element form__checkbox">
             <input type="checkbox" class="form-check-input" id="login-remember-me">
             <label class="form-check-label" for="login-remember-me" i18n>
               <span class="ui"></span>
               Zapamiętaj mnie
             </label>
-          </li>
+          </li> -->
           <li class="form__element">
             <button class="button button--primary" type="submit" [disabled]="form.invalid">
               <fa-icon [hidden]="!(loading$ | async)" [icon]="['fas', 'circle-notch']" [spin]="true"></fa-icon>

--- a/s4e-web/src/app/views/logout/logout.component.spec.ts
+++ b/s4e-web/src/app/views/logout/logout.component.spec.ts
@@ -1,0 +1,43 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { SessionService } from './../../state/session/session.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { LogoutModule } from './logout.module';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LogoutComponent } from './logout.component';
+import { TestingConfigProvider } from 'src/app/app.configuration.spec';
+
+describe('LogoutComponent', () => {
+  let component: LogoutComponent;
+  let fixture: ComponentFixture<LogoutComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        LogoutModule,
+        RouterTestingModule,
+        HttpClientTestingModule
+      ],
+      providers: [TestingConfigProvider]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LogoutComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('Should logout and run notification', () => {
+    const sessionService = TestBed.get(SessionService);
+    const spySession = spyOn(sessionService, 'logout');
+
+    fixture.detectChanges();
+
+    expect(spySession).toHaveBeenCalled();
+  });
+});

--- a/s4e-web/src/app/views/logout/logout.component.ts
+++ b/s4e-web/src/app/views/logout/logout.component.ts
@@ -1,0 +1,14 @@
+import { SessionService } from './../../state/session/session.service';
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  template: ''
+})
+export class LogoutComponent implements OnInit {
+
+  constructor(private _sessionService: SessionService) {}
+
+  ngOnInit() {
+    this._sessionService.logout();
+  }
+}

--- a/s4e-web/src/app/views/logout/logout.module.ts
+++ b/s4e-web/src/app/views/logout/logout.module.ts
@@ -1,0 +1,15 @@
+import { CommonStateModule } from './../../state/common-state.module';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LogoutComponent } from './logout.component';
+import { SessionService } from 'src/app/state/session/session.service';
+
+@NgModule({
+  declarations: [LogoutComponent],
+  imports: [
+    CommonModule,
+    CommonStateModule
+  ],
+  exports: [LogoutComponent]
+})
+export class LogoutModule { }

--- a/s4e-web/src/app/views/map-view/map-view.component.html
+++ b/s4e-web/src/app/views/map-view/map-view.component.html
@@ -57,7 +57,7 @@
           <a routerLink="/settings" i18n>Ustawienia</a>
         </li>
         <li>
-          <a href="javascript:undefined" (click)="logout()" i18n>Wyloguj</a>
+          <a routerLink="/logout" i18n>Wyloguj</a>
         </li>
       </ng-template>
     </ul>

--- a/s4e-web/src/app/views/map-view/map-view.component.ts
+++ b/s4e-web/src/app/views/map-view/map-view.component.ts
@@ -125,11 +125,6 @@ export class MapViewComponent implements OnInit, OnDestroy {
     this.sceneService.setActive(sceneId);
   }
 
-
-  logout() {
-    this.sessionService.logout();
-  }
-
   toggleLegend() {
     this.legendService.toggleLegend();
   }

--- a/s4e-web/src/app/views/settings/settings.component.html
+++ b/s4e-web/src/app/views/settings/settings.component.html
@@ -13,7 +13,7 @@
           <button [routerLink]="['/']" i18n class="button button--borderPrimary button--small">Wróć do mapy</button>
         </li>
         <li>
-          <a href="javascript:undefined" (click)="logout()" i18n>Wyloguj</a>
+          <a href="javascript:undefined" routerLink="/logout" i18n>Wyloguj</a>
         </li>
       </ul>
     </section>

--- a/s4e-web/src/app/views/settings/settings.component.ts
+++ b/s4e-web/src/app/views/settings/settings.component.ts
@@ -16,8 +16,4 @@ export class SettingsComponent implements OnInit {
   ngOnInit() {
     this.showInstitutions$ = this.profileQuery.selectCanSeeInstitutions();
   }
-
-  logout() {
-    this.sessionService.logout();
-  }
 }


### PR DESCRIPTION
- logout can be done by navigating to link `/logout`
- when log out button clicked, a user should be navigated to `/login` page
- Storage error (after login, logout, login and moving to `/settings/profile`) have been repaired 