### PR TITLE
[#570] Fix schema scanning and parallel seeding when running from a jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- Fix schema scanning and parallel seeding when running from a jar [#570](https://github.com/cyfronet-fid/sat4envi/pull/570)
 - Fix Institution edition, registration form, add child institution and cancel password change [#558](https://github.com/cyfronet-fid/sat4envi/pull/558)
 - [fix] dropdowns toggle on map and in settings [#562](https://github.com/cyfronet-fid/sat4envi/issues/562)
 - Fix institution loading in search box

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SchemaScanner.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SchemaScanner.java
@@ -3,7 +3,7 @@ package pl.cyfronet.s4e.db.seed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Component;
 import pl.cyfronet.s4e.bean.Schema;
 import pl.cyfronet.s4e.util.ResourceReader;
@@ -12,7 +12,6 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -22,18 +21,12 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 class SchemaScanner {
-    private final ResourceLoader resourceLoader;
+    private final ResourcePatternResolver resourcePatternResolver;
 
-    public List<Schema> scan(String path) throws IOException {
-        log.trace(String.format("Scanning: '%s'", path));
-        Resource resource = resourceLoader.getResource(path);
-        File file = resource.getFile();
+    public List<Schema> scan(String schemasPattern) throws IOException {
+        log.trace(String.format("Scanning: '%s'", schemasPattern));
         List<Schema> schemas = new ArrayList<>();
-        if (file.isDirectory()) {
-            for (String child : file.list()) {
-                schemas.addAll(scan(path + "/" + child));
-            }
-        } else {
+        for (Resource resource : resourcePatternResolver.getResources(schemasPattern)) {
             String content = ResourceReader.asString(resource);
             schemas.add(loadSchema(content));
         }


### PR DESCRIPTION
SchemaScanner::scan used operations restricted to filesystem, however,
Spring provides classpath resource resolution methods applicable here,
which I use.

Morever, using parallel stream is problematic in conjunction with
ServiceLoader.
It seems, that threads spawned by a parallel stream are independent from
the ones created by a ThreadPool, they inherit another classloader,
which doesn't see SPI loaded classes (in our case JsonProviderImpl).
I solve this by registering tasks one by one and waiting afterwards.

Closes: #570