### PR TITLE
[#439] Add s4e-sync-1 dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Synchronize scenes from S3 (s4-sync-1 dataset) [#439](https://github.com/cyfronet-fid/sat4envi/issues/439)
 - Audit selected entities [#158](https://github.com/cyfronet-fid/sat4envi/issues/158)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -119,14 +119,21 @@ the products seeding by setting the profile `skip-seed-products`.)
 Like in the case of the base dataset, the data is stored in the Cyfronet CEPH in bucket `s4e-demo-2`.
 You have to observe the steps for `s4e-demo` with updated dataset and bucket names.
 
+`s4e-sync-1` is the first dataset which scenes are loaded based on their scene files.
+It consists of 6 products: OST, Setvak_Eu, Setvak_PL, Sentinel-1-GRDH, Sentinel-1-GRDM and Sentinel-1-SLC_.
+See the separate section for info on loading it.
+
+
 #### Seeding with s4e-demo data
 
-The first thing is to obtain production CEPH credentials, they are for example [here](https://docs.cyfronet.pl/display/FID/Projekty).
+The first thing is to obtain production CEPH credentials, they are for example
+[here](https://docs.cyfronet.pl/display/FID/Projekty).
+(Use `storage.cloud...` endpoint for `s4e-demo` and `s3.cloud...` for `s4e-sync`.)
 Once you have them, point your GeoServer instance to the Cyfronet CEPH by setting the following evvars in `.env`:
 ```
-GEOSERVER_S3_ENDPOINT=http://minio:9000/
-GEOSERVER_S3_ACCESS_KEY=minio
-GEOSERVER_S3_SECRET_KEY=minio123
+GEOSERVER_S3_ENDPOINT=<endpoint>
+GEOSERVER_S3_ACCESS_KEY=<access key>
+GEOSERVER_S3_SECRET_KEY=<secret key>
 ```
 
 The `.env` file is ignored in `.gitignore`, **UNDER NO CIRCUMSTANCES DO NOT COMMIT, NOR PUSH THIS FILE TO THE REPO!!!**
@@ -136,13 +143,13 @@ If you run with docker, package the application with `./mvnw package -DskipTests
 If you had already created a GeoServer container you may need to recreate it: `docker-compose down`, to remove
 the container.
 This will also erase other containers from the project.
-Then, run required docker-compose services with `docker-compose up -d db minio geoserver`.
+Then, run required docker-compose services with `docker-compose up -d db geoserver`.
 
 Then, run the backend with properties:
 ```
 spring.profiles.active=development
-seed.products.data-set=s4e-demo
-s3.bucket=s4e-demo
+seed.products.data-set=<dataset>
+s3.bucket=<dataset>
 s3.access-key=<access_key>
 s3.secret-key=<secret_key>
 s3.endpoint=<path to storage>
@@ -150,8 +157,8 @@ s3.endpoint=<path to storage>
 If you run with docker, update the `backend-development.env` (or another env file you have wired up to `s4e-backend`
 service in `docker-compose.yml`) by appending:
 ```
-SEED_PRODUCTS_DATASET=s4e-demo
-S3_BUCKET=s4e-demo
+SEED_PRODUCTS_DATASET=<dataset>
+S3_BUCKET=<dataset>
 S3_ACCESSKEY=<access_key>
 S3_SECRETKEY=<secret_key>
 S3_ENDPOINT=<path to storage>
@@ -159,7 +166,11 @@ S3_ENDPOINT=<path to storage>
 
 The backend will seed db and GeoServer.
 It is normal that there are some errors in the backend's logs as there are gaps in the available data.
-However, the beginning of the data is quite clean, so you should see progress info when the seeder starts.
+However, the beginning of the `s4e-demo` data is quite clean, so you should see progress info when the seeder starts.
+
+If you're seeding `s4e-sync-1` there can also be some errors in the logs, however, most likely it is fine.
+Nevertheless, if you see S3ClientExceptions, or too many keys not found errors, you may need to evaluate if you have
+correct credentials.
 
 If you want to skip seeding db and GeoServer with products on subsequent runs add profile `skip-seed-products`,
 either by adding property:
@@ -170,6 +181,10 @@ or by setting envvar (in `backend-development.env`, not `.env`):
 ```
 SPRING_PROFILES_ACTIVE=development,skip-seed-products
 ```
+
+To control the number of scenes seeded per product for `s4e-sync-1` dataset use property
+`seed.products.s4e-sync-v1.limit`, by default the seeder loads only 100 scenes of each product.
+To load an unlimited number set its value to -1.
 
 
 #### Custom docker-compose local configurations

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SchemaScanner.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SchemaScanner.java
@@ -1,0 +1,56 @@
+package pl.cyfronet.s4e.db.seed;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+import pl.cyfronet.s4e.bean.Schema;
+import pl.cyfronet.s4e.util.ResourceReader;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+class SchemaScanner {
+    private final ResourceLoader resourceLoader;
+
+    public List<Schema> scan(String path) throws IOException {
+        log.trace(String.format("Scanning: '%s'", path));
+        Resource resource = resourceLoader.getResource(path);
+        File file = resource.getFile();
+        List<Schema> schemas = new ArrayList<>();
+        if (file.isDirectory()) {
+            for (String child : file.list()) {
+                schemas.addAll(scan(path + "/" + child));
+            }
+        } else {
+            String content = ResourceReader.asString(resource);
+            schemas.add(loadSchema(content));
+        }
+        return schemas;
+    }
+
+    private Schema loadSchema(String content) {
+        JsonObject jsonObject;
+        try (JsonReader reader = Json.createReader(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))) {
+            jsonObject = reader.readObject();
+        }
+        String name = jsonObject.getString("id");
+        Schema.Type type = name.contains("scene") ? Schema.Type.SCENE : Schema.Type.METADATA;
+        return Schema.builder()
+                .name(name)
+                .content(content)
+                .type(type)
+                .build();
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperations.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperations.java
@@ -17,6 +17,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import pl.cyfronet.s4e.util.ResourceReader;
 import pl.cyfronet.s4e.geoserver.op.request.CreateS3CoverageRequest;
 import pl.cyfronet.s4e.geoserver.op.request.CreateStyleRequest;
 import pl.cyfronet.s4e.geoserver.op.request.CreateWorkspaceRequest;
@@ -26,11 +27,9 @@ import pl.cyfronet.s4e.properties.GeoServerProperties;
 
 import java.io.*;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -284,9 +283,8 @@ public class GeoServerOperations {
 
 
     private String loadSldFile(String path) {
-        try (InputStream inputStream = resourceLoader.getResource(path).getInputStream()) {
-            return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
-                    .lines().collect(Collectors.joining("\n"));
+        try {
+            return ResourceReader.asString(resourceLoader.getResource(path));
         } catch (FileNotFoundException e) {
             throw new IllegalStateException(e);
         } catch (IOException e) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/SeedProperties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/SeedProperties.java
@@ -3,6 +3,7 @@ package pl.cyfronet.s4e.properties;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties("seed.products")
@@ -14,4 +15,13 @@ public class SeedProperties {
     private boolean syncGeoserver = true;
     private boolean syncGeoserverResetWorkspace = true;
     private String dataSet = "minio-data-v1";
+    @NestedConfigurationProperty
+    private S4eSyncV1 s4eSyncV1 = new S4eSyncV1();
+
+    @Getter
+    @Setter
+    public static class S4eSyncV1 {
+        /// Set to -1 to disable the limit.
+        private int limit = 100;
+    }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/PrefixScanner.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/PrefixScanner.java
@@ -1,0 +1,29 @@
+package pl.cyfronet.s4e.sync;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.stereotype.Component;
+import pl.cyfronet.s4e.properties.S3Properties;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
+
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+@Component
+public class PrefixScanner {
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
+
+    public Stream<S3Object> scan(String prefix) {
+        String bucket =  s3Properties.getBucket();
+        val request = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(prefix)
+                .build();
+        ListObjectsV2Iterable objectsIterable = s3Client.listObjectsV2Paginator(request);
+        return objectsIterable.contents().stream();
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExist.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExist.java
@@ -45,14 +45,15 @@ public class VerifyAllArtifactsExist<T extends BaseContext> implements Step<T, E
                 return error.code(ERR_ARTIFACT_PATH_INCORRECT)
                         .parameter("artifact_" + name, path).build();
             }
-            artifacts.put(name, path);
+            String artifactKey = pathToKey(path);
+            artifacts.put(name, artifactKey);
             try {
-                if (!sceneStorage.exists(path)) {
-                    notFound.put(name, path);
+                if (!sceneStorage.exists(artifactKey)) {
+                    notFound.put(name, artifactKey);
                 }
             } catch (S3ClientException e) {
-                return error.code(ERR_S3_CLIENT_EXCEPTION)
-                        .parameter("artifact_" + name, path).build();
+                return error.code(ERR_S3_CLIENT_EXCEPTION).cause(e)
+                        .parameter("artifact_" + name, artifactKey).build();
             }
         }
         if (!notFound.isEmpty()) {
@@ -67,5 +68,9 @@ public class VerifyAllArtifactsExist<T extends BaseContext> implements Step<T, E
 
     private boolean isPathCorrect(String path) {
         return path.startsWith("/");
+    }
+
+    private String pathToKey(String path) {
+        return path.substring(1);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/metadata/IngestS3Path.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/metadata/IngestS3Path.java
@@ -32,7 +32,7 @@ public class IngestS3Path<T extends BaseContext> implements Step<T, Error> {
         String artifactKey = getArtifactKey(format, granuleArtifactRule);
         String path = artifacts.get(artifactKey);
 
-        update.accept(context, convertToS3Path(path));
+        update.accept(context, path);
 
         return null;
     }
@@ -43,10 +43,5 @@ public class IngestS3Path<T extends BaseContext> implements Step<T, Error> {
             return key;
         }
         return granuleArtifactRule.get(METADATA_FORMAT_DEFAULT);
-    }
-
-    private String convertToS3Path(String path) {
-        // Skip leading slash, as product.s3_path assumes no leading slash.
-        return path.substring(1);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/util/ResourceReader.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/util/ResourceReader.java
@@ -1,0 +1,18 @@
+package pl.cyfronet.s4e.util;
+
+import org.springframework.core.io.Resource;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class ResourceReader {
+    private ResourceReader() { }
+
+    public static String asString(Resource resource) throws IOException {
+        try (InputStream inputStream = resource.getInputStream()) {
+            return StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/s4e-backend/src/main/resources/db/migration/V34__drop_scene_product_id_timestamp_key_unique.sql
+++ b/s4e-backend/src/main/resources/db/migration/V34__drop_scene_product_id_timestamp_key_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scene
+    DROP CONSTRAINT scene_product_id_timestamp_key;

--- a/s4e-backend/src/main/resources/schema/s4e-sync-1/MSG.metadata.v1.json
+++ b/s4e-backend/src/main/resources/schema/s4e-sync-1/MSG.metadata.v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "MSG.metadata.v1.json",
+  "title": "MSG_Products.metadata.v1",
+  "description": "Schema for MSG products metadata",
+  "required": [
+    "spacecraft",
+    "product_type",
+    "sensor_mode",
+    "processing_level",
+    "sensing_time",
+    "polygon",
+    "format",
+    "schema"
+  ],
+  "type": "object",
+  "properties": {
+    "spacecraft": {
+      "type": "string"
+    },
+    "product_type": {
+      "type": "string",
+      "pattern": "^[-_a-zA-Z0-9]+$"
+    },
+    "sensor_mode": {
+      "type": "string"
+    },
+    "processing_level": {
+      "type": "string"
+    },
+    "sensing_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "polygon": {
+      "type": "string",
+      "pattern": "^(-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?)( -?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?)+$"
+    },
+    "format": {
+      "type": "string"
+    },
+    "schema": {
+      "type": "string"
+    }
+  }
+}

--- a/s4e-backend/src/main/resources/schema/s4e-sync-1/MSG.scene.v1.json
+++ b/s4e-backend/src/main/resources/schema/s4e-sync-1/MSG.scene.v1.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "MSG.scene.v1.json",
+  "title": "MSG_Products.scene.v1",
+  "description": "Schema for MSG Products",
+  "required": [
+    "product_type",
+    "artifacts",
+    "schema"
+  ],
+  "type": "object",
+  "properties": {
+    "product_type": {
+      "type": "string",
+      "pattern": "^[-_a-zA-Z0-9]+$"
+    },
+    "artifacts": {
+      "type": "object",
+      "required": [
+        "metadata",
+        "product_file",
+	"original_file"
+        ],
+      "properties": {
+        "metadata": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.metadata$"
+        },
+        "product_file": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.tif$"
+        },
+        "original_file": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+$"
+        },
+        "source_raw_data": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.zip$"
+        }
+      }
+    },
+    "schema": {
+      "type": "string"
+    }
+  }
+}

--- a/s4e-backend/src/main/resources/schema/s4e-sync-1/Sentinel-1.metadata.v1.json
+++ b/s4e-backend/src/main/resources/schema/s4e-sync-1/Sentinel-1.metadata.v1.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "Sentinel-1.metadata.v1.json",
+  "title": "Sentinel-1.metadata.v1",
+  "description": "First schema for Sentinel-1 metadata",
+  "required": [
+    "spacecraft",
+    "product_type",
+    "sensor_mode",
+    "processing_level",
+    "polarisation",
+    "sensing_time",
+    "ingestion_time",
+    "relative_orbit_number",
+    "polygon",
+    "format",
+    "schema"
+  ],
+  "type": "object",
+  "properties": {
+    "spacecraft": {
+      "type": "string"
+    },
+    "product_type": {
+      "type": "string",
+      "pattern": "^[-_a-zA-Z0-9]+$"
+    },
+    "sensor_mode": {
+      "type": "string"
+    },
+    "processing_level": {
+      "type": "string"
+    },
+    "polarisation": {
+      "type": "string"
+    },
+    "sensing_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "ingestion_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "relative_orbit_number": {
+      "type": "string"
+    },
+    "polygon": {
+      "type": "string",
+      "pattern": "^(-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?)( -?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?)+$"
+    },
+    "format": {
+      "type": "string"
+    },
+    "schema": {
+      "type": "string"
+    }
+  }
+}

--- a/s4e-backend/src/main/resources/schema/s4e-sync-1/Sentinel-1.scene.v1.json
+++ b/s4e-backend/src/main/resources/schema/s4e-sync-1/Sentinel-1.scene.v1.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "Sentinel-1.scene.v1.json",
+  "title": "Sentinel-1.scene.v1",
+  "description": "First schema for Sentinel-1",
+  "required": [
+    "product_type",
+    "artifacts",
+    "schema"
+  ],
+  "type": "object",
+  "properties": {
+    "product_type": {
+      "type": "string",
+      "pattern": "^[-_a-zA-Z0-9]+$"
+    },
+    "artifacts": {
+      "type": "object",
+      "required": [
+        "metadata",
+        "manifest",
+        "product_archive",
+        "checksum"
+      ],
+      "properties": {
+        "metadata": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.metadata$"
+        },
+        "manifest": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.manifest\\.xml$"
+        },
+        "product_archive": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.zip$"
+        },
+        "checksum": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.md5$"
+        },
+        "quicklook": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.tif$"
+        },
+        "RGB_16b": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.tif$"
+        },
+        "RGBs_8b": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.tif$"
+        }
+      }
+    },
+    "schema": {
+      "type": "string"
+    }
+  }
+}

--- a/s4e-backend/src/main/resources/schema/s4e-sync-1/Sentinel-2.metadata.v1.json
+++ b/s4e-backend/src/main/resources/schema/s4e-sync-1/Sentinel-2.metadata.v1.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "Sentinel-2.metadata.v1.json",
+  "title": "Sentinel-2.metadata.v1",
+  "description": "First schema for Sentinel-2 metadata",
+  "required": [
+    "spacecraft",
+    "processing_level",
+    "sensing_time",
+    "ingestion_time",
+    "relative_orbit_number",
+    "tile",
+    "polygon",
+    "cloud_cover",
+    "schema"
+  ],
+  "type": "object",
+  "properties": {
+    "spacecraft": {
+      "type": "string"
+    },
+    "processing_level": {
+      "type": "string"
+    },
+    "sensing_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "ingestion_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "relative_orbit_number": {
+      "type": "string"
+    },
+    "tile": {
+      "type": "string"
+    },
+    "polygon": {
+      "type": "string",
+      "pattern": "^(-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?)( -?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?)+$"
+    },
+    "cloud_cover": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "format": {
+      "type": "string"
+    },
+    "schema": {
+      "type": "string"
+    }
+  }
+}

--- a/s4e-backend/src/main/resources/schema/s4e-sync-1/Sentinel-2.scene.v1.json
+++ b/s4e-backend/src/main/resources/schema/s4e-sync-1/Sentinel-2.scene.v1.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "Sentinel-2.scene.v1.json",
+  "title": "Sentinel-2.scene.v1",
+  "description": "First schema for Sentinel-2",
+  "required": [
+    "product_type",
+    "artifacts",
+    "schema"
+  ],
+  "type": "object",
+  "properties": {
+    "product_type": {
+      "type": "string",
+      "pattern": "^[-_a-zA-Z0-9]+$"
+    },
+    "artifacts": {
+      "type": "object",
+      "required": [
+        "metadata",
+        "product_archive",
+        "checksum"
+      ],
+      "properties": {
+        "metadata": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.metadata$"
+        },
+        "manifest": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.manifest\\.xml$"
+        },
+        "product_archive": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.zip$"
+        },
+        "checksum": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.md5$"
+        },
+        "quicklook": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.tif$"
+        },
+        "RGB_16b": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.tif$"
+        },
+        "RGBs_8b": {
+          "type": "string",
+          "pattern": "^(/[^/]+)+\\.tif$"
+        }
+      }
+    },
+    "schema": {
+      "type": "string"
+    }
+  }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/PrefixScannerIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/PrefixScannerIntegrationTest.java
@@ -1,0 +1,42 @@
+package pl.cyfronet.s4e.sync;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import pl.cyfronet.s4e.IntegrationTest;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Note that in these tests we pass it a path prefixed with slash.
+ * This is ok, most likely because of the minio implementation of the AWS S3, which is also different
+ * than CEPH.
+ * See e.g. https://github.com/minio/minio/issues/7717.
+ */
+@IntegrationTest
+class PrefixScannerIntegrationTest {
+    @Autowired
+    private PrefixScanner prefixScanner;
+
+    @Test
+    public void shouldWork() {
+        Stream<S3Object> scan = prefixScanner.scan("/");
+
+        assertThat(scan.count(), is(equalTo(288L)));
+    }
+
+    @Test
+    public void shouldLimitResultsToPrefix() {
+        Stream<S3Object> scan = prefixScanner.scan("/201810040000_");
+
+        assertThat(scan.map(S3Object::key).collect(Collectors.toList()), containsInAnyOrder(
+                "/201810040000_Merkator_Europa_ir_108_setvak.tif",
+                "/201810040000_Merkator_Europa_ir_108m.tif",
+                "/201810040000_Merkator_WV-IR.tif"
+        ));
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorIntegrationTest.java
@@ -76,7 +76,7 @@ class SceneAcceptorIntegrationTest {
 
         assertThat(sceneRepository.count(), is(equalTo(0L)));
 
-        String sceneKey = "/Sentinel-1/GRDH/2020-02-28/S1A_IW_GRDH_1SDV_20200228T045117_20200228T045142_031448_039EDF_82C8.scene";
+        String sceneKey = "Sentinel-1/GRDH/2020-02-28/S1A_IW_GRDH_1SDV_20200228T045117_20200228T045142_031448_039EDF_82C8.scene";
         sceneAcceptor.accept(sceneKey);
 
         assertThat(sceneRepository.count(), is(equalTo(1L)));

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExistTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExistTest.java
@@ -55,13 +55,13 @@ class VerifyAllArtifactsExistTest extends BaseStepTest<BaseContext> {
         when(artifactsJsonObject.entrySet()).thenReturn(artifacts.entrySet());
         when(sceneJson.getJsonObject(SCENE_ARTIFACTS_PROPERTY)).thenReturn(artifactsJsonObject);
 
-        when(sceneStorage.exists("/path_1")).thenReturn(true);
-        when(sceneStorage.exists("/path_2")).thenReturn(true);
+        when(sceneStorage.exists("path_1")).thenReturn(true);
+        when(sceneStorage.exists("path_2")).thenReturn(true);
 
         Error error = step.apply(context);
 
         assertThat(error, is(nullValue()));
-        verify(update).accept(eq(context), eq(Map.of("key_1", "/path_1", "key_2", "/path_2")));
+        verify(update).accept(eq(context), eq(Map.of("key_1", "path_1", "key_2", "path_2")));
         verifyNoMoreInteractions(update);
     }
 
@@ -94,17 +94,17 @@ class VerifyAllArtifactsExistTest extends BaseStepTest<BaseContext> {
         when(artifactsJsonObject.entrySet()).thenReturn(artifacts.entrySet());
         when(sceneJson.getJsonObject(SCENE_ARTIFACTS_PROPERTY)).thenReturn(artifactsJsonObject);
 
-        when(sceneStorage.exists("/path_1")).thenReturn(false);
-        when(sceneStorage.exists("/path_2")).thenReturn(true);
-        when(sceneStorage.exists("/path_3")).thenReturn(false);
+        when(sceneStorage.exists("path_1")).thenReturn(false);
+        when(sceneStorage.exists("path_2")).thenReturn(true);
+        when(sceneStorage.exists("path_3")).thenReturn(false);
 
         Error error = step.apply(context);
 
         assertThat(error, is(notNullValue()));
         assertThat(error.getCode(), is(equalTo(ERR_ARTIFACTS_NOT_FOUND)));
         assertThat(error.getParameters(), allOf(
-                hasEntry("artifact_key_1", "/path_1"),
-                hasEntry("artifact_key_3", "/path_3")
+                hasEntry("artifact_key_1", "path_1"),
+                hasEntry("artifact_key_3", "path_3")
         ));
         verifyNoMoreInteractions(update);
     }
@@ -118,14 +118,14 @@ class VerifyAllArtifactsExistTest extends BaseStepTest<BaseContext> {
         when(artifactsJsonObject.entrySet()).thenReturn(artifacts.entrySet());
         when(sceneJson.getJsonObject(SCENE_ARTIFACTS_PROPERTY)).thenReturn(artifactsJsonObject);
 
-        when(sceneStorage.exists("/path_1")).thenThrow(S3ClientException.class);
+        when(sceneStorage.exists("path_1")).thenThrow(S3ClientException.class);
 
         Error error = step.apply(context);
 
         assertThat(error, is(notNullValue()));
         assertThat(error.getCode(), is(equalTo(ERR_S3_CLIENT_EXCEPTION)));
         assertThat(error.getParameters(), allOf(
-                hasEntry("artifact_key_1", "/path_1")
+                hasEntry("artifact_key_1", "path_1")
         ));
         verifyNoMoreInteractions(update);
     }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/metadata/IngestS3PathTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/metadata/IngestS3PathTest.java
@@ -49,7 +49,7 @@ class IngestS3PathTest extends BaseStepTest<BaseContext> {
     public void shouldWork() {
         when(metadataJson.getString(eq(METADATA_FORMAT_PROPERTY), any(String.class)))
                 .thenReturn("GeoTiff");
-        artifacts.put("key_1", "/some/path");
+        artifacts.put("key_1", "some/path");
         when(product.getGranuleArtifactRule()).thenReturn(Map.of("GeoTiff", "key_1"));
 
         Error error = step.apply(context);
@@ -63,7 +63,7 @@ class IngestS3PathTest extends BaseStepTest<BaseContext> {
     public void shouldUseDefault() {
         when(metadataJson.getString(eq(METADATA_FORMAT_PROPERTY), any(String.class)))
                 .thenReturn("GeoTiff");
-        artifacts.put("key_1", "/some/path");
+        artifacts.put("key_1", "some/path");
         when(product.getGranuleArtifactRule()).thenReturn(Map.of("default", "key_1"));
 
         Error error = step.apply(context);


### PR DESCRIPTION
The PR contains some refactoring prior to introducing the actual functionality.
The synchronization itself is a thin layer using PrefixScanner and SceneAcceptor and is not extracted to a separate class for now.

There is no endpoint for running this sort of synchronization. It should come with other endpoints for managing Schemas and Products, I guess.

#### New dataset implementation

Load the schemas from resources and create products which base on them in SeedProducts.
Then, PrefixScanner is used to enumerate all the keys under each product prefix.

The number of loaded scenes per product is controlled by an extra property: `seed.products.s4e-sync-1.limit`.

#### Correct S3 key handling and prevent connection leak

Keys must come without a leading slash, although we require the leading
slash in scene file to allow for relative path handling.

Execute a HeadObjectRequest in SceneStorage::exists, the opened
connection wasn't cleared and exhausted the AWS SDK connection pool.

#### Drop unique constraint on Scene.product_id and .timestamp

The constraint will not be met for Sentinel Scenes. However, it opens up the case for scene identification when updating, as these two columns are no longer unique.
A natural candidate seems to be the scene file key, I would hear some other opinions on this though.

Closes: #439.