### PR TITLE
Handle Scene updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Changed
 
+- Handle Scene updates in ScenePersister [#469](https://github.com/cyfronet-fid/sat4envi/issues/469)
 - New sidebar look [#454](https://github.com/cyfronet-fid/sat4envi/issues/454)
 - Improve institutions endpoint to work for any signed in user [#457](https://github.com/cyfronet-fid/sat4envi/issues/457)
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Scene.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Scene.java
@@ -29,6 +29,10 @@ public class Scene extends CreationAndModificationAudited {
     @ManyToOne(optional = false)
     private Product product;
 
+    /// E.g. "path/to/granule.tiff", excluding endpoint and bucket information
+    @NotEmpty
+    private String sceneKey;
+
     @NotNull
     private LocalDateTime timestamp;
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/WMSOverlay.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/WMSOverlay.java
@@ -5,13 +5,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
 
 @Entity
+@Table(name = "wms_overlay")
 @Data
 @Builder
 @NoArgsConstructor

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/PRGOverlayRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/PRGOverlayRepository.java
@@ -9,5 +9,7 @@ import java.util.List;
 
 @Transactional(readOnly = true)
 public interface PRGOverlayRepository extends CrudRepository<PRGOverlay, Long> {
+    List<PRGOverlay> findAll();
+
     List<PRGOverlayResponse> findAllByCreatedTrue();
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
@@ -12,10 +12,12 @@ import java.util.Optional;
 public interface SceneRepository extends JpaRepository<Scene, Long>, SceneRepositoryExt {
     <T> Optional<T> findById(Long id, Class<T> projection);
 
-    List<Scene> findByProductId(Long productId);
+    List<Scene> findAllByProductId(Long productId);
+
     List<Scene> findAllByProductIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestampAsc(
             Long productId, LocalDateTime start, LocalDateTime end
     );
+
     int countAllByProductIdAndTimestampGreaterThanEqualAndTimestampLessThan(
             Long productId, LocalDateTime start, LocalDateTime end
     );

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 public interface SceneRepository extends JpaRepository<Scene, Long>, SceneRepositoryExt {
     <T> Optional<T> findById(Long id, Class<T> projection);
 
+    Optional<Scene> findBySceneKey(String sceneKey);
+
     List<Scene> findAllByProductId(Long productId);
 
     List<Scene> findAllByProductIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestampAsc(

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedProducts.java
@@ -52,6 +52,7 @@ public class SeedProducts implements ApplicationRunner {
     private static final DateTimeFormatter DATE_PATTERN = DateTimeFormatter.ofPattern("yyyyMMdd");
     private static final DateTimeFormatter YEAR_PATTERN = DateTimeFormatter.ofPattern("yyyy");
     private static final DateTimeFormatter TIME_PATTERN = DateTimeFormatter.ofPattern("HHmm");
+    private static final String SCENE_KEY_PATTERN = "path/to/%dth.scene";
 
     @Builder
     @Value
@@ -91,6 +92,8 @@ public class SeedProducts implements ApplicationRunner {
     private final PrefixScanner prefixScanner;
     private final SceneAcceptor sceneAcceptor;
     private final SchemaScanner schemaScanner;
+
+    private final AtomicInteger sceneKeyCounter = new AtomicInteger();
 
     @Async
     @Override
@@ -661,6 +664,7 @@ public class SeedProducts implements ApplicationRunner {
 
             val scene = Scene.builder()
                     .product(product)
+                    .sceneKey(nextUniqueSceneKey())
                     .timestamp(timestamp)
                     .s3Path(s3Path)
                     .granulePath(granulePath)
@@ -682,6 +686,10 @@ public class SeedProducts implements ApplicationRunner {
                 log.info((i + 1) + "/" + count + " scenes of product '" + product.getName() + "' processed");
             }
         }
+    }
+
+    private String nextUniqueSceneKey() {
+        return String.format(SCENE_KEY_PATTERN, sceneKeyCounter.getAndIncrement());
     }
 
     private void readScenes(String prefix) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/ScenePersister.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/ScenePersister.java
@@ -38,15 +38,25 @@ public class ScenePersister {
         JsonNode sceneJsonNode = convert(prototype.getSceneJson());
         JsonNode metadataJsonNode = convert(prototype.getMetadataJson());
 
-        Scene scene = sceneRepository.save(Scene.builder()
-                .product(product)
-                .timestamp(prototype.getTimestamp())
-                .s3Path(prototype.getS3Path())
-                .granulePath(granulePath)
-                .footprint(prototype.getFootprint())
-                .sceneContent(sceneJsonNode)
-                .metadataContent(metadataJsonNode)
-                .build());
+        Scene scene = sceneRepository.findBySceneKey(prototype.getSceneKey()).orElse(new Scene());
+        if (scene.getProduct() != null && !product.equals(scene.getProduct())) {
+            Long existingProductId = scene.getProduct().getId();
+            Long prototypeProductId = prototype.getProductId();
+            throw new IllegalArgumentException(String.format("Existing Scene's Product %d is not equal to the prototype Product %d", existingProductId, prototypeProductId));
+        } else {
+            scene.setProduct(product);
+        }
+        scene.setSceneKey(prototype.getSceneKey());
+        scene.setTimestamp(prototype.getTimestamp());
+        scene.setS3Path(prototype.getS3Path());
+        scene.setGranulePath(granulePath);
+        scene.setFootprint(prototype.getFootprint());
+        scene.setSceneContent(sceneJsonNode);
+        scene.setMetadataContent(metadataJsonNode);
+
+        if (scene.getId() == null) {
+            scene = sceneRepository.save(scene);
+        }
 
         return scene.getId();
     }

--- a/s4e-backend/src/main/resources/db/migration/V36__add_scene_key_column_to_scene_table.sql
+++ b/s4e-backend/src/main/resources/db/migration/V36__add_scene_key_column_to_scene_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scene
+    ADD COLUMN scene_key VARCHAR UNIQUE NOT NULL;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SceneTestHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SceneTestHelper.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 
 public class SceneTestHelper {
     private static final AtomicInteger COUNT = new AtomicInteger();
+    private static final String SCENE_KEY_PATTERN = "path/to/%dth.scene";
     private static final String PRODUCT_NAME_PATTERN = "Great %d Product";
 
     public static String nextUnique(String format) {
@@ -28,6 +29,7 @@ public class SceneTestHelper {
     public static Scene.SceneBuilder sceneBuilder(Product product) {
         return Scene.builder()
                 .product(product)
+                .sceneKey(nextUnique(SCENE_KEY_PATTERN))
                 .timestamp(LocalDateTime.now())
                 .s3Path("some/path")
                 .granulePath("mailto://bucket/some/path")

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SceneTestHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SceneTestHelper.java
@@ -1,0 +1,40 @@
+package pl.cyfronet.s4e;
+
+import pl.cyfronet.s4e.bean.Product;
+import pl.cyfronet.s4e.bean.Scene;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+public class SceneTestHelper {
+    private static final AtomicInteger COUNT = new AtomicInteger();
+    private static final String PRODUCT_NAME_PATTERN = "Great %d Product";
+
+    public static String nextUnique(String format) {
+        return String.format(format, COUNT.getAndIncrement());
+    }
+
+    public static Product.ProductBuilder productBuilder() {
+        String displayName = nextUnique(PRODUCT_NAME_PATTERN);
+        String name = displayName.replace(" ", "_");
+        return Product.builder()
+                .name(name)
+                .displayName(displayName)
+                .description("sth")
+                .layerName(name.toLowerCase());
+    }
+
+    public static Scene.SceneBuilder sceneBuilder(Product product) {
+        return Scene.builder()
+                .product(product)
+                .timestamp(LocalDateTime.now())
+                .s3Path("some/path")
+                .granulePath("mailto://bucket/some/path")
+                .footprint(TestGeometryHelper.ANY_POLYGON);
+    }
+
+    public static Function<LocalDateTime, Scene> toScene(Product product) {
+        return timestamp -> sceneBuilder(product).timestamp(timestamp).build();
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/TestDbHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/TestDbHelper.java
@@ -12,6 +12,9 @@ public class TestDbHelper {
     private final PlaceRepository placeRepository;
     private final ProductRepository productRepository;
     private final SchemaRepository schemaRepository;
+    private final WMSOverlayRepository wmsOverlayRepository;
+    private final PRGOverlayRepository prgOverlayRepository;
+    private final SldStyleRepository sldStyleRepository;
 
     public void clean() {
         institutionRepository.deleteAll();
@@ -19,5 +22,8 @@ public class TestDbHelper {
         placeRepository.deleteAll();
         productRepository.deleteAll();
         schemaRepository.deleteAll();
+        wmsOverlayRepository.deleteAll();
+        prgOverlayRepository.deleteAll();
+        sldStyleRepository.deleteAll();
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/TestGeometryHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/TestGeometryHelper.java
@@ -12,26 +12,26 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
-import org.springframework.stereotype.Service;
 
-@Service
 @Slf4j
 public class TestGeometryHelper {
-    public Geometry any() {
+    public static final Geometry ANY_POLYGON;
+    static {
         GeometryFactory factory = new GeometryFactory(new PrecisionModel(), 3857);
         WKTReader reader = new WKTReader(factory);
+        Geometry polygon = null;
         try {
             // 108m
             // lat/long
-            Geometry g = reader.read("POLYGON((18.981890089820652 -36.95919177442794,74.10811836891402 -36.95919177442794,74.10811836891402 57.037586807964416,18.981890089820652 57.037586807964416,18.981890089820652 -36.95919177442794))");
-            return transform(g, "EPSG:4326", "EPSG:3857");
+            polygon = reader.read("POLYGON((18.981890089820652 -36.95919177442794,74.10811836891402 -36.95919177442794,74.10811836891402 57.037586807964416,18.981890089820652 57.037586807964416,18.981890089820652 -36.95919177442794))");
+            polygon = transform(polygon, "EPSG:4326", "EPSG:3857");
         } catch (ParseException | FactoryException | TransformException e) {
             log.warn("Unexpected", e);
         }
-        return null;
+        ANY_POLYGON = polygon;
     }
 
-    public Geometry transform(Geometry g, String from, String to) throws FactoryException, TransformException {
+    public static Geometry transform(Geometry g, String from, String to) throws FactoryException, TransformException {
         CoordinateReferenceSystem toCRS = CRS.decode(to);
         CoordinateReferenceSystem fromCRS = CRS.decode(from);
         MathTransform transform = CRS.findMathTransform(fromCRS, toCRS);

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/db/DbTimestampTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/db/DbTimestampTest.java
@@ -5,17 +5,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import pl.cyfronet.s4e.BasicTest;
-import pl.cyfronet.s4e.TestGeometryHelper;
-import pl.cyfronet.s4e.bean.Scene;
-import pl.cyfronet.s4e.bean.Product;
-import pl.cyfronet.s4e.data.repository.SceneRepository;
 import pl.cyfronet.s4e.data.repository.ProductRepository;
+import pl.cyfronet.s4e.data.repository.SceneRepository;
 
 import java.time.LocalDateTime;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static pl.cyfronet.s4e.SceneTestHelper.productBuilder;
+import static pl.cyfronet.s4e.SceneTestHelper.sceneBuilder;
 
 @BasicTest
 public class DbTimestampTest {
@@ -25,9 +24,6 @@ public class DbTimestampTest {
     @Autowired
     private ProductRepository productRepository;
 
-    @Autowired
-    private TestGeometryHelper geom;
-
     @BeforeEach
     public void beforeEach() {
         sceneRepository.deleteAll();
@@ -36,21 +32,13 @@ public class DbTimestampTest {
 
     @Test
     public void shouldSaveTimestampWithoutDSTCorrections() {
-        val product = productRepository.save(Product.builder()
-                .name("testProductType")
-                .displayName("testProductType")
-                .layerName("test_layer_name")
-                .build());
+        val product = productRepository.save(productBuilder().build());
 
         // A datetime, which if Polish timezone is used gets shifted one hour forward
         // on writing to DB.
         LocalDateTime dstBorderTimestamp = LocalDateTime.of(2019, 3, 31, 2, 0);
-        val scene = sceneRepository.save(Scene.builder()
-                .product(product)
+        val scene = sceneRepository.save(sceneBuilder(product)
                 .timestamp(dstBorderTimestamp)
-                .s3Path("some/path")
-                .granulePath("mailto://bucket/some/path")
-                .footprint(geom.any())
                 .build());
 
         val sceneId = sceneRepository.save(scene).getId();

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperationsIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperationsIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import pl.cyfronet.s4e.Constants;
 import pl.cyfronet.s4e.IntegrationTest;
+import pl.cyfronet.s4e.TestDbHelper;
 
 import java.util.List;
 
@@ -17,15 +18,19 @@ import static org.hamcrest.Matchers.*;
 public class GeoServerOperationsIntegrationTest {
     @Autowired
     private GeoServerOperations geoServerOperations;
+
     @Autowired
     private SeedProductsTest seedProductsTest;
 
+    @Autowired
+    private TestDbHelper testDbHelper;
+
     @BeforeEach
     public void beforeEach() {
+        testDbHelper.clean();
         for (String workspace: geoServerOperations.listWorkspaces()) {
             geoServerOperations.deleteWorkspace(workspace, true);
         }
-        seedProductsTest.preparedb();
     }
 
     @Test
@@ -75,6 +80,7 @@ public class GeoServerOperationsIntegrationTest {
 
     @Test
     public void shouldCreateS3CoverageStore() {
+        seedProductsTest.prepareDb();
         geoServerOperations.createWorkspace("test");
 
         assertThat(geoServerOperations.listCoverageStores("test"), hasSize(0));
@@ -86,6 +92,7 @@ public class GeoServerOperationsIntegrationTest {
 
     @Test
     public void shouldDeleteCoverageStore() {
+        seedProductsTest.prepareDb();
         geoServerOperations.createWorkspace("test");
         geoServerOperations.createS3CoverageStore("test", "setvak");
 
@@ -98,6 +105,7 @@ public class GeoServerOperationsIntegrationTest {
 
     @Test
     public void shouldCreateS3Coverage() {
+        seedProductsTest.prepareDb();
         geoServerOperations.createWorkspace("test");
         geoServerOperations.createS3CoverageStore("test", "setvak");
 
@@ -110,6 +118,7 @@ public class GeoServerOperationsIntegrationTest {
 
     @Test
     public void shouldDeleteCoverage() {
+        seedProductsTest.prepareDb();
         geoServerOperations.createWorkspace("test");
         geoServerOperations.createS3CoverageStore("test", "setvak");
         geoServerOperations.createS3Coverage("test", "setvak", "setvak");

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/SeedProductsTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/SeedProductsTest.java
@@ -134,6 +134,7 @@ public class SeedProductsTest {
 
             val scene = Scene.builder()
                     .product(product)
+                    .sceneKey(SceneTestHelper.nextUnique("path/to/%dth.scene"))
                     .timestamp(timestamp)
                     .s3Path(s3Path)
                     .granulePath(granulePath)

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/SeedProductsTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/geoserver/op/SeedProductsTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import pl.cyfronet.s4e.SceneTestHelper;
 import pl.cyfronet.s4e.bean.Product;
 import pl.cyfronet.s4e.bean.Scene;
 import pl.cyfronet.s4e.data.repository.ProductRepository;
@@ -64,9 +65,7 @@ public class SeedProductsTest {
         Duration increment = Duration.ofHours(1);
     }
 
-    public void preparedb() {
-        sceneRepository.deleteAll();
-        productRepository.deleteAll();
+    public void prepareDb() {
         seedProductsMinioDataV1();
     }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/GeoServerServiceIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/GeoServerServiceIntegrationTest.java
@@ -1,6 +1,5 @@
 package pl.cyfronet.s4e.service;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import pl.cyfronet.s4e.IntegrationTest;
+import pl.cyfronet.s4e.TestDbHelper;
 import pl.cyfronet.s4e.bean.PRGOverlay;
 import pl.cyfronet.s4e.bean.Product;
 import pl.cyfronet.s4e.bean.SldStyle;
@@ -19,7 +19,6 @@ import pl.cyfronet.s4e.geoserver.op.GeoServerOperations;
 import pl.cyfronet.s4e.geoserver.op.SeedProductsTest;
 import pl.cyfronet.s4e.properties.GeoServerProperties;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,21 +50,13 @@ public class GeoServerServiceIntegrationTest {
     @Autowired
     private SeedProductsTest seedProductsTest;
 
+    @Autowired
+    private TestDbHelper testDbHelper;
+
     @BeforeEach
     public void beforeEach() {
-        seedProductsTest.preparedb();
-        prgOverlayRepository.deleteAll();
-        sldStyleRepository.deleteAll();
-
+        testDbHelper.clean();
         geoServerService.resetWorkspace();
-    }
-
-    @AfterEach
-    public void afterEach() {
-        sceneRepository.deleteAll();
-        productRepository.deleteAll();
-        prgOverlayRepository.deleteAll();
-        sldStyleRepository.deleteAll();
     }
 
     @Test
@@ -93,8 +84,7 @@ public class GeoServerServiceIntegrationTest {
                 .sldStyle(sldStyle)
                 .build());
 
-        List<PRGOverlay> prgOverlays = new ArrayList<>();
-        prgOverlayRepository.findAll().forEach(prgOverlays::add);
+        List<PRGOverlay> prgOverlays = prgOverlayRepository.findAll();
 
         geoServerService.createPrgOverlays(prgOverlays);
 
@@ -104,6 +94,7 @@ public class GeoServerServiceIntegrationTest {
 
     @Test
     public void shouldAddStoreAndLayer() {
+        seedProductsTest.prepareDb();
         Product product = productRepository.findByNameContainingIgnoreCase("108m").get();
         geoServerService.addStoreAndLayer(product);
 
@@ -124,7 +115,8 @@ public class GeoServerServiceIntegrationTest {
     }
 
     @Test
-    public void shouldCheckIfLayerExists(){
+    public void shouldCheckIfLayerExists() {
+        seedProductsTest.prepareDb();
         Product product = productRepository.findByNameContainingIgnoreCase("108m").get();
         geoServerService.addStoreAndLayer(product);
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/QueueReceiverIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/QueueReceiverIntegrationTest.java
@@ -65,7 +65,7 @@ public class QueueReceiverIntegrationTest {
         sendMessage(incomingQueueName, SCENE_KEY, "s3:ObjectCreated:Put");
 
         await().atMost(Durations.TEN_SECONDS)
-                .until(() -> sceneRepository.findByProductId(productId), hasSize(greaterThan(0)));
+                .until(() -> sceneRepository.findAllByProductId(productId), hasSize(greaterThan(0)));
     }
 
     private void sendMessage(String routingKey, String sceneKey, String eventName) {

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorIntegrationTest.java
@@ -45,6 +45,6 @@ class SceneAcceptorIntegrationTest {
         sceneAcceptor.accept(SCENE_KEY);
 
         await().atMost(Durations.TEN_SECONDS)
-                .until(() -> sceneRepository.findByProductId(productId), hasSize(greaterThan(0)));
+                .until(() -> sceneRepository.findAllByProductId(productId), hasSize(greaterThan(0)));
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/ScenePersisterTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/ScenePersisterTest.java
@@ -1,0 +1,139 @@
+package pl.cyfronet.s4e.sync;
+
+import com.github.javafaker.Faker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.TestGeometryHelper;
+import pl.cyfronet.s4e.bean.Product;
+import pl.cyfronet.s4e.bean.Scene;
+import pl.cyfronet.s4e.data.repository.ProductRepository;
+import pl.cyfronet.s4e.data.repository.SceneRepository;
+import pl.cyfronet.s4e.ex.NotFoundException;
+
+import javax.json.JsonValue;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static pl.cyfronet.s4e.SceneTestHelper.sceneBuilder;
+
+@BasicTest
+class ScenePersisterTest {
+    @Autowired
+    private ScenePersister scenePersister;
+
+    @Autowired
+    private SceneRepository sceneRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    private Faker faker = new Faker();
+
+    @BeforeEach
+    public void beforeEach() {
+        testDbHelper.clean();
+    }
+
+    @Test
+    public void shouldSaveNewScene() throws NotFoundException {
+        Product product = createProduct();
+        Prototype prototype = getPrototype(product.getId(), "key/path/of/a.scene");
+
+        assertThat(listProductScenes(product.getId()), hasSize(0));
+
+        Long persistedId = scenePersister.persist(prototype);
+
+        assertThat(listProductScenes(product.getId()), hasItems(allOf(
+                hasProperty("id", equalTo(persistedId)),
+                hasProperty("sceneKey", equalTo(prototype.getSceneKey()))
+        )));
+    }
+
+    @Test
+    public void shouldUpdateExistingScene() throws NotFoundException {
+        Product product = createProduct();
+        String sceneKey = "key/path/of/a.scene";
+        Scene scene = createScene(product, sceneKey);
+        Prototype prototype = getPrototype(product.getId(), sceneKey);
+
+        assertThat(listProductScenes(product.getId()), hasItems(allOf(
+                hasProperty("id", equalTo(scene.getId())),
+                hasProperty("sceneKey", equalTo(sceneKey))
+        )));
+
+        Long persistedId = scenePersister.persist(prototype);
+
+        assertThat(persistedId, is(equalTo(scene.getId())));
+        assertThat(listProductScenes(product.getId()), hasItems(allOf(
+                hasProperty("id", equalTo(persistedId)),
+                hasProperty("sceneKey", equalTo(sceneKey)),
+                hasProperty("s3Path", equalTo(prototype.getS3Path())),
+                hasProperty("granulePath", equalTo("mailto://s4e-test-1/" + prototype.getS3Path()))
+        )));
+    }
+
+    @Test
+    public void shouldVerifyUpdatedSceneProductMatches() {
+        Product product1 = createProduct();
+        Product product2 = createProduct();
+        String sceneKey = "key/path/of/a.scene";
+        Scene scene = createScene(product1, sceneKey);
+        Prototype prototype = getPrototype(product2.getId(), sceneKey);
+
+        assertThat(listProductScenes(product1.getId()), hasItems(allOf(
+                hasProperty("id", equalTo(scene.getId())),
+                hasProperty("sceneKey", equalTo(sceneKey))
+        )));
+        assertThat(listProductScenes(product2.getId()), is(empty()));
+
+        assertThrows(IllegalArgumentException.class, () -> scenePersister.persist(prototype));
+
+        assertThat(listProductScenes(product1.getId()), hasItems(allOf(
+                hasProperty("id", equalTo(scene.getId())),
+                hasProperty("sceneKey", equalTo(sceneKey))
+        )));
+        assertThat(listProductScenes(product2.getId()), is(empty()));
+    }
+
+    private Product createProduct() {
+        String displayName = faker.numerify(faker.space().constellation() + " ##");
+        String name = displayName.replace(" ", "_");
+        return productRepository.save(Product.builder()
+                .name(name)
+                .displayName(displayName)
+                .layerName(name.toLowerCase())
+                .build());
+    }
+
+    private Scene createScene(Product product, String sceneKey) {
+        return sceneRepository.save(sceneBuilder(product)
+                .sceneKey(sceneKey)
+                .build());
+    }
+
+    private Prototype getPrototype(Long productId, String sceneKey) {
+        return Prototype.builder()
+                .sceneKey(sceneKey)
+                .s3Path("path/to/granule.tif")
+                .productId(productId)
+                .timestamp(LocalDateTime.now())
+                .footprint(TestGeometryHelper.ANY_POLYGON)
+                .sceneJson(JsonValue.EMPTY_JSON_OBJECT)
+                .metadataJson(JsonValue.EMPTY_JSON_OBJECT)
+                .build();
+    }
+
+    private List<Scene> listProductScenes(Long productId) {
+        return sceneRepository.findAllByProductId(productId);
+    }
+
+}


### PR DESCRIPTION
I add scene.scene_key unique column, which identifies each Scene. It is consulted when receiving a scene file update to determine if we have to update a record or create a new one.

This addition forces updates in Scene bootstraping in tests and seeds.

Apart from that, refactor Scene and Product creation in tests in a separate commit, as there was a lot of repetition there. Also, fix WMSOverlay table name and several other improvements.

Closes: #469.
