### PR TITLE
[#491] Allow null in custom validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- Handle nulls in custom Validators [#491](https://github.com/cyfronet-fid/sat4envi/issues/491)
 - Fix PUT endpoint for Institutions [#500](https://github.com/cyfronet-fid/sat4envi/issues/500)
 - Fix and test refactor for /institutions endpoint [#472](https://github.com/cyfronet-fid/sat4envi/issues/472)
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/Base64Validator.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/Base64Validator.java
@@ -5,6 +5,10 @@ import javax.validation.ConstraintValidatorContext;
 
 public class Base64Validator implements ConstraintValidator<Base64, String> {
    public boolean isValid(String encoded, ConstraintValidatorContext context) {
+       if (encoded == null) {
+           return true;
+       }
+
        try {
            java.util.Base64.getDecoder().decode(encoded);
            return true;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/ContentTypeValidator.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/ContentTypeValidator.java
@@ -17,14 +17,18 @@ public class ContentTypeValidator implements ConstraintValidator<ContentType, St
     }
 
     public boolean isValid(String encoded, ConstraintValidatorContext context) {
-       try {
-           byte[] bytes = Base64.getDecoder().decode(encoded);
-           String contentType = URLConnection.guessContentTypeFromStream(new ByteArrayInputStream(bytes));
-           return pattern.matcher(contentType).matches();
-       } catch (IllegalArgumentException e) {
-           return false;
-       } catch (IOException e) {
-           return false;
-       }
+        if (encoded == null) {
+            return true;
+        }
+
+        try {
+            byte[] bytes = Base64.getDecoder().decode(encoded);
+            String contentType = URLConnection.guessContentTypeFromStream(new ByteArrayInputStream(bytes));
+            return pattern.matcher(contentType).matches();
+        } catch (IllegalArgumentException e) {
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/ImageDimensionsValidator.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/ImageDimensionsValidator.java
@@ -19,14 +19,18 @@ public class ImageDimensionsValidator implements ConstraintValidator<ImageDimens
     }
 
     public boolean isValid(String encoded, ConstraintValidatorContext context) {
-       try {
-           byte[] bytes = Base64.getDecoder().decode(encoded);
-           BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
-           return image.getWidth() <= maxWidth && image.getHeight() <= maxHeight;
-       } catch (IllegalArgumentException e) {
-           return false;
-       } catch (IOException e) {
-           return false;
-       }
+        if (encoded == null) {
+            return true;
+        }
+
+        try {
+            byte[] bytes = Base64.getDecoder().decode(encoded);
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+            return image.getWidth() <= maxWidth && image.getHeight() <= maxHeight;
+        } catch (IllegalArgumentException e) {
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/validation/ContentTypeValidatorTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/validation/ContentTypeValidatorTest.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.controller.validation;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,4 +31,13 @@ class ContentTypeValidatorTest {
         );
     }
 
+    @Test
+    public void shouldAllowNullValue() {
+        ContentTypeValidator validator = new ContentTypeValidator();
+        ContentType annotation = mock(ContentType.class);
+        when(annotation.pattern()).thenReturn("");
+        validator.initialize(annotation);
+
+        assertThat(validator.isValid(null, null), is(true));
+    }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/validation/ImageDimensionsValidatorTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/validation/ImageDimensionsValidatorTest.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.controller.validation;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,6 +34,15 @@ class ImageDimensionsValidatorTest {
                 Arguments.of(95,  95,  false),
                 Arguments.of(10,  10,  false)
         );
+    }
+
+    @Test
+    public void shouldAllowNullValue() {
+        ImageDimensionsValidator validator = new ImageDimensionsValidator();
+        ImageDimensions annotation = mock(ImageDimensions.class);
+        validator.initialize(annotation);
+
+        assertThat(validator.isValid(null, null), is(true));
     }
 
 }


### PR DESCRIPTION
Regardless if the emblem is required or not, Validators shouldn't throw NPEs in case incoming value is null.

Closes: #491.