### PR TITLE
[#625] Confirm or reject invitation with email URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Confirm or reject invitation with email URLs [#625](https://github.com/cyfronet-fid/sat4envi/issues/625)
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ In order do run docker-compose following steps must be done (**unless stated oth
 
 6. Run `docker-compose up`.
 
-7. You're done - application should be available on http://localhost:4200 and have 3 available products.
+7. You're done - application should be available on https://localhost:4200 and have 3 available products.
 
 **IMPORTANT** If you run `docker-compose up` you'll get application all set up, but it does not support any kind of live reload, etc. If you plan on developing any part of the project (frontend or backend) you should run docker compose without module you would like to develop - for example:
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/InvitationController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/InvitationController.java
@@ -60,7 +60,7 @@ public class InvitationController {
     public BasicInstitutionResponse confirm(@PathVariable String token) throws NotFoundException {
         invitationService.confirmInvitation(token);
         val institution = invitationService.findInstitutionBy(token, BasicInstitutionResponse.class)
-                .orElseThrow(() -> new NotFoundException("Institution couldn't be found"));;
+                .orElseThrow(() -> new NotFoundException("Institution couldn't be found"));
         val confirmInvitationEvent = new OnConfirmInvitationEvent(token, LocaleContextHolder.getLocale());
         eventPublisher.publishEvent(confirmInvitationEvent);
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/InvitationListener.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/listener/InvitationListener.java
@@ -66,7 +66,7 @@ public class InvitationListener {
         ctx.setVariable("institutionName", invitation.getInstitution().getName());
 
         String confirmUrl = mailHelper.prefixWithDomain("/login?token=" + invitation.getToken());
-        String rejectUrl = mailHelper.prefixWithDomain("/login?reject=''&token=" + invitation.getToken());
+        String rejectUrl = mailHelper.prefixWithDomain("/login?reject=true&token=" + invitation.getToken());
         ctx.setVariable("confirmUrl", confirmUrl);
         ctx.setVariable("rejectUrl", rejectUrl);
 

--- a/s4e-backend/src/main/resources/application-development.properties
+++ b/s4e-backend/src/main/resources/application-development.properties
@@ -30,7 +30,7 @@ s3.file-storage.key-prefix-emblem=emblems/
 recaptcha.validation.secretKey=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 recaptcha.validation.siteKey=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 
-mail.urlDomain=http://localhost:4200
+mail.urlDomain=https://localhost:4200
 
 jwt.key-store=dev_key.p12
 jwt.key-store-password=dev_password

--- a/s4e-backend/src/main/resources/mail/invitation-email.txt
+++ b/s4e-backend/src/main/resources/mail/invitation-email.txt
@@ -3,5 +3,8 @@ Dzień dobry!
 Zostałeś zaproszony do instytucji '[( ${institutionName} )]'.
 Potwierdź klikając 'Dołącz', a następnie zaloguj się lub zarejestruj.
 
+Dołącz: [( ${confirmUrl} )]
+Odrzuć: [( ${rejectUrl} )]
+
 Pozdrawiamy,
 Zespół sat4envi

--- a/s4e-backend/src/test/resources/application-test.properties
+++ b/s4e-backend/src/test/resources/application-test.properties
@@ -37,7 +37,7 @@ spring.mail.test-connection=false
 
 recaptcha.testing.enabled=true
 
-mail.urlDomain=http://localhost:4200
+mail.urlDomain=https://localhost:4200
 
 recaptcha.validation.secretKey=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 recaptcha.validation.siteKey=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/s4e-web/README.md
+++ b/s4e-web/README.md
@@ -33,7 +33,7 @@ So to start application for development run:
 npm start
 ```
 
-**NOTICE**: Local web server will be available on http://localhost:4200/, and it will start with `/api` route proxied to `http://localhost:4201`, where backend should be present.
+**NOTICE**: Local web server will be available on https://localhost:4200/, and it will start with `/api` route proxied to `http://localhost:4201`, where backend should be present.
 
 #### Other important information
 

--- a/s4e-web/src/app/errors/errors.component.html
+++ b/s4e-web/src/app/errors/errors.component.html
@@ -3,9 +3,9 @@
   <h4 class="description">{{ actualError.description }}</h4>
   <p>
     <b><a routerLink="/">Return to main page</a></b>
-    <b *ngIf="!!back_link && back_link !== ''" >
+    <b *ngIf="!!backLink && backLink !== ''" >
       <span>&nbsp; | &nbsp;</span>
-      <a routerLink="{{ back_link }}">Return to last page</a>
+      <a routerLink="{{ backLink }}">Return to last page</a>
     </b>
   </p>
 </div>

--- a/s4e-web/src/app/errors/errors.component.ts
+++ b/s4e-web/src/app/errors/errors.component.ts
@@ -2,6 +2,7 @@ import {untilDestroyed} from 'ngx-take-until-destroy';
 import {ActivatedRoute} from '@angular/router';
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR, HTTP_502_BAD_GATEWAY} from './errors.model';
+import { BACK_LINK_QUERY_PARAM } from '../state/session/session.service';
 
 @Component({
   selector: 's4e-errors',
@@ -10,7 +11,7 @@ import {HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR, HTTP_502_BAD_GATEWAY
 })
 export class ErrorsComponent implements OnInit, OnDestroy {
   public actualError = ErrorsComponent._getErrorBy(null);
-  public back_link?: string;
+  public backLink?: string;
 
   constructor(private _activatedRoute: ActivatedRoute) {
   }
@@ -52,7 +53,7 @@ export class ErrorsComponent implements OnInit, OnDestroy {
     this._activatedRoute.queryParamMap
       .pipe(untilDestroyed(this))
       .subscribe((params) => {
-        this.back_link = params.get('back_link');
+        this.backLink = params.get(BACK_LINK_QUERY_PARAM);
       });
   }
 

--- a/s4e-web/src/app/state/session/session.model.ts
+++ b/s4e-web/src/app/state/session/session.model.ts
@@ -1,7 +1,6 @@
 export interface LoginFormState {
-  login: string;
+  email: string;
   password: string;
-  rememberMe: boolean;
 }
 
 export interface Role {

--- a/s4e-web/src/app/utils.ts
+++ b/s4e-web/src/app/utils.ts
@@ -1,4 +1,4 @@
-import {UrlSegment} from '@angular/router';
+import { UrlSegment } from '@angular/router';
 
 export function activateMatcher(url: UrlSegment[]) {
   const uuidv4 = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);

--- a/s4e-web/src/app/utils/auth-guard/auth-guard.service.spec.ts
+++ b/s4e-web/src/app/utils/auth-guard/auth-guard.service.spec.ts
@@ -4,6 +4,7 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {SessionQuery} from '../../state/session/session.query';
 import {Component} from '@angular/core';
 import {Router} from '@angular/router';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 @Component({selector: 'neutral', template: ''})
 class NeutralComponent {}
@@ -20,13 +21,16 @@ describe('IsLoggedIn & IsNotLoggedIn', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [SubComponent, LoginComponent, NeutralComponent],
-      imports: [RouterTestingModule.withRoutes(
-        [
-          {path: 'map/products', component: NeutralComponent},
-          {path: 'login', canActivate: [IsNotLoggedIn], component: LoginComponent},
-          {path: 'sub', canActivate: [IsLoggedIn], component: SubComponent}
-        ]
-      )],
+      imports: [
+        RouterTestingModule.withRoutes(
+          [
+            {path: 'map/products', component: NeutralComponent},
+            {path: 'login', canActivate: [IsNotLoggedIn], component: LoginComponent},
+            {path: 'sub', canActivate: [IsLoggedIn], component: SubComponent}
+          ]
+        ),
+        HttpClientTestingModule
+      ],
       providers: [IsLoggedIn, IsNotLoggedIn, SessionQuery],
     });
     router = TestBed.get(Router);

--- a/s4e-web/src/app/utils/auth-guard/auth-guard.service.ts
+++ b/s4e-web/src/app/utils/auth-guard/auth-guard.service.ts
@@ -1,15 +1,24 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
 import {SessionQuery} from '../../state/session/session.query';
+import {
+  TOKEN_QUERY_PARAMETER,
+  REJECTION_QUERY_PARAMETER,
+  InvitationService
+} from 'src/app/views/settings/people/state/invitation.service';
 
 @Injectable({providedIn: 'root'})
 export class IsLoggedIn implements CanActivate {
-  constructor(protected sessionQuery: SessionQuery, protected router: Router) {}
+  constructor(
+    protected _invitationService: InvitationService,
+    protected _sessionQuery: SessionQuery,
+    protected _router: Router
+  ) {}
 
   canActivate(next: ActivatedRouteSnapshot,
               state: RouterStateSnapshot): UrlTree | boolean {
-    if (!this.sessionQuery.isLoggedIn()) {
-      return this.router.parseUrl('/login');
+    if (!this._sessionQuery.isLoggedIn()) {
+      return this._router.parseUrl('/login');
     }
     return true;
   }
@@ -19,11 +28,19 @@ export class IsLoggedIn implements CanActivate {
 @Injectable({providedIn: 'root'})
 export class IsNotLoggedIn extends IsLoggedIn implements CanActivate {
 
-  canActivate(next: ActivatedRouteSnapshot,
-              state: RouterStateSnapshot): UrlTree | boolean {
-    if (this.sessionQuery.isLoggedIn()) {
-      return this.router.parseUrl('/map/products');
+  canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): UrlTree | boolean {
+    if (this._sessionQuery.isLoggedIn()) {
+      if (next.queryParamMap.has(TOKEN_QUERY_PARAMETER)) {
+        this._invitationService.handleInvitation(next);
+        return this._router.parseUrl('');
+      }
+
+      return this._router.parseUrl('/map/products');
     }
-    return true
+
+    return true;
   }
 }

--- a/s4e-web/src/app/utils/initializer/config.service.spec.ts
+++ b/s4e-web/src/app/utils/initializer/config.service.spec.ts
@@ -1,3 +1,4 @@
+import { RouterTestingModule } from '@angular/router/testing';
 import {TestBed} from '@angular/core/testing';
 import {S4eConfig} from './config.service';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
@@ -12,8 +13,14 @@ describe('Configuration service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [S4eConfig, SessionService],
-      imports: [HttpClientTestingModule]
+      providers: [
+        S4eConfig,
+        SessionService
+      ],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule
+      ]
     });
 
     configService = TestBed.get(S4eConfig);

--- a/s4e-web/src/app/views/login/login.component.html
+++ b/s4e-web/src/app/views/login/login.component.html
@@ -44,22 +44,14 @@
         <ul class="form__list">
           <li class="form__element">
             <label for="login-login" i18n>Email</label>
-            <input class="form-control" formControlName="login" id="login-login" type="text">
-            <ul s4e-form-error [control]="form.controls.login"></ul>
+            <input class="form-control" formControlName="email" id="login-login" type="text">
+            <ul s4e-form-error [control]="form.controls.email"></ul>
           </li>
           <li class="form__element">
             <label for="login-password" i18n>Hasło</label>
             <input class="form-control" formControlName="password" id="login-password" type="password">
             <ul s4e-form-error [control]="form.controls.password"></ul>
           </li>
-          <!-- TODO update feature of `Remember me` -->
-          <!-- <li class="form__element form__checkbox">
-            <input type="checkbox" class="form-check-input" id="login-remember-me">
-            <label class="form-check-label" for="login-remember-me" i18n>
-              <span class="ui"></span>
-              Zapamiętaj mnie
-            </label>
-          </li> -->
           <li class="form__element">
             <button class="button button--primary" type="submit" [disabled]="form.invalid">
               <fa-icon [hidden]="!(loading$ | async)" [icon]="['fas', 'circle-notch']" [spin]="true"></fa-icon>

--- a/s4e-web/src/app/views/login/login.component.spec.ts
+++ b/s4e-web/src/app/views/login/login.component.spec.ts
@@ -40,7 +40,7 @@ describe('LoginComponent', () => {
 
   it('should send valid form', () => {
     const spy = spyOn(sessionService, 'login');
-    component.form.setValue({rememberMe: false, login: 'user@domain', password: 'pass'});
+    component.form.setValue({email: 'user@domain', password: 'pass'});
     component.login();
     expect(spy).toHaveBeenCalled();
   });
@@ -52,12 +52,12 @@ describe('LoginComponent', () => {
     expect(component.form.controls.password.valid).toBeTruthy();
   });
 
-  it('should validate login', () => {
-    component.form.controls.login.setValue('');
-    expect(component.form.controls.login.valid).toBeFalsy();
-    component.form.controls.login.setValue('user');
-    expect(component.form.controls.login.valid).toBeFalsy();
-    component.form.controls.login.setValue('user@domain');
-    expect(component.form.controls.login.valid).toBeTruthy();
+  it('should validate email', () => {
+    component.form.controls.email.setValue('');
+    expect(component.form.controls.email.valid).toBeFalsy();
+    component.form.controls.email.setValue('user');
+    expect(component.form.controls.email.valid).toBeFalsy();
+    component.form.controls.email.setValue('user@domain');
+    expect(component.form.controls.email.valid).toBeTruthy();
   });
 });

--- a/s4e-web/src/app/views/login/login.component.ts
+++ b/s4e-web/src/app/views/login/login.component.ts
@@ -1,14 +1,16 @@
+import { NotificationService } from './../../../../projects/notifications/src/lib/state/notification.service';
+import { InvitationService, REJECTION_QUERY_PARAMETER, TOKEN_QUERY_PARAMETER } from './../settings/people/state/invitation.service';
 import {Component, ViewEncapsulation} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@ng-stack/forms';
 import {AkitaNgFormsManager} from '@datorama/akita-ng-forms-manager';
 import {FormState} from '../../state/form/form.model';
 import {validateAllFormFields} from '../../utils/miscellaneous/miscellaneous';
 import {SessionQuery} from '../../state/session/session.query';
-import {SessionService} from '../../state/session/session.service';
+import {SessionService, BACK_LINK_QUERY_PARAM} from '../../state/session/session.service';
 import {LoginFormState} from '../../state/session/session.model';
-import {ActivatedRoute, Router} from '@angular/router';
+import { ActivatedRoute, Router, ParamMap } from '@angular/router';
 import {GenericFormComponent} from '../../utils/miscellaneous/generic-form.component';
-import { S4eConfig } from 'src/app/utils/initializer/config.service';
+import { filter, map } from 'rxjs/operators';
 
 @Component({
   selector: 's4e-login',
@@ -17,26 +19,25 @@ import { S4eConfig } from 'src/app/utils/initializer/config.service';
   encapsulation: ViewEncapsulation.None
 })
 export class LoginComponent extends GenericFormComponent<SessionQuery, LoginFormState> {
-  constructor(fm: AkitaNgFormsManager<FormState>,
-              router: Router,
-              public CONFIG: S4eConfig,
-              private sessionService: SessionService,
-              private sessionQuery: SessionQuery,
-              private _activatedRoute: ActivatedRoute
+  constructor(
+    fm: AkitaNgFormsManager<FormState>,
+    private _router: Router,
+    private _sessionService: SessionService,
+    private _sessionQuery: SessionQuery,
+    private _activatedRoute: ActivatedRoute,
+    private _invitationService: InvitationService,
+    private _notificationService: NotificationService
   ) {
-    super(fm, router, sessionQuery, 'login');
+    super(fm, _router, _sessionQuery, 'login');
   }
 
   ngOnInit() {
-    this._activatedRoute.queryParamMap
-      .subscribe(
-        (queryParams) => this.sessionService.setBackLink(queryParams.get('back_link'))
-      );
+    this._loadBackLink();
+    this._handleInvitation();
 
     this.form = new FormGroup<LoginFormState>({
-      login: new FormControl('', [Validators.required, Validators.email]),
-      password: new FormControl('', [Validators.required]),
-      rememberMe: new FormControl(false)
+      email: new FormControl('', [Validators.required, Validators.email]),
+      password: new FormControl('', [Validators.required])
     });
 
     super.ngOnInit();
@@ -44,11 +45,36 @@ export class LoginComponent extends GenericFormComponent<SessionQuery, LoginForm
 
   login() {
     validateAllFormFields(this.form, {formKey: this.formKey, fm: this.fm});
-
     if (!this.form.valid) {
       return;
     }
 
-    this.sessionService.login(this.form.value);
+    this._sessionService.login(this.form.value, this._activatedRoute);
+  }
+
+  protected _loadBackLink() {
+    this._activatedRoute.queryParamMap
+      .pipe(
+        filter((params) => params.has(BACK_LINK_QUERY_PARAM)),
+        map((params) => params.get(BACK_LINK_QUERY_PARAM))
+      )
+      .subscribe((backLink) => !!backLink ? this._sessionService.setBackLink(backLink) : null);
+  }
+
+  protected _handleInvitation() {
+    this._activatedRoute.queryParamMap
+      .pipe(filter((params) => params.has(TOKEN_QUERY_PARAMETER)))
+      .subscribe((params) => {
+        if (params.has(REJECTION_QUERY_PARAMETER)) {
+          const token = params.get(TOKEN_QUERY_PARAMETER);
+          this._invitationService.reject(token);
+        }
+
+        const content = 'Zaloguj się lub zarejestruj, żeby dołączyć do instytucji';
+        this._notificationService.addGeneral({
+          content,
+          type: 'info'
+        });
+      });
   }
 }

--- a/s4e-web/src/app/views/map-view/zk/configuration/state/configuration.model.ts
+++ b/s4e-web/src/app/views/map-view/zk/configuration/state/configuration.model.ts
@@ -24,7 +24,7 @@ export interface ConfigurationModal extends Modal {
 }
 
 export function isConfigurationModal(modal: Modal): modal is ConfigurationModal {
-  return modal.id == SHARE_CONFIGURATION_MODAL_ID
+  return modal.id === SHARE_CONFIGURATION_MODAL_ID
     && (modal as ConfigurationModal).mapImage != null
     && (modal as ConfigurationModal).configurationUrl != null;
 }

--- a/s4e-web/src/app/views/register/register.component.spec.ts
+++ b/s4e-web/src/app/views/register/register.component.spec.ts
@@ -82,7 +82,8 @@ describe('RegisterComponent', () => {
     component.form.setValue(userRegister);
     component.register();
 
-    expect(spy).toHaveBeenCalledWith(userRegister);
+    const {recaptcha, passwordRepeat, ...request} = userRegister;
+    expect(spy).toHaveBeenCalledWith(request, recaptcha);
   });
 
   it('should not call RegisterService.register on submit if form is not valid', () => {
@@ -95,6 +96,7 @@ describe('RegisterComponent', () => {
 
     component.register();
 
-    expect(spy).not.toHaveBeenCalledWith(userRegister);
+    const {recaptcha, passwordRepeat, ...request} = userRegister;
+    expect(spy).not.toHaveBeenCalledWith(request, recaptcha);
   });
 });

--- a/s4e-web/src/app/views/register/register.component.ts
+++ b/s4e-web/src/app/views/register/register.component.ts
@@ -59,11 +59,11 @@ export class RegisterComponent extends GenericFormComponent<RegisterQuery, Regis
 
   register() {
     validateAllFormFields(this.form, {formKey: this.formKey, fm: this.fm});
-
     if (!this.form.valid) {
       return;
     }
 
-    this.registerService.register(this.form.value);
+    const {recaptcha, passwordRepeat, ...request} = this.form.value;
+    this.registerService.register(request, recaptcha);
   }
 }

--- a/s4e-web/src/app/views/register/state/register.service.spec.ts
+++ b/s4e-web/src/app/views/register/state/register.service.spec.ts
@@ -34,12 +34,12 @@ describe('RegisterService', () => {
 
     it('should correctly pass userRegister', () => {
       const userRegister = RegisterFactory.build();
-      registerService.register(userRegister);
-      const req = http.expectOne(`api/v1/register?g-recaptcha-response=${userRegister.recaptcha}`);
+      const {recaptcha, passwordRepeat, ...request} = userRegister;
+      registerService.register(request, recaptcha);
+      const req = http.expectOne(`api/v1/register?g-recaptcha-response=${recaptcha}`);
       expect(req.request.method).toBe('POST');
 
-      const {recaptcha, passwordRepeat, ...userData} = userRegister;
-      expect(req.request.body).toEqual(userData);
+      expect(req.request.body).toEqual(request);
       req.flush({});
       http.verify();
     });
@@ -49,19 +49,21 @@ describe('RegisterService', () => {
       const spy = spyOn(router, 'navigate').and.stub();
 
       const userRegister = RegisterFactory.build();
-      registerService.register(userRegister);
-      const req = http.expectOne(`api/v1/register?g-recaptcha-response=${userRegister.recaptcha}`);
+      const {recaptcha, passwordRepeat, ...request} = userRegister;
+      registerService.register(request, recaptcha);
+      const req = http.expectOne(`api/v1/register?g-recaptcha-response=${recaptcha}`);
       req.flush({});
 
       tick(1000);
       http.verify();
-      expect(spy).toBeCalledWith(['/']);
+      expect(spy).toBeCalledWith(['/'], {queryParamsHandling: 'merge'});
     }));
 
     it('should handle error 400', (done) => {
       const userRegister = RegisterFactory.build();
-      registerService.register(userRegister);
-      const req = http.expectOne(`api/v1/register?g-recaptcha-response=${userRegister.recaptcha}`);
+      const {recaptcha, passwordRepeat, ...request} = userRegister;
+      registerService.register(request, recaptcha);
+      const req = http.expectOne(`api/v1/register?g-recaptcha-response=${recaptcha}`);
       req.flush({email: ['Invalid email']}, {status: 400, statusText: 'Bad Request'});
 
       registerQuery.selectError().subscribe(error => {
@@ -74,7 +76,8 @@ describe('RegisterService', () => {
 
     it('should handle other errors', (done) => {
       const userRegister = RegisterFactory.build();
-      registerService.register(userRegister);
+      const {recaptcha, passwordRepeat, ...request} = userRegister;
+      registerService.register(request, recaptcha);
       const req = http.expectOne(`api/v1/register?g-recaptcha-response=${userRegister.recaptcha}`);
       req.flush('Server Failed', {status: 500, statusText: 'Server Error'});
 

--- a/s4e-web/src/app/views/settings/admin-dashboard/admin-dashboard.component.html
+++ b/s4e-web/src/app/views/settings/admin-dashboard/admin-dashboard.component.html
@@ -30,7 +30,7 @@
         routerLink="../groups"
         queryParamsHandling="merge"
         class="button button--secondary button--small"
-        [disabled]="!(hasSelectedInstitution$ | async)"
+        [disabled]="!(isInstitutionActive$ | async)"
         footer-navigation
       >
         Zarządzaj

--- a/s4e-web/src/app/views/settings/admin-dashboard/admin-dashboard.component.ts
+++ b/s4e-web/src/app/views/settings/admin-dashboard/admin-dashboard.component.ts
@@ -15,7 +15,7 @@ import { InstitutionsSearchResultsStore } from '../state/institutions-search/ins
   styleUrls: ['./admin-dashboard.component.scss']
 })
 export class AdminDashboardComponent implements OnInit {
-  public hasSelectedInstitution$: Observable<boolean>;
+  public isInstitutionActive$: Observable<boolean>;
   public searchValue: string = '';
 
   constructor(
@@ -28,8 +28,8 @@ export class AdminDashboardComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.hasSelectedInstitution$ = this.institutionsSearchResultsQuery
-      .hasInstitutionSlugIn$(this._activatedRoute);
+    this.isInstitutionActive$ = this.institutionsSearchResultsQuery
+      .isAnyInstitutionActive$(this._activatedRoute);
 
     if (environment.hmr) {
       const searchResult = this.institutionsSearchResultsQuery.getValue().searchResult;

--- a/s4e-web/src/app/views/settings/dashboard/dashboard.component.html
+++ b/s4e-web/src/app/views/settings/dashboard/dashboard.component.html
@@ -13,7 +13,7 @@
         routerLink="../people"
         queryParamsHandling="merge"
         class="button button--secondary"
-        [disabled]="!(hasSelectedInstitution$ | async)"
+        [disabled]="!(isInstitutionActive$ | async)"
         footer-navigation
       >
         Zarządzaj ludźmi
@@ -28,7 +28,7 @@
         routerLink="../institution"
         queryParamsHandling="merge"
         class="button button--secondary"
-        [disabled]="!(hasSelectedInstitution$ | async)"
+        [disabled]="!(isInstitutionActive$ | async)"
         footer-navigation
       >
         Zobacz profil

--- a/s4e-web/src/app/views/settings/dashboard/dashboard.component.ts
+++ b/s4e-web/src/app/views/settings/dashboard/dashboard.component.ts
@@ -1,5 +1,3 @@
-import { map } from 'rxjs/operators';
-import { InstitutionService } from './../state/institution/institution.service';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Component, OnDestroy, OnInit } from '@angular/core';
@@ -10,16 +8,14 @@ import { InstitutionsSearchResultsQuery } from '../state/institutions-search/ins
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss']
 })
-export class DashboardComponent implements OnInit {
-  public hasSelectedInstitution$: Observable<boolean>;
+export class DashboardComponent {
+  public isInstitutionActive$: Observable<boolean>;
 
   constructor(
     private _institutionsSearchResultsQuery: InstitutionsSearchResultsQuery,
     private _activatedRoute: ActivatedRoute
-  ) {}
-
-  ngOnInit() {
-    this.hasSelectedInstitution$ = this._institutionsSearchResultsQuery
-      .hasInstitutionSlugIn$(this._activatedRoute);
+  ) {
+    this.isInstitutionActive$ = this._institutionsSearchResultsQuery
+      .isAnyInstitutionActive$(this._activatedRoute);
   }
 }

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.html
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.html
@@ -35,7 +35,7 @@
     <button
       class="button button--secondary button--small"
       [routerLink]="['/settings/add-institution']"
-      [queryParams]="{'addChild': true}"
+      [queryParams]="{'add_child': true}"
       queryParamsHandling="merge"
       i18n
     >

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.spec.ts
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.spec.ts
@@ -6,51 +6,43 @@ import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core
 
 import { InstitutionProfileComponent } from './institution-profile.component';
 import { InstitutionProfileModule } from './institution-profile.module';
-import { convertToParamMap, ParamMap, ActivatedRoute } from '@angular/router';
+import { convertToParamMap, ParamMap, ActivatedRoute, Router } from '@angular/router';
 import { Subject, ReplaySubject, of } from 'rxjs';
 import { DebugElement } from '@angular/core';
 import { S4eConfig } from 'src/app/utils/initializer/config.service';
 import { InstitutionService } from '../state/institution/institution.service';
-
-class ActivatedRouteStub {
-  queryParamMap: Subject<ParamMap> = new ReplaySubject(1);
-  snapshot = {};
-
-  constructor() {
-    this.queryParamMap.next(convertToParamMap({}));
-  }
-}
+import { InjectorModule } from 'src/app/common/injector.module';
 
 describe('InstitutionProfileComponent', () => {
   let component: InstitutionProfileComponent;
   let fixture: ComponentFixture<InstitutionProfileComponent>;
-  let activatedRoute: ActivatedRouteStub;
   let institutionService: InstitutionService;
+  let route: ActivatedRoute;
+  let router: Router;
   let de: DebugElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
+        InjectorModule,
         InstitutionProfileModule,
         HttpClientTestingModule,
         RouterTestingModule
       ],
       providers: [
-        {provide: ActivatedRoute, useClass: ActivatedRouteStub},
         S4eConfig
       ]
     })
     .compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(InstitutionProfileComponent);
     component = fixture.componentInstance;
-    activatedRoute = <ActivatedRouteStub>TestBed.get(ActivatedRoute);
+    route = TestBed.get(ActivatedRoute);
+    router = TestBed.get(Router);
     institutionService = TestBed.get(InstitutionService);
     de = fixture.debugElement;
     fixture.detectChanges();
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
@@ -59,7 +51,15 @@ describe('InstitutionProfileComponent', () => {
   it('Should display institution on init', fakeAsync(() => {
     const institution = InstitutionFactory.build();
     const spyFindBy = spyOn(institutionService, 'findBy').and.returnValue(of(institution));
-    activatedRoute.queryParamMap.next(convertToParamMap({ institution: institution.slug }));
+    router.navigate(
+      [],
+      {
+        relativeTo: route,
+        queryParams: { institution: institution.slug },
+        queryParamsHandling: 'merge',
+        skipLocationChange: true
+      }
+    );
     tick();
     fixture.detectChanges();
 

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.ts
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.ts
@@ -30,7 +30,7 @@ export class InstitutionProfileComponent implements OnInit, OnDestroy {
     this.isLoading$ = this._institutionQuery.selectLoading();
     this.institutions$ = combineLatest(
       this._institutionQuery.selectAll(),
-      this._institutionsSearchResultsQuery.getInstitutionFrom$(this._activatedRoute)
+      this._institutionsSearchResultsQuery.selectActive$(this._activatedRoute)
     )
       .pipe(
         filter(([institutions, parentInstitution]) => !!parentInstitution && !!institutions && institutions.length > 0),
@@ -41,7 +41,7 @@ export class InstitutionProfileComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this._institutionsSearchResultsQuery
-      .getInstitutionFrom$(this._activatedRoute)
+      .selectActive$(this._activatedRoute)
       .pipe(untilDestroyed(this))
       .subscribe(institution => this.activeInstitution = institution);
   }

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.spec.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.spec.ts
@@ -11,6 +11,7 @@ import { InstitutionFormComponent } from './institution-form.component';
 import { S4eConfig } from 'src/app/utils/initializer/config.service';
 import { Data, ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
 import { InstitutionProfileComponent } from '../../intitution-profile/institution-profile.component';
+import { InjectorModule } from 'src/app/common/injector.module';
 
 class ActivatedRouteStub {
   queryParamMap: Subject<ParamMap> = new ReplaySubject(1);
@@ -31,6 +32,7 @@ describe('InstitutionFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
+        InjectorModule,
         ManageInstitutionsModule,
         InstitutionProfileModule,
         RouterTestingModule

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.ts
@@ -21,7 +21,7 @@ import {InstitutionQuery} from '../../state/institution/institution.query';
 import {Institution} from '../../state/institution/institution.model';
 import {InstitutionService} from '../../state/institution/institution.service';
 import {File, ImageBase64} from './files.utils';
-import {combineLatest} from 'rxjs';
+import {combineLatest, of} from 'rxjs';
 import {ADD_INSTITUTION_PATH, INSTITUTION_PROFILE_PATH, INSTITUTIONS_LIST_PATH} from '../../settings.breadcrumbs';
 
 @Component({
@@ -156,8 +156,8 @@ export class InstitutionFormComponent extends GenericFormComponent<InstitutionQu
 
   protected _updateFormState() {
     combineLatest(
-      this._institutionsSearchResultsQuery.getInstitutionFrom$(this._activatedRoute),
-      this._institutionsSearchResultsQuery.addChild$(this._activatedRoute),
+      this._institutionsSearchResultsQuery.selectActive$(this._activatedRoute),
+      this._institutionsSearchResultsQuery.isChildAddition$(this._activatedRoute),
       this._breadcrumbService.breadcrumbs$,
       this._activatedRoute.data
     )

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-list/institution-list.component.html
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-list/institution-list.component.html
@@ -5,7 +5,7 @@
   <ng-container add-button>
     <button class="button button--secondary button--small" data-e2e="addInstitution"
             routerLink="../add-institution"
-            [queryParams]="{'addChild': null}"
+            [queryParams]="{'add_child': null}"
             queryParamsHandling="merge" i18n>Dodaj nową instytucję</button>
   </ng-container>
   <ng-container description></ng-container>

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form-modal.model.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form-modal.model.ts
@@ -1,7 +1,13 @@
+import { Institution } from 'src/app/views/settings/state/institution/institution.model';
 import {Modal} from '../../../../modal/state/modal.model';
 
 export const INVITATION_FORM_MODAL_ID = 'person-form-modal';
 
+export interface InvitationFormModal extends Modal {
+  institution: Institution;
+}
+
 export function isInvitationFormModal(modal: Modal): modal is Modal {
-  return modal.id === INVITATION_FORM_MODAL_ID;
+  return modal.id === INVITATION_FORM_MODAL_ID
+    && (modal as InvitationFormModal).institution != null;
 }

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.spec.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.spec.ts
@@ -8,10 +8,11 @@ import { InvitationFormComponent } from './invitation-form.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { S4eConfig } from 'src/app/utils/initializer/config.service';
 import { MODAL_DEF } from 'src/app/modal/modal.providers';
-import { INVITATION_FORM_MODAL_ID } from './invitation-form-modal.model';
+import { INVITATION_FORM_MODAL_ID, InvitationFormModal } from './invitation-form-modal.model';
 import { Subject, ReplaySubject, of } from 'rxjs';
 import { InstitutionsSearchResultsStore } from '../../state/institutions-search/institutions-search-results.store';
 import { InstitutionService } from '../../state/institution/institution.service';
+import { InjectorModule } from 'src/app/common/injector.module';
 
 class ActivatedRouteStub {
   queryParamMap: Subject<ParamMap>;
@@ -27,11 +28,11 @@ describe('InvitationFormComponent', () => {
   let fixture: ComponentFixture<InvitationFormComponent>;
   let invitationService: InvitationService;
   let route: ActivatedRouteStub;
-  let institutionQuery: InstitutionsSearchResultsQuery;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
+        InjectorModule,
         PeopleModule,
         HttpClientTestingModule,
         RouterTestingModule,
@@ -43,7 +44,8 @@ describe('InvitationFormComponent', () => {
           useValue: {
               id: INVITATION_FORM_MODAL_ID,
               size: 'lg',
-            }
+              institution: {name: 'test', slug: 'test'}
+            } as InvitationFormModal
         },
         S4eConfig
       ]

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.ts
@@ -1,9 +1,10 @@
+import { InjectorModule } from 'src/app/common/injector.module';
 import { Validators } from '@angular/forms';
 import { NotificationService } from './../../../../../../projects/notifications/src/lib/state/notification.service';
 import { InvitationService } from './../state/invitation.service';
 import { Institution } from './../../state/institution/institution.model';
 import { Modal } from '../../../../modal/state/modal.model';
-import { INVITATION_FORM_MODAL_ID, isInvitationFormModal } from './invitation-form-modal.model';
+import { INVITATION_FORM_MODAL_ID, isInvitationFormModal, InvitationFormModal } from './invitation-form-modal.model';
 import { ModalQuery } from 'src/app/modal/state/modal.query';
 import { ModalService } from 'src/app/modal/state/modal.service';
 import {Component, Inject} from '@angular/core';
@@ -28,7 +29,7 @@ export class InvitationFormComponent extends FormModalComponent<'invitation'> {
   form: FormGroup<InvitationForm>;
   modalId = INVITATION_FORM_MODAL_ID;
 
-  institution: Institution = null;
+  institution: Institution;
 
   constructor(
     fm: AkitaNgFormsManager<FormState>,
@@ -36,14 +37,15 @@ export class InvitationFormComponent extends FormModalComponent<'invitation'> {
     private _institutionsSearchResultsQuery: InstitutionsSearchResultsQuery,
     private _invitationService: InvitationService,
     private _route: ActivatedRoute,
-    private _activatedRoute: ActivatedRoute,
     private _modalService: ModalService,
     private _modalQuery: ModalQuery,
     private _notificationService: NotificationService,
-    @Inject(MODAL_DEF) modal: Modal
+    @Inject(MODAL_DEF) modal: InvitationFormModal
   ) {
     super(fm, _modalService, _modalQuery, INVITATION_FORM_MODAL_ID, 'invitation');
     assertModalType(isInvitationFormModal, modal);
+
+    this.institution = modal.institution;
   }
 
   makeForm(): FormGroup<InvitationForm> {
@@ -52,21 +54,16 @@ export class InvitationFormComponent extends FormModalComponent<'invitation'> {
     });
   }
 
-  ngOnInit() {
-    this._institutionsSearchResultsQuery
-      .getInstitutionFrom$(this._activatedRoute)
-      .pipe(untilDestroyed(this))
-      .subscribe(institution => this.institution = institution);
-
-    super.ngOnInit();
-  }
-
   create() {
     if (!this.institution) {
       this._notificationService.addGeneral({
-        content: 'Please select institution before inviting someone',
+        content: `
+          Institution isn't selected,
+          please refresh page or contact admins if error still occurs
+        `,
         type: 'error'
       });
+      return;
     }
 
     validateAllFormFields(this.form);

--- a/s4e-web/src/app/views/settings/people/state/invitation.service.ts
+++ b/s4e-web/src/app/views/settings/people/state/invitation.service.ts
@@ -1,6 +1,15 @@
+import { Institution } from './../../state/institution/institution.model';
+import { S4eConfig } from './../../../../utils/initializer/config.service';
 import { NotificationService } from './../../../../../../projects/notifications/src/lib/state/notification.service';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { ParamMap, Route, Router, ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
+import { SessionQuery } from 'src/app/state/session/session.query';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export const TOKEN_QUERY_PARAMETER = 'token';
+export const REJECTION_QUERY_PARAMETER = 'reject';
 
 @Injectable({
   providedIn: 'root'
@@ -8,14 +17,65 @@ import { HttpClient } from '@angular/common/http';
 export class InvitationService {
   constructor(
     private _http: HttpClient,
-    private _notificationService: NotificationService
+    private _notificationService: NotificationService,
+    private _sessionQuery: SessionQuery,
+    private _router: Router,
+    private _activatedRoute: ActivatedRoute
   ) {}
 
-  get(): void {}
-  create(institutionSlug: string, email: string): void {
-    const url = `/institutions/${institutionSlug}/invitations`;
-    this._http.post(url, {email}).subscribe();
+  public get(): void {}
+
+  public create(institutionSlug: string, email: string): void {
+    const notificationMessage = 'Zaproszenie zostało wysłane';
+    const url = `/api/v1/institutions/${institutionSlug}/invitations`;
+    this._http.post(url, {email})
+      .subscribe(() => this._notificationService.addGeneral({
+        content: notificationMessage,
+        type: 'success'
+      }));
   }
-  accept(): void {}
-  reject(): void {}
+
+  public accept(token: string): void {
+    const notificationMessage = 'Zostałeś dodany do instytucji';
+    const url = `/api/v1/invitations/${token}/confirm`;
+    this._http.post<Institution>(url, {})
+      .subscribe((institution: Institution) => {
+        this._router.navigate(
+          ['/settings/institution'],
+          {
+            queryParams: {
+              institution: institution.slug
+            }
+          }
+        )
+        .then(() => this._notificationService.addGeneral({
+          content: notificationMessage,
+          type: 'success'
+        }));
+      });
+  }
+
+  public reject(token: string): void {
+    const notificationMessage = 'Twoje zaproszenie zostało poprawnie odrzucone';
+    const url = `/api/v1/invitations/${token}/reject`;
+    this._http.put(url, {})
+      .subscribe(() => {
+        this._notificationService.addGeneral({
+          content: notificationMessage,
+          type: 'success'
+        });
+        this._router.navigate(['.']);
+      });
+  }
+
+  public handleInvitation(next: ActivatedRouteSnapshot) {
+    const token = next.queryParamMap.get(TOKEN_QUERY_PARAMETER);
+
+    const isRejected = next.queryParamMap.has(REJECTION_QUERY_PARAMETER);
+    if (isRejected) {
+      this.reject(token);
+    }
+
+    this.accept(token);
+  }
 }

--- a/s4e-web/src/app/views/settings/settings.component.html
+++ b/s4e-web/src/app/views/settings/settings.component.html
@@ -48,7 +48,7 @@
         <a
           [routerLink]="['./people']"
           queryParamsHandling="merge"
-          [class.disabled]="!(hasSelectedInstitution$ | async)"
+          [class.disabled]="!(isInstitutionActive$ | async)"
           i18n
         >
           Ludzie
@@ -58,7 +58,7 @@
         <a
           [routerLink]="['./institution']"
           queryParamsHandling="merge"
-          [class.disabled]="!(hasSelectedInstitution$ | async)"
+          [class.disabled]="!(isInstitutionActive$ | async)"
           i18n
         >
           Profil Instytucji
@@ -68,7 +68,7 @@
     <section class="login">
       <ul>
         <li>
-          <button [routerLink]="['/']" i18n class="button button--borderPrimary button--small">Wróć do mapy</button>
+          <button [routerLink]="['/map/products']" i18n class="button button--borderPrimary button--small">Wróć do mapy</button>
         </li>
         <li>
           <a href="javascript:void(0)" routerLink="/logout" i18n>Wyloguj</a>

--- a/s4e-web/src/app/views/settings/settings.component.ts
+++ b/s4e-web/src/app/views/settings/settings.component.ts
@@ -1,3 +1,4 @@
+import { InstitutionQuery } from './state/institution/institution.query';
 import { InstitutionsSearchResultsStore } from './state/institutions-search/institutions-search-results.store';
 import {InstitutionService} from './state/institution/institution.service';
 import {Component, OnInit} from '@angular/core';
@@ -20,11 +21,12 @@ export class SettingsComponent implements OnInit {
 
   public searchValue: string;
 
-  public hasSelectedInstitution$: Observable<boolean>;
+  public isInstitutionActive$: Observable<boolean>;
 
   constructor(
     private _institutionsSearchResultsService: InstitutionsSearchResultsService,
     private _institutionService: InstitutionService,
+    private _institutionQuery: InstitutionQuery,
     private _sessionQuery: SessionQuery,
     private _router: Router,
     private _activatedRoute: ActivatedRoute,
@@ -36,8 +38,8 @@ export class SettingsComponent implements OnInit {
   ngOnInit() {
     this.showInstitutions$ = this._sessionQuery.selectCanSeeInstitutions();
 
-    this.hasSelectedInstitution$ = this.institutionsSearchResultsQuery
-      .hasInstitutionSlugIn$(this._activatedRoute);
+    this.isInstitutionActive$ = this.institutionsSearchResultsQuery
+      .isAnyInstitutionActive$(this._activatedRoute);
 
     // TODO: set institution from storage
     if (environment.hmr) {


### PR DESCRIPTION
Source: #483 

Due to error with notifications, they don't work:
[Fix] Notification don't appear on the screen #651

#### UI
- [x] Confirm invitation after authentication of user
  - [x] Add a notification `Zaloguj się lub zarejestruj by dołączyć do instytucji` if url contain token
  - [x] Move to `/settings/institution-profile` with active new `institution`
- [x] Reject invitation
  - [x] Add notification `Zostałeś poprawnie usunięty z listy zaproszeń` after redirect from rejecton url
  - [x] Clear query params from url after rejection action (so user wouldn't confirm it after rejection)


#### Backend
- [x] change prefix for `localhost` instance from `http` to `https`

Close #625 