### PR TITLE
[#610] Improve scene time filtering performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- Improve scene time filtering performance [#610](https://github.com/cyfronet-fid/sat4envi/issues/610)
+
 ### Updated
 
 ## [v9.1.0]

--- a/s4e-backend/src/main/resources/db/migration/V39__add_scene_timestamp_index.sql
+++ b/s4e-backend/src/main/resources/db/migration/V39__add_scene_timestamp_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_scene_timestamp ON scene USING btree (timestamp);


### PR DESCRIPTION
Add a B-tree index on `scene.timestamp`, as without it `SceneService::getAvailabilityDates` performance degraded when many Scenes were present in the table.

Closes: #610.