### PR TITLE
Backend dependencies update - 2020.06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Updated
 
+- 2020.06 backend dependencies update
+
 ## [v8.0.0]
 
 ### Added

--- a/gs-gateway/pom.xml
+++ b/gs-gateway/pom.xml
@@ -10,7 +10,6 @@
         <version>${revision}${sha1}${changelist}</version>
     </parent>
 
-    <groupId>pl.cyfronet.s4e</groupId>
     <artifactId>gs-gateway</artifactId>
     <packaging>jar</packaging>
 
@@ -18,7 +17,7 @@
     <description>GeoServer Gateway</description>
 
     <properties>
-        <spring-cloud.version>Hoxton.SR4</spring-cloud.version>
+        <spring-cloud.version>Hoxton.SR5</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
@@ -133,5 +132,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,19 +26,19 @@
         <java.version>11</java.version>
         <maven.compiler.release>11</maven.compiler.release>
 
-        <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
+        <spring-boot.version>2.3.0.RELEASE</spring-boot.version>
 
-        <jjwt.version>0.11.1</jjwt.version>
-        <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
-        <commonmark.version>0.14.0</commonmark.version>
-        <hibernate-types.version>2.9.9</hibernate-types.version>
-        <poiooxml.version>4.1.2</poiooxml.version>
-        <greenmail.version>1.5.13</greenmail.version>
-        <slugify.version>2.4</slugify.version>
-        <springdoc-openapi.version>1.3.9</springdoc-openapi.version>
-        <awssdk.version>2.13.8</awssdk.version>
+        <awssdk.version>2.13.31</awssdk.version>
+        <commonmark.version>0.15.1</commonmark.version>
         <commons-email.version>1.5</commons-email.version>
-        <geotools.version>23.0</geotools.version>
+        <geotools.version>23.1</geotools.version>
+        <greenmail.version>1.5.13</greenmail.version>
+        <jjwt.version>0.11.1</jjwt.version>
+        <hibernate-types.version>2.9.11</hibernate-types.version>
+        <poiooxml.version>4.1.2</poiooxml.version>
+        <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
+        <slugify.version>2.4</slugify.version>
+        <springdoc-openapi.version>1.4.0</springdoc-openapi.version>
         <unirest.version>3.7.02</unirest.version>
     </properties>
 
@@ -113,6 +113,26 @@
                     <version>3.0.0-M4</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.9.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${spring-boot.version}</version>
@@ -127,8 +147,12 @@
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>1.6.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <version>1.10.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
-
 </project>

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -10,7 +10,6 @@
         <version>${revision}${sha1}${changelist}</version>
     </parent>
 
-    <groupId>pl.cyfronet.s4e</groupId>
     <artifactId>s4e-backend</artifactId>
     <packaging>jar</packaging>
 
@@ -43,6 +42,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -88,6 +91,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-email</artifactId>
             <version>${commons-email.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!--
@@ -200,7 +209,7 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-data-rest</artifactId>
+            <artifactId>springdoc-openapi-webmvc-core</artifactId>
             <version>${springdoc-openapi.version}</version>
         </dependency>
 
@@ -300,6 +309,7 @@
                     </includes>
                     <groups>integration</groups>
                     <skipTests>${skip.failsafe.tests}</skipTests>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                 </configuration>
                 <executions>
                     <execution>
@@ -319,5 +329,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/GroupController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/GroupController.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.data.rest.converters.PageableAsQueryParam;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/InstitutionController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/InstitutionController.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.data.rest.converters.PageableAsQueryParam;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/PlaceController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/PlaceController.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.data.rest.converters.PageableAsQueryParam;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SavedViewController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SavedViewController.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.data.rest.converters.PageableAsQueryParam;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;

--- a/s4e-web/pom.xml
+++ b/s4e-web/pom.xml
@@ -40,7 +40,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.2.0</version>
         <configuration>
           <descriptors>
             <descriptor>assembly.xml</descriptor>
@@ -60,7 +59,6 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.8.0</version>
         <configuration>
           <installDirectory>target</installDirectory>
           <nodeVersion>v11.10.1</nodeVersion>
@@ -107,6 +105,4 @@
       </plugin>
     </plugins>
   </build>
-
-
 </project>


### PR DESCRIPTION
Include json-path explicitly in s4e-backend/pom.xml, otherwise
com.jayway.jsonpath.spi.mapper.MappingProvider isn't found in AmqpConfig::messageConverter.
It sets setUseProjectionForInterfaces(true), which in turn depends on the MappingProvider.

This was in caused by moving from openapi-data-rest dependency to
openapi-webmvc-core. The former forced dependency on spring-data-rest,
which is unnecessary in our case. However, it caused the problem
described in the paragraph above.

Apart from this, I moved plugin versions from s4e-web to
pluginManagement in parent module.