### PR TITLE
[#603] Set GeoServer mosaic levels and heterogeneous properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ The most recent changes are on top, in each type of changes category.
 ## [Unreleased]
 
 ### Added
+
 - Create events directive [#592](https://github.com/cyfronet-fid/sat4envi/issues/592)
 
 ### Changed
 
+- Set GeoServer mosaic levels and heterogeneous properties [#603](https://github.com/cyfronet-fid/sat4envi/issues/603)
 
 ### Fixed
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperations.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperations.java
@@ -150,7 +150,7 @@ public class GeoServerOperations {
         ClassLoader classloader = Thread.currentThread().getContextClassLoader();
         String mosaic = "Name=" + coverageStore + "\n" +
                 "TypeName=scene_" + coverageStore + "\n" +
-                "Levels=5000,5000\n" +
+                "Levels=1,1\n" +
                 "LevelsNum=1\n";
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/s4e-backend/src/main/resources/geoserver/mosaic.properties
+++ b/s4e-backend/src/main/resources/geoserver/mosaic.properties
@@ -3,7 +3,7 @@
 #Levels=5000,5000
 #LevelsNum=1
 MosaicCRS=EPSG\:3857
-Heterogeneous=false
+Heterogeneous=true
 HeterogeneousCRS=false
 Caching=false
 ExpandToRGB=false


### PR DESCRIPTION
Previously, levels were set to a high value, and there was quality loss due to that.
Also, some layers were shifted horizontally, setting heterogeneous property fixes the problem.

Closes: #603.