### PR TITLE
[#467] Update springdoc-openapi to 1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Updated
 
+- Update springdoc-openapi to 1.3.9 and add a test openapi endpoint works [#467](https://github.com/cyfronet-fid/sat4envi/issues/467)
+
 ## [v7.0.0]
 
 ### Added

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -25,7 +25,7 @@
         <poiooxml.version>4.1.2</poiooxml.version>
         <greenmail.version>1.5.13</greenmail.version>
         <slugify.version>2.4</slugify.version>
-        <springdoc-openapi.version>1.3.7</springdoc-openapi.version>
+        <springdoc-openapi.version>1.3.9</springdoc-openapi.version>
         <awssdk.version>2.13.8</awssdk.version>
         <commons-email.version>1.5</commons-email.version>
         <geotools.version>23.0</geotools.version>

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SwaggerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SwaggerTest.java
@@ -1,0 +1,22 @@
+package pl.cyfronet.s4e;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@BasicTest
+@AutoConfigureMockMvc
+public class SwaggerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void test() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
Moreover, add a test which verifies, that OpenAPI is returning 200.

Fixes: #467.