### PR TITLE
[#620] Admin Scene controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Admin endpoints for Scenes management [#620](https://github.com/cyfronet-fid/sat4envi/issues/620)
 - Confirm or reject invitation with email URLs [#625](https://github.com/cyfronet-fid/sat4envi/issues/625)
 
 ### Changed
@@ -35,8 +36,6 @@ The most recent changes are on top, in each type of changes category.
 ### Fixed
 
 - Improve scene time filtering performance [#610](https://github.com/cyfronet-fid/sat4envi/issues/610)
-
-### Updated
 
 ## [v9.1.0]
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
         <geotools.version>23.1</geotools.version>
         <greenmail.version>1.5.14</greenmail.version>
         <guava.version>29.0-jre</guava.version>
-        <jjwt.version>0.11.2</jjwt.version>
         <hibernate-types.version>2.9.12</hibernate-types.version>
+        <jjwt.version>0.11.2</jjwt.version>
+        <mapstruct.version>1.4.0.Beta3</mapstruct.version>
         <poiooxml.version>4.1.2</poiooxml.version>
         <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
         <slugify.version>2.4</slugify.version>

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -116,6 +116,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
             <version>${geotools.version}</version>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/product/AdminProductController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/product/AdminProductController.java
@@ -2,7 +2,6 @@ package pl.cyfronet.s4e.admin.product;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.BeanUtils;
 import org.springframework.web.bind.annotation.*;
 import pl.cyfronet.s4e.ex.NotFoundException;
 import pl.cyfronet.s4e.ex.product.ProductDeletionException;
@@ -21,11 +20,11 @@ import static pl.cyfronet.s4e.Constants.ADMIN_PREFIX;
 @RequiredArgsConstructor
 public class AdminProductController {
     private final ProductService productService;
+    private final AdminProductMapper adminProductMapper;
 
     @PostMapping(consumes = APPLICATION_JSON_VALUE)
     public AdminProductResponse create(@RequestBody @Valid AdminCreateProductRequest request) throws ProductException {
-        ProductService.DTO dto = ProductService.DTO.builder().build();
-        BeanUtils.copyProperties(request, dto);
+        ProductService.DTO dto = adminProductMapper.toProductServiceDTO(request);
         Long newId = productService.create(dto);
         return productService.findByIdFetchSchemas(newId, AdminProductResponse.class).get();
     }
@@ -42,9 +41,11 @@ public class AdminProductController {
     }
 
     @PatchMapping(path = "/{id}", consumes = APPLICATION_JSON_VALUE)
-    public AdminProductResponse update(@PathVariable Long id, @RequestBody @Valid AdminUpdateProductRequest request) throws NotFoundException, ProductException {
-        ProductService.DTO dto = ProductService.DTO.builder().build();
-        BeanUtils.copyProperties(request, dto);
+    public AdminProductResponse update(
+            @PathVariable Long id,
+            @RequestBody @Valid AdminUpdateProductRequest request
+    ) throws NotFoundException, ProductException {
+        ProductService.DTO dto = adminProductMapper.toProductServiceDTO(request);
         productService.update(id, dto);
         return productService.findByIdFetchSchemas(id, AdminProductResponse.class).get();
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/product/AdminProductController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/product/AdminProductController.java
@@ -1,5 +1,9 @@
 package pl.cyfronet.s4e.admin.product;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +26,13 @@ public class AdminProductController {
     private final ProductService productService;
     private final AdminProductMapper adminProductMapper;
 
+    @Operation(summary = "Create Product")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
     @PostMapping(consumes = APPLICATION_JSON_VALUE)
     public AdminProductResponse create(@RequestBody @Valid AdminCreateProductRequest request) throws ProductException {
         ProductService.DTO dto = adminProductMapper.toProductServiceDTO(request);
@@ -29,17 +40,38 @@ public class AdminProductController {
         return productService.findByIdFetchSchemas(newId, AdminProductResponse.class).get();
     }
 
+    @Operation(summary = "List Products")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
     @GetMapping
     public List<AdminProductResponse> list() {
         return productService.findAllFetchSchemas(AdminProductResponse.class);
     }
 
+    @Operation(summary = "Return Product")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Product doesn't exist", content = @Content)
+    })
     @GetMapping("/{id}")
     public AdminProductResponse read(@PathVariable Long id) throws NotFoundException {
         return productService.findByIdFetchSchemas(id, AdminProductResponse.class)
                 .orElseThrow(() -> new NotFoundException("Product not found for id '" + id + "'"));
     }
 
+    @Operation(summary = "Update Product")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Product doesn't exist", content = @Content)
+    })
     @PatchMapping(path = "/{id}", consumes = APPLICATION_JSON_VALUE)
     public AdminProductResponse update(
             @PathVariable Long id,
@@ -50,6 +82,14 @@ public class AdminProductController {
         return productService.findByIdFetchSchemas(id, AdminProductResponse.class).get();
     }
 
+    @Operation(summary = "Delete Product")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "There are existing references to the Product", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Product doesn't exist", content = @Content)
+    })
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) throws NotFoundException, ProductDeletionException {
         productService.delete(id);

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/product/AdminProductMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/product/AdminProductMapper.java
@@ -1,0 +1,11 @@
+package pl.cyfronet.s4e.admin.product;
+
+import org.mapstruct.Mapper;
+import pl.cyfronet.s4e.config.MapStructCentralConfig;
+import pl.cyfronet.s4e.service.ProductService;
+
+@Mapper(config = MapStructCentralConfig.class)
+public interface AdminProductMapper {
+    ProductService.DTO toProductServiceDTO(AdminCreateProductRequest request);
+    ProductService.DTO toProductServiceDTO(AdminUpdateProductRequest request);
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneController.java
@@ -1,0 +1,102 @@
+package pl.cyfronet.s4e.admin.scene;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
+import org.springframework.web.bind.annotation.*;
+import pl.cyfronet.s4e.ex.NotFoundException;
+import pl.cyfronet.s4e.service.SceneService;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static pl.cyfronet.s4e.Constants.ADMIN_PREFIX;
+
+@RestController
+@RequestMapping(path = ADMIN_PREFIX, produces = APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Tag(name = "admin-scene", description = "The Admin Scene API")
+public class AdminSceneController {
+    private static final String DEFAULT_SORT = "timestamp";
+
+    private final SceneService sceneService;
+
+    private final AdminSceneMapper adminSceneMapper;
+
+    @Operation(summary = "Return Scene")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Scene doesn't exist", content = @Content)
+    })
+    @GetMapping("/scenes/{id}")
+    public AdminSceneResponse read(@PathVariable Long id) throws NotFoundException {
+        return sceneService.findById(id, AdminSceneProjection.class)
+                .map(adminSceneMapper::projectionToResponse)
+                .orElseThrow(() -> new NotFoundException("Scene with id '" + id + "' not found"));
+    }
+
+    @Operation(summary = "Return Scenes")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @PageableAsQueryParam
+    @GetMapping("/scenes")
+    public Page<AdminSceneResponse> list(
+            @Parameter(hidden = true) @SortDefault(sort = DEFAULT_SORT, direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return sceneService.list(pageable, AdminSceneProjection.class)
+                .map(adminSceneMapper::projectionToResponse);
+    }
+
+    @Operation(summary = "Return Scenes by Product")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Product doesn't exist", content = @Content)
+    })
+    @PageableAsQueryParam
+    @GetMapping("/products/{productId}/scenes")
+    public Page<AdminSceneResponse> listByProduct(
+            @PathVariable Long productId,
+            @Parameter(hidden = true) @SortDefault(sort = DEFAULT_SORT, direction = Sort.Direction.DESC) Pageable pageable
+    ) throws NotFoundException {
+        return sceneService.listByProduct(productId, pageable, AdminSceneProjection.class)
+                .map(adminSceneMapper::projectionToResponse);
+    }
+
+    @Operation(summary = "Delete Scene")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Scene doesn't exist", content = @Content)
+    })
+    @DeleteMapping("/scenes/{id}")
+    public void delete(@PathVariable Long id) throws NotFoundException {
+        sceneService.delete(id);
+    }
+
+    @Operation(summary = "Delete all Scenes of a Product")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Product doesn't exist", content = @Content)
+    })
+    @DeleteMapping("/products/{productId}/scenes")
+    public void deleteProductScenes(@PathVariable Long productId) throws NotFoundException {
+        sceneService.deleteProductScenes(productId);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneMapper.java
@@ -1,0 +1,38 @@
+package pl.cyfronet.s4e.admin.scene;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.locationtech.jts.geom.Geometry;
+import org.mapstruct.Mapper;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.operation.TransformException;
+import org.springframework.beans.factory.annotation.Autowired;
+import pl.cyfronet.s4e.config.MapStructCentralConfig;
+import pl.cyfronet.s4e.util.GeometryUtil;
+
+@Mapper(config = MapStructCentralConfig.class)
+@Slf4j
+public abstract class AdminSceneMapper {
+    @Autowired
+    private GeometryUtil geometryUtil;
+
+    public abstract AdminSceneResponse projectionToResponse(AdminSceneProjection sceneProjection);
+
+    protected AdminSceneResponse.FootprintPart geometryToFootprintPart(Geometry geometry3857) {
+        if (geometry3857 == null) {
+            return null;
+        }
+
+        val footprintPart = new AdminSceneResponse.FootprintPart();
+
+        footprintPart.setEpsg3857(geometry3857.toText());
+        try {
+            Geometry geometry4326 = geometryUtil.transform(geometry3857, "EPSG:3857", "EPSG:4326");
+            footprintPart.setEpsg4326(geometry4326.toText());
+        } catch (FactoryException | TransformException e) {
+            log.info("Cannot transform geometry to EPSG:4326: '" + geometry3857.toText() + "'", e);
+        }
+
+        return footprintPart;
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneProjection.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneProjection.java
@@ -1,0 +1,25 @@
+package pl.cyfronet.s4e.admin.scene;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.locationtech.jts.geom.Geometry;
+import pl.cyfronet.s4e.bean.Legend;
+
+import java.time.LocalDateTime;
+
+public interface AdminSceneProjection {
+    interface ProductProjection {
+        Long getId();
+        String getName();
+    }
+
+    Long getId();
+    ProductProjection getProduct();
+    String getSceneKey();
+    LocalDateTime getTimestamp();
+    String getS3Path();
+    String getGranulePath();
+    Geometry getFootprint();
+    Legend getLegend();
+    JsonNode getSceneContent();
+    JsonNode getMetadataContent();
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneResponse.java
@@ -1,0 +1,33 @@
+package pl.cyfronet.s4e.admin.scene;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Data;
+import pl.cyfronet.s4e.bean.Legend;
+
+import java.time.LocalDateTime;
+
+@Data
+class AdminSceneResponse {
+    @Data
+    public static class ProductPart {
+        private Long id;
+        private String name;
+    }
+
+    @Data
+    public static class FootprintPart {
+        private String epsg3857;
+        private String epsg4326;
+    }
+
+    private Long id;
+    private ProductPart product;
+    private String sceneKey;
+    private LocalDateTime timestamp;
+    private String s3Path;
+    private String granulePath;
+    private FootprintPart footprint;
+    private Legend legend;
+    private JsonNode sceneContent;
+    private JsonNode metadataContent;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/api/OSearchController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/api/OSearchController.java
@@ -51,7 +51,7 @@ public class OSearchController {
         // TODO: format
         try {
             return searchService.getScenesBy(searchService.parseToParamMap(rowsSize, rowStart, orderby, query)).stream()
-                    .map(scene -> responseExtender.map(scene, timeZone.getZoneId()))
+                    .map(scene -> responseExtender.toResponse(scene, timeZone.getZoneId()))
                     .collect(Collectors.toList());
         } catch (DateTimeParseException e) {
             throw new BadRequestException("Cannot parse date: " + e.getParsedString());

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/api/ResponseExtender.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/api/ResponseExtender.java
@@ -18,6 +18,8 @@ import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
+import static pl.cyfronet.s4e.bean.Schema.SCENE_SCHEMA_ARTIFACTS_KEY;
+
 @Mapper(config = MapStructCentralConfig.class)
 @Slf4j
 public abstract class ResponseExtender {
@@ -40,7 +42,7 @@ public abstract class ResponseExtender {
         }
 
         try {
-            JsonNode artifactsNode = objectMapper.readTree(sceneContent).get("artifacts");
+            JsonNode artifactsNode = objectMapper.readTree(sceneContent).get(SCENE_SCHEMA_ARTIFACTS_KEY);
             return getKeys(artifactsNode);
         } catch (JsonProcessingException e) {
             log.warn("Cannot parse scene content", e);

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
@@ -16,7 +16,7 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class AppUser extends CreationAndModificationAudited {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Institution.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Institution.java
@@ -15,6 +15,7 @@ import javax.validation.constraints.NotEmpty;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 @Table(name = "institution", uniqueConstraints = @UniqueConstraint(columnNames = {"name", "slug"}))
 public class Institution extends CreationAndModificationAudited {
     @Id

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Invitation.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Invitation.java
@@ -12,6 +12,7 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class Invitation extends CreationAndModificationAudited {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Product.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Product.java
@@ -24,7 +24,7 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class Product extends CreationAndModificationAudited {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Scene.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Scene.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class Scene extends CreationAndModificationAudited {
     public static final String COLUMN_ID = "id";
     public static final String COLUMN_PRODUCT_ID = "product_id";

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Schema.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Schema.java
@@ -1,9 +1,6 @@
 package pl.cyfronet.s4e.bean;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import pl.cyfronet.s4e.bean.audit.CreationAudited;
 
 import javax.persistence.*;
@@ -15,6 +12,7 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class Schema extends CreationAudited {
     public enum Type {
         SCENE, METADATA;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Schema.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Schema.java
@@ -14,6 +14,8 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 public class Schema extends CreationAudited {
+    public static final String SCENE_SCHEMA_ARTIFACTS_KEY = "artifacts";
+
     public enum Type {
         SCENE, METADATA;
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/UserRole.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/UserRole.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @Table(name = "user_role", uniqueConstraints = @UniqueConstraint(columnNames = {"role", "app_user_id", "inst_group_id"}))
 public class UserRole extends CreationAudited {
     @Id

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/MapStructCentralConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/MapStructCentralConfig.java
@@ -1,0 +1,13 @@
+package pl.cyfronet.s4e.config;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+
+@MapperConfig(
+        componentModel = "spring",
+        typeConversionPolicy = ReportingPolicy.WARN,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
+public interface MapStructCentralConfig {
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SearchController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SearchController.java
@@ -42,7 +42,7 @@ public class SearchController {
             throws SQLException, QueryException {
         ZoneId zoneId = ZoneId.of(String.valueOf(params.getOrDefault("timeZone", "UTC")));
             return searchService.getScenesBy(params).stream()
-                    .map(scene -> responseExtender.map(scene, zoneId))
+                    .map(scene -> responseExtender.toResponse(scene, zoneId))
                     .collect(Collectors.toList());
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/SceneResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/SceneResponse.java
@@ -3,25 +3,30 @@ package pl.cyfronet.s4e.controller.response;
 import lombok.Builder;
 import lombok.Data;
 import pl.cyfronet.s4e.bean.Legend;
-import pl.cyfronet.s4e.bean.Scene;
-import pl.cyfronet.s4e.util.TimeHelper;
 
-import java.time.ZoneId;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.function.Function;
 
 @Data
 @Builder
 public class SceneResponse {
+    public interface Projection {
+        Long getId();
+        LocalDateTime getTimestamp();
+        Legend getLegend();
+    }
+
     private Long id;
     private Long productId;
     private ZonedDateTime timestamp;
     private Legend legend;
 
-    public static SceneResponse of(Scene scene, ZoneId zoneId, TimeHelper timeHelper) {
+    public static SceneResponse of(Long productId, Projection scene, Function<LocalDateTime, ZonedDateTime> timestampConverter) {
         return SceneResponse.builder()
                 .id(scene.getId())
-                .productId(scene.getProduct().getId())
-                .timestamp(timeHelper.getZonedDateTime(scene.getTimestamp(), zoneId))
+                .productId(productId)
+                .timestamp(timestampConverter.apply(scene.getTimestamp()))
                 .legend(scene.getLegend())
                 .build();
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
@@ -16,8 +16,8 @@ public interface SceneRepository extends JpaRepository<Scene, Long>, SceneReposi
 
     List<Scene> findAllByProductId(Long productId);
 
-    List<Scene> findAllByProductIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestampAsc(
-            Long productId, LocalDateTime start, LocalDateTime end
+    <T> List<T> findAllByProductIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestampAsc(
+            Long productId, LocalDateTime start, LocalDateTime end, Class<T> projection
     );
 
     int countAllByProductIdAndTimestampGreaterThanEqualAndTimestampLessThan(

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
@@ -1,5 +1,7 @@
 package pl.cyfronet.s4e.data.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 import pl.cyfronet.s4e.bean.Scene;
@@ -20,7 +22,14 @@ public interface SceneRepository extends JpaRepository<Scene, Long>, SceneReposi
             Long productId, LocalDateTime start, LocalDateTime end, Class<T> projection
     );
 
+    <T> Page<T> findAllBy(Pageable pageable, Class<T> projection);
+
+    <T> Page<T> findAllByProductId(Long productId, Pageable pageable, Class<T> projection);
+
     int countAllByProductIdAndTimestampGreaterThanEqualAndTimestampLessThan(
             Long productId, LocalDateTime start, LocalDateTime end
     );
+
+    @Transactional
+    void deleteAllByProductId(Long productId);
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/ProductMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/ProductMapper.java
@@ -1,0 +1,32 @@
+package pl.cyfronet.s4e.service;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import pl.cyfronet.s4e.bean.Product;
+import pl.cyfronet.s4e.config.MapStructCentralConfig;
+
+@Mapper(
+        config = MapStructCentralConfig.class,
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+)
+public interface ProductMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "sceneSchema", ignore = true)
+    @Mapping(target = "metadataSchema", ignore = true)
+    @Mapping(target = "scenes", ignore = true)
+    @Mapping(target = "favourites", ignore = true)
+    void create(ProductService.DTO dto, @MappingTarget Product.ProductBuilder productBuilder);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "sceneSchema", ignore = true)
+    @Mapping(target = "metadataSchema", ignore = true)
+    @Mapping(target = "scenes", ignore = true)
+    @Mapping(target = "favourites", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "lastModifiedAt", ignore = true)
+    @Mapping(target = "lastModifiedBy", ignore = true)
+    void update(ProductService.DTO dto, @MappingTarget Product product);
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/ProductService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/ProductService.java
@@ -63,6 +63,8 @@ public class ProductService {
 
     private final ObjectMapper objectMapper;
 
+    private final ProductMapper productMapper;
+
     public <T> List<T> findAll(Class<T> projection) {
         return productRepository.findAllBy(projection);
     }
@@ -81,13 +83,7 @@ public class ProductService {
 
     @Transactional
     public Long create(DTO dto) throws ProductException {
-        val productBuilder = Product.builder()
-                .name(dto.getName())
-                .displayName(dto.getDisplayName())
-                .description(dto.getDescription())
-                .legend(dto.getLegend())
-                .layerName(dto.getLayerName())
-                .granuleArtifactRule(dto.getGranuleArtifactRule());
+        val productBuilder = Product.builder();
 
         BindingResult bindingResult = new MapBindingResult(objectMapper.convertValue(dto, Map.class), "productCreateRequest");
         productBuilder.sceneSchema(findAndValidateSchema(
@@ -102,6 +98,7 @@ public class ProductService {
             throw new ProductValidationException(bindingResult);
         }
 
+        productMapper.create(dto, productBuilder);
         return productRepository.save(productBuilder.build()).getId();
     }
 
@@ -127,25 +124,7 @@ public class ProductService {
             throw new ProductValidationException(bindingResult);
         }
 
-        if (dto.getName() != null) {
-            product.setName(dto.getName());
-        }
-
-        if (dto.getDisplayName() != null) {
-            product.setDisplayName(dto.getDisplayName());
-        }
-
-        if (dto.getDescription() != null) {
-            product.setDescription(dto.getDescription());
-        }
-
-        if (dto.getLegend() != null) {
-            product.setLegend(dto.getLegend());
-        }
-
-        if (dto.getLayerName() != null) {
-            product.setLayerName(dto.getLayerName());
-        }
+        productMapper.update(dto, product);
 
         if (sceneSchema != null) {
             product.setSceneSchema(sceneSchema);
@@ -153,10 +132,6 @@ public class ProductService {
 
         if (metadataSchema != null) {
             product.setMetadataSchema(metadataSchema);
-        }
-
-        if (dto.getGranuleArtifactRule() != null) {
-            product.setGranuleArtifactRule(dto.getGranuleArtifactRule());
         }
     }
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneFileStorageService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneFileStorageService.java
@@ -10,6 +10,8 @@ import pl.cyfronet.s4e.ex.NotFoundException;
 
 import java.util.Map;
 
+import static pl.cyfronet.s4e.bean.Schema.SCENE_SCHEMA_ARTIFACTS_KEY;
+
 @Service
 @RequiredArgsConstructor
 public class SceneFileStorageService {
@@ -25,7 +27,7 @@ public class SceneFileStorageService {
         SceneProjection sceneProjection = sceneRepository.findById(id, SceneProjection.class)
                 .orElseThrow(() -> new NotFoundException("Scene with id '" + id + "' not found"));
         return  objectMapper.convertValue(
-                sceneProjection.getSceneContent().get("artifacts"),
+                sceneProjection.getSceneContent().get(SCENE_SCHEMA_ARTIFACTS_KEY),
                 new TypeReference<>() {});
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneService.java
@@ -3,8 +3,11 @@ package pl.cyfronet.s4e.service;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import pl.cyfronet.s4e.bean.Scene;
+import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.data.repository.SceneRepository;
+import pl.cyfronet.s4e.ex.NotFoundException;
 import pl.cyfronet.s4e.util.TimeHelper;
 
 import java.time.*;
@@ -15,15 +18,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SceneService {
     private final SceneRepository sceneRepository;
+    private final ProductRepository productRepository;
     private final TimeHelper timeHelper;
 
-    public List<Scene> getScenes(Long productId, LocalDateTime start, LocalDateTime end) {
+    public <T> List<T> list(Long productId, LocalDateTime start, LocalDateTime end, Class<T> projection) throws NotFoundException {
+        if (!productRepository.existsById(productId)) {
+            throw constructNFE("Product", productId);
+        }
         return sceneRepository.findAllByProductIdAndTimestampGreaterThanEqualAndTimestampLessThanOrderByTimestampAsc(
-                productId, start, end
+                productId, start, end, projection
         );
     }
 
-    public void saveScene(Scene scene) {
+    public void save(Scene scene) {
         sceneRepository.save(scene);
     }
 
@@ -46,5 +53,9 @@ public class SceneService {
         }
 
         return dates;
+    }
+
+    private NotFoundException constructNFE(String name, Long id) {
+        return new NotFoundException(name + " with id '" + id + "' not found");
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneService.java
@@ -2,6 +2,8 @@ package pl.cyfronet.s4e.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pl.cyfronet.s4e.bean.Scene;
@@ -13,6 +15,7 @@ import pl.cyfronet.s4e.util.TimeHelper;
 import java.time.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,8 +33,39 @@ public class SceneService {
         );
     }
 
+    public <T> Page<T> list(Pageable pageable, Class<T> projection) {
+        return sceneRepository.findAllBy(pageable, projection);
+    }
+
+    public <T> Page<T> listByProduct(Long productId, Pageable pageable, Class<T> projection) throws NotFoundException {
+        if (!productRepository.existsById(productId)) {
+            throw constructNFE("Product", productId);
+        }
+        return sceneRepository.findAllByProductId(productId, pageable, projection);
+    }
+
+    public <T> Optional<T> findById(Long id, Class<T> projection) {
+        return sceneRepository.findById(id, projection);
+    }
+
     public void save(Scene scene) {
         sceneRepository.save(scene);
+    }
+
+    @Transactional
+    public void delete(Long id) throws NotFoundException {
+        if (!sceneRepository.existsById(id)) {
+            throw constructNFE("Scene", id);
+        }
+        sceneRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void deleteProductScenes(Long productId) throws NotFoundException {
+        if (!productRepository.existsById(productId)) {
+            throw constructNFE("Product", productId);
+        }
+        sceneRepository.deleteAllByProductId(productId);
     }
 
     public List<LocalDate> getAvailabilityDates(Long productId, YearMonth yearMonth, ZoneId tz) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneStorage.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneStorage.java
@@ -15,6 +15,8 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 import java.net.URL;
 import java.time.Duration;
 
+import static pl.cyfronet.s4e.bean.Schema.SCENE_SCHEMA_ARTIFACTS_KEY;
+
 @Service
 public class SceneStorage extends Storage {
     private final S3Properties s3Properties;
@@ -72,7 +74,7 @@ public class SceneStorage extends Storage {
 
     public String getKey(SceneProjection sceneProjection, String type) {
         if (type != null) {
-            return sceneProjection.getSceneContent().get("artifacts").get(type).asText().substring(1);
+            return sceneProjection.getSceneContent().get(SCENE_SCHEMA_ARTIFACTS_KEY).get(type).asText().substring(1);
         }
         return sceneProjection.getS3Path();
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExist.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExist.java
@@ -16,12 +16,11 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static pl.cyfronet.s4e.bean.Schema.SCENE_SCHEMA_ARTIFACTS_KEY;
 import static pl.cyfronet.s4e.sync.Error.*;
 
 @Builder
 public class VerifyAllArtifactsExist<T extends BaseContext> implements Step<T, Error> {
-    public static final String SCENE_ARTIFACTS_PROPERTY = "artifacts";
-
     private final Supplier<SceneStorage> sceneStorage;
 
     private final Function<T, JsonObject> sceneJson;
@@ -36,7 +35,7 @@ public class VerifyAllArtifactsExist<T extends BaseContext> implements Step<T, E
 
         val artifacts = new HashMap<String, String>();
 
-        JsonObject artifactsObject = sceneJson.getJsonObject(SCENE_ARTIFACTS_PROPERTY);
+        JsonObject artifactsObject = sceneJson.getJsonObject(SCENE_SCHEMA_ARTIFACTS_KEY);
         Map<String, String> notFound = new LinkedHashMap<>();
         for (val entry : artifactsObject.entrySet()) {
             String name = entry.getKey();

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SceneTestHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SceneTestHelper.java
@@ -1,6 +1,9 @@
 package pl.cyfronet.s4e;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import pl.cyfronet.s4e.bean.Legend;
 import pl.cyfronet.s4e.bean.Product;
 import pl.cyfronet.s4e.bean.Scene;
 
@@ -27,14 +30,22 @@ public class SceneTestHelper {
                 .layerName(name.toLowerCase());
     }
 
+    @SneakyThrows
     public static Scene.SceneBuilder sceneBuilder(Product product) {
+        JsonNode sceneContent = new ObjectMapper().readTree("{\"key\":\"value\"}");
+        JsonNode metadataContent = new ObjectMapper().readTree("{\"key\":\"value\"}");
         return Scene.builder()
                 .product(product)
                 .sceneKey(nextUnique(SCENE_KEY_PATTERN))
                 .timestamp(LocalDateTime.now())
                 .s3Path("some/path")
                 .granulePath("mailto://s4e-test-1/some/path")
-                .footprint(TestGeometryHelper.ANY_POLYGON);
+                .footprint(TestGeometryHelper.ANY_POLYGON)
+                .legend(Legend.builder()
+                        .type("some_type")
+                        .build())
+                .sceneContent(sceneContent)
+                .metadataContent(metadataContent);
     }
 
     public static Scene.SceneBuilder sceneWithMetadataBuilder(Product product, JsonNode jsonNode) {
@@ -45,7 +56,10 @@ public class SceneTestHelper {
                 .s3Path("some/path")
                 .granulePath("mailto://s4e-test-1/some/path")
                 .metadataContent(jsonNode)
-                .footprint(TestGeometryHelper.ANY_POLYGON);
+                .footprint(TestGeometryHelper.ANY_POLYGON)
+                .legend(Legend.builder()
+                        .type("some_type")
+                        .build());
     }
 
     public static String getMetaDataWithNumber(long number) {

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SchemaTestHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SchemaTestHelper.java
@@ -1,0 +1,25 @@
+package pl.cyfronet.s4e;
+
+import pl.cyfronet.s4e.bean.Schema;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SchemaTestHelper {
+    public static final String SCHEMA_PATH_PREFIX = "classpath:schema/";
+    public static final List<String> SCENE_AND_METADATA_SCHEMA_NAMES = Stream.of(
+            "Sentinel-1.scene.v1.json",
+            "Sentinel-1.metadata.v1.json"
+    )
+            .map(s -> SCHEMA_PATH_PREFIX + s)
+            .collect(Collectors.toList());
+
+    public static Schema.SchemaBuilder schemaBuilder(String path, TestResourceHelper testResourceHelper) {
+        String content = new String(testResourceHelper.getAsBytes(path));
+        return Schema.builder()
+                .name(path.substring(path.lastIndexOf("/") + 1))
+                .type(path.contains("scene") ? Schema.Type.SCENE : Schema.Type.METADATA)
+                .content(content);
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/product/AdminProductControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/product/AdminProductControllerTest.java
@@ -20,7 +20,6 @@ import pl.cyfronet.s4e.data.repository.SchemaRepository;
 
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -84,15 +83,8 @@ public class AdminProductControllerTest {
                 .enabled(true)
                 .build());
 
-        schemas = Stream.of("Sentinel-1.scene.v1.json", "Sentinel-1.metadata.v1.json")
-                .map(name -> {
-                    String content = new String(testResourceHelper.getAsBytes(SCHEMA_PATH_PREFIX + name));
-                    return Schema.builder()
-                            .name(name)
-                            .type(name.contains("scene") ? Schema.Type.SCENE : Schema.Type.METADATA)
-                            .content(content)
-                            .build();
-                })
+        schemas = SchemaTestHelper.SCENE_AND_METADATA_SCHEMA_NAMES.stream()
+                .map(path -> SchemaTestHelper.schemaBuilder(path, testResourceHelper).build())
                 .map(schemaRepository::save)
                 .collect(Collectors.toMap(Schema::getName, schema -> schema));
     }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/scene/AdminSceneControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/scene/AdminSceneControllerTest.java
@@ -1,0 +1,323 @@
+package pl.cyfronet.s4e.admin.scene;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.cyfronet.s4e.*;
+import pl.cyfronet.s4e.bean.*;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+import pl.cyfronet.s4e.data.repository.ProductRepository;
+import pl.cyfronet.s4e.data.repository.SceneRepository;
+import pl.cyfronet.s4e.data.repository.SchemaRepository;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
+
+@BasicTest
+@AutoConfigureMockMvc
+public class AdminSceneControllerTest {
+    private static final String SCHEMA_PATH_PREFIX = "classpath:schema/";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SchemaRepository schemaRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private SceneRepository sceneRepository;
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    @Autowired
+    private TestResourceHelper testResourceHelper;
+
+    private AppUser admin;
+    private AppUser user;
+
+    private Map<String, Schema> schemas;
+    private Map<String, Product> products;
+    private Map<String, List<Scene>> productScenes;
+    private long maxSceneId;
+
+    @BeforeEach
+    public void beforeEach() {
+        testDbHelper.clean();
+
+        admin = appUserRepository.save(AppUser.builder()
+                .email("admin@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .admin(true)
+                .build());
+
+        user = appUserRepository.save(AppUser.builder()
+                .email("user@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .build());
+
+        schemas = Stream.of("Sentinel-1.scene.v1.json", "Sentinel-1.metadata.v1.json")
+                .map(name -> {
+                    String content = new String(testResourceHelper.getAsBytes(SCHEMA_PATH_PREFIX + name));
+                    return Schema.builder()
+                            .name(name)
+                            .type(name.contains("scene") ? Schema.Type.SCENE : Schema.Type.METADATA)
+                            .content(content)
+                            .build();
+                })
+                .map(schemaRepository::save)
+                .collect(Collectors.toMap(Schema::getName, schema -> schema));
+
+        products = IntStream.range(0, 2)
+                .mapToObj(i -> SceneTestHelper.productBuilder()
+                        .name("Product-" + i)
+                        .build())
+                .map
+                        (productRepository::save)
+                .collect(Collectors.toMap(Product::getName, product -> product));
+
+        productScenes = new HashMap<>();
+        for (Product product : products.values()) {
+            Function<LocalDateTime, Scene> toScene = SceneTestHelper.toScene(product);
+            List<Scene> scenes = IntStream.range(0, 10)
+                    .mapToObj(i -> LocalDateTime.of(2020, 10, 7, 0, 0).plusHours(i))
+                    .map(toScene)
+                    .map(sceneRepository::save)
+                    .collect(Collectors.toList());
+            productScenes.put(product.getName(), scenes);
+        }
+
+        maxSceneId = productScenes.values().stream()
+                .flatMap(List::stream)
+                .mapToLong(Scene::getId)
+                .max().orElse(Long.MIN_VALUE);
+    }
+
+    @Nested
+    class Read {
+        @Test
+        public void shouldRead() throws Exception {
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+            Product product = products.get("Product-0");
+            Scene scene = productScenes.get(product.getName()).get(0);
+
+            mockMvc.perform(get(Constants.ADMIN_PREFIX + "/scenes/{id}", scene.getId())
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").isNumber())
+                    .andExpect(jsonPath("$.product.id", is(equalTo(product.getId().intValue()))))
+                    .andExpect(jsonPath("$.product.name", is(equalTo(product.getName()))))
+                    .andExpect(jsonPath("$.sceneKey").isString())
+                    .andExpect(jsonPath("$.timestamp", is(equalTo("2020-10-07T00:00:00"))))
+                    .andExpect(jsonPath("$.s3Path").isString())
+                    .andExpect(jsonPath("$.granulePath").isString())
+                    .andExpect(jsonPath("$.footprint.epsg3857").isString())
+                    .andExpect(jsonPath("$.footprint.epsg4326").isString())
+                    .andExpect(jsonPath("$.legend").isMap())
+                    .andExpect(jsonPath("$.sceneContent").isMap())
+                    .andExpect(jsonPath("$.metadataContent").isMap());
+
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+        }
+
+        @Test
+        public void shouldHandleNotFound() throws Exception {
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+            mockMvc.perform(get(Constants.ADMIN_PREFIX + "/scenes/{id}", maxSceneId + 1)
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isNotFound());
+
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+        }
+    }
+
+    @Nested
+    class Lists {
+        @Test
+        public void shouldList() throws Exception {
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+            mockMvc.perform(get(Constants.ADMIN_PREFIX + "/scenes")
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(20)));
+
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+        }
+
+        @Test
+        public void shouldListByProduct() throws Exception {
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+            Product product = products.get("Product-0");
+
+            mockMvc.perform(get(Constants.ADMIN_PREFIX + "/products/{id}/scenes", product.getId())
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(10)));
+
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+        }
+
+        @Test
+        public void shouldHandleNFE() throws Exception {
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+            Product product = products.get("Product-1");
+
+            mockMvc.perform(get(Constants.ADMIN_PREFIX + "/products/{id}/scenes", product.getId() + 1)
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isNotFound());
+
+            assertThat(productRepository.count(), is(equalTo(2L)));
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+        }
+    }
+
+    @Nested
+    class Delete {
+        @Test
+        public void shouldWork() throws Exception {
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+            Product product = products.get("Product-0");
+            Scene scene = productScenes.get(product.getName()).get(0);
+
+            mockMvc.perform(delete(Constants.ADMIN_PREFIX + "/scenes/{id}", scene.getId())
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isOk());
+
+            assertThat(sceneRepository.count(), is(equalTo(19L)));
+        }
+
+        @Test
+        public void shouldHandleNotFound() throws Exception {
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+            mockMvc.perform(delete(Constants.ADMIN_PREFIX + "/scenes/{id}", maxSceneId + 1)
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isNotFound());
+
+            assertThat(sceneRepository.count(), is(equalTo(20L)));
+        }
+    }
+
+    @Nested
+    class DeleteProductScenes {
+        @Nested
+        class WhenProductHasNoScenes {
+            private Product emptyProduct;
+
+            @BeforeEach
+            public void beforeEach() {
+                emptyProduct = productRepository.save(SceneTestHelper.productBuilder().build());
+            }
+
+            @Test
+            public void shouldBeNoOpIfThereAreNoScenes() throws Exception {
+                assertThat(productRepository.count(), is(equalTo(3L)));
+                assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+                mockMvc.perform(delete(Constants.ADMIN_PREFIX + "/products/{id}/scenes", emptyProduct.getId())
+                        .with(jwtBearerToken(admin, objectMapper)))
+                        .andExpect(status().isOk());
+
+                assertThat(productRepository.count(), is(equalTo(3L)));
+                assertThat(sceneRepository.count(), is(equalTo(20L)));
+            }
+
+            @Test
+            public void shouldHandleNotFound() throws Exception {
+                assertThat(productRepository.count(), is(equalTo(3L)));
+                assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+                mockMvc.perform(delete(Constants.ADMIN_PREFIX + "/products/{id}/scenes", emptyProduct.getId() + 1)
+                        .with(jwtBearerToken(admin, objectMapper)))
+                        .andExpect(status().isNotFound());
+
+                assertThat(productRepository.count(), is(equalTo(3L)));
+                assertThat(sceneRepository.count(), is(equalTo(20L)));
+            }
+        }
+
+        @Nested
+        class WhenThereAreScenes {
+            private Product populatedProduct;
+
+            @BeforeEach
+            public void beforeEach() {
+                populatedProduct = products.get("Product-1");
+            }
+
+            @Test
+            public void shouldRemoveAllScenes() throws Exception {
+                assertThat(productRepository.count(), is(equalTo(2L)));
+                assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+                mockMvc.perform(delete(Constants.ADMIN_PREFIX + "/products/{id}/scenes", populatedProduct.getId())
+                        .with(jwtBearerToken(admin, objectMapper)))
+                        .andExpect(status().isOk());
+
+                assertThat(productRepository.count(), is(equalTo(2L)));
+                assertThat(sceneRepository.count(), is(equalTo(10L)));
+            }
+
+            @Test
+            public void shouldHandleNotFound() throws Exception {
+                assertThat(productRepository.count(), is(equalTo(2L)));
+                assertThat(sceneRepository.count(), is(equalTo(20L)));
+
+                mockMvc.perform(delete(Constants.ADMIN_PREFIX + "/products/{id}/scenes", populatedProduct.getId() + 1)
+                        .with(jwtBearerToken(admin, objectMapper)))
+                        .andExpect(status().isNotFound());
+
+                assertThat(productRepository.count(), is(equalTo(2L)));
+                assertThat(sceneRepository.count(), is(equalTo(20L)));
+            }
+        }
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/scene/AdminSceneControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/scene/AdminSceneControllerTest.java
@@ -8,7 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 import pl.cyfronet.s4e.*;
-import pl.cyfronet.s4e.bean.*;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.bean.Product;
+import pl.cyfronet.s4e.bean.Scene;
+import pl.cyfronet.s4e.bean.Schema;
 import pl.cyfronet.s4e.data.repository.AppUserRepository;
 import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.data.repository.SceneRepository;
@@ -21,7 +24,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -34,8 +36,6 @@ import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
 @BasicTest
 @AutoConfigureMockMvc
 public class AdminSceneControllerTest {
-    private static final String SCHEMA_PATH_PREFIX = "classpath:schema/";
-
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -89,15 +89,8 @@ public class AdminSceneControllerTest {
                 .enabled(true)
                 .build());
 
-        schemas = Stream.of("Sentinel-1.scene.v1.json", "Sentinel-1.metadata.v1.json")
-                .map(name -> {
-                    String content = new String(testResourceHelper.getAsBytes(SCHEMA_PATH_PREFIX + name));
-                    return Schema.builder()
-                            .name(name)
-                            .type(name.contains("scene") ? Schema.Type.SCENE : Schema.Type.METADATA)
-                            .content(content)
-                            .build();
-                })
+        schemas = SchemaTestHelper.SCENE_AND_METADATA_SCHEMA_NAMES.stream()
+                .map(path -> SchemaTestHelper.schemaBuilder(path, testResourceHelper).build())
                 .map(schemaRepository::save)
                 .collect(Collectors.toMap(Schema::getName, schema -> schema));
 
@@ -105,8 +98,7 @@ public class AdminSceneControllerTest {
                 .mapToObj(i -> SceneTestHelper.productBuilder()
                         .name("Product-" + i)
                         .build())
-                .map
-                        (productRepository::save)
+                .map(productRepository::save)
                 .collect(Collectors.toMap(Product::getName, product -> product));
 
         productScenes = new HashMap<>();

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/schema/AdminSchemaControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/schema/AdminSchemaControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.SchemaTestHelper;
 import pl.cyfronet.s4e.TestDbHelper;
 import pl.cyfronet.s4e.TestResourceHelper;
 import pl.cyfronet.s4e.bean.AppUser;
@@ -140,15 +141,13 @@ public class AdminSchemaControllerTest {
 
         @Test
         public void shouldSetPrevious() throws Exception {
-            schemaRepository.save(Schema.builder()
-                    .name("test.scene.v1.json")
-                    .type(Schema.Type.SCENE)
-                    .content(new String(testResourceHelper.getAsBytes(S1_SCENE_SCHEMA_PATH)))
+            schemaRepository.save(SchemaTestHelper
+                    .schemaBuilder(S1_SCENE_SCHEMA_PATH, testResourceHelper)
                     .build());
 
             AdminCreateSchemaRequest request = getCreateSchemaRequestBuilder()
-                    .name("test.scene.v2.json")
-                    .previous("test.scene.v1.json")
+                    .name("Sentinel-1.scene.v2.json")
+                    .previous("Sentinel-1.scene.v1.json")
                     .build();
 
             assertThat(schemaRepository.count(), is(equalTo(1L)));
@@ -165,15 +164,14 @@ public class AdminSchemaControllerTest {
 
         @Test
         public void shouldVerifySchemaType() throws Exception {
-            schemaRepository.save(Schema.builder()
-                    .name("test.metadata.v1.json")
+            schemaRepository.save(SchemaTestHelper
+                    .schemaBuilder(S1_SCENE_SCHEMA_PATH, testResourceHelper)
                     .type(Schema.Type.METADATA)
-                    .content(new String(testResourceHelper.getAsBytes(S1_SCENE_SCHEMA_PATH)))
                     .build());
 
             AdminCreateSchemaRequest request = getCreateSchemaRequestBuilder()
-                    .name("test.scene.v2.json")
-                    .previous("test.metadata.v1.json")
+                    .name("Sentinel-1.scene.v2.json")
+                    .previous("Sentinel-1.scene.v1.json")
                     .build();
 
             assertThat(schemaRepository.count(), is(equalTo(1L)));

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/ProductServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/ProductServiceTest.java
@@ -12,10 +12,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-import pl.cyfronet.s4e.BasicTest;
-import pl.cyfronet.s4e.SceneTestHelper;
-import pl.cyfronet.s4e.TestDbHelper;
-import pl.cyfronet.s4e.TestResourceHelper;
+import pl.cyfronet.s4e.*;
 import pl.cyfronet.s4e.bean.AppUser;
 import pl.cyfronet.s4e.bean.Legend;
 import pl.cyfronet.s4e.bean.Product;
@@ -35,7 +32,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
@@ -110,15 +106,8 @@ public class ProductServiceTest {
 
         @BeforeEach
         public void beforeEach() {
-            Stream.of("Sentinel-1.scene.v1.json", "Sentinel-1.metadata.v1.json")
-                    .map(name -> {
-                        String content = new String(testResourceHelper.getAsBytes(SCHEMA_PATH_PREFIX + name));
-                        return Schema.builder()
-                                .name(name)
-                                .type(name.contains("scene") ? Schema.Type.SCENE : Schema.Type.METADATA)
-                                .content(content)
-                                .build();
-                    })
+            SchemaTestHelper.SCENE_AND_METADATA_SCHEMA_NAMES.stream()
+                    .map(path -> SchemaTestHelper.schemaBuilder(path, testResourceHelper).build())
                     .forEach(schemaRepository::save);
 
             dtoBuilder = ProductService.DTO.builder()
@@ -278,15 +267,8 @@ public class ProductServiceTest {
 
         @BeforeEach
         public void beforeEach() {
-            Map<String, Schema> schemas = Stream.of("Sentinel-1.scene.v1.json", "Sentinel-1.metadata.v1.json")
-                    .map(name -> {
-                        String content = new String(testResourceHelper.getAsBytes(SCHEMA_PATH_PREFIX + name));
-                        return Schema.builder()
-                                .name(name)
-                                .type(name.contains("scene") ? Schema.Type.SCENE : Schema.Type.METADATA)
-                                .content(content)
-                                .build();
-                    })
+            Map<String, Schema> schemas = SchemaTestHelper.SCENE_AND_METADATA_SCHEMA_NAMES.stream()
+                    .map(path -> SchemaTestHelper.schemaBuilder(path, testResourceHelper).build())
                     .map(schemaRepository::save)
                     .collect(Collectors.toMap(Schema::getName, schema -> schema));
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/SceneServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/SceneServiceTest.java
@@ -3,6 +3,7 @@ package pl.cyfronet.s4e.service;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import pl.cyfronet.s4e.BasicTest;
@@ -11,7 +12,7 @@ import pl.cyfronet.s4e.bean.Product;
 import pl.cyfronet.s4e.bean.Scene;
 import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.data.repository.SceneRepository;
-import pl.cyfronet.s4e.util.TimeHelper;
+import pl.cyfronet.s4e.ex.NotFoundException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,12 +21,17 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static pl.cyfronet.s4e.SceneTestHelper.productBuilder;
 import static pl.cyfronet.s4e.SceneTestHelper.sceneBuilder;
 
 @BasicTest
 @Slf4j
 public class SceneServiceTest {
+    private interface SceneProjection {
+        Long getId();
+    }
+
     @Autowired
     private ProductRepository productRepository;
 
@@ -33,47 +39,57 @@ public class SceneServiceTest {
     private SceneRepository sceneRepository;
 
     @Autowired
-    private TimeHelper timeHelper;
-
-    @Autowired
     private TestDbHelper testDbHelper;
 
     @Autowired
     private SceneService sceneService;
 
+    private Product product;
+
     @BeforeEach
     public void setUp() {
         testDbHelper.clean();
+        product = productRepository.save(productBuilder().build());
     }
 
-    @Test
-    public void shouldReturnFilteredScenes() {
-        Product product = productRepository.save(productBuilder().build());
+    @Nested
+    class ListWithTimestampRange {
+        @Test
+        public void shouldReturnFilteredScenes() throws NotFoundException {
+            val scenes = Stream.of(
+                    LocalDateTime.of(2019, 10, 11, 0, 0),
+                    LocalDateTime.of(2019, 10, 11, 1, 0),
+                    LocalDateTime.of(2019, 10, 12, 0, 0)
+            )
+                    .map(timestamp -> sceneBuilder(product).timestamp(timestamp).build())
+                    .collect(Collectors.toList());
+            sceneRepository.saveAll(scenes);
 
-        val scenes = Stream.of(
-                LocalDateTime.of(2019, 10, 11, 0, 0),
-                LocalDateTime.of(2019, 10, 11, 1, 0),
-                LocalDateTime.of(2019, 10, 12, 0, 0)
-        )
-                .map(timestamp -> sceneBuilder(product).timestamp(timestamp).build())
-                .collect(Collectors.toList());
-        sceneRepository.saveAll(scenes);
+            List<SceneProjection> returned = sceneService.list(product.getId(), scenes.get(0).getTimestamp(), scenes.get(2).getTimestamp(), SceneProjection.class);
 
-        List<Scene> returned = sceneService.getScenes(product.getId(), scenes.get(0).getTimestamp(), scenes.get(2).getTimestamp());
+            assertThat(returned.stream().map(SceneProjection::getId).collect(Collectors.toList()), contains(scenes.get(0).getId(),scenes.get(1).getId()));
+        }
 
-        assertThat(returned.stream().map(Scene::getId).collect(Collectors.toList()), contains(scenes.get(0).getId(),scenes.get(1).getId()));
+        @Test
+        public void shouldThrowNFEIfProductDoesntExist() {
+            assertThrows(
+                    NotFoundException.class,
+                    () -> sceneService.list(product.getId() + 1, null, null, SceneProjection.class)
+            );
+        }
     }
 
-    @Test
-    public void shouldSaveScene() {
-        Product product = productRepository.save(productBuilder().build());
+    @Nested
+    class Save {
+        @Test
+        public void shouldWork() {
+            Scene scene = sceneBuilder(product).build();
 
-        Scene scene = sceneBuilder(product).build();
+            assertThat(sceneRepository.count(), is(equalTo(0L)));
 
-        assertThat(sceneRepository.count(), is(equalTo(0L)));
+            sceneService.save(scene);
 
-        sceneService.saveScene(scene);
-
-        assertThat(sceneRepository.count(), is(equalTo(1L)));
+            assertThat(sceneRepository.count(), is(equalTo(1L)));
+        }
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorTestHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorTestHelper.java
@@ -2,20 +2,19 @@ package pl.cyfronet.s4e.sync;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import pl.cyfronet.s4e.SchemaTestHelper;
 import pl.cyfronet.s4e.TestResourceHelper;
 import pl.cyfronet.s4e.bean.Product;
 import pl.cyfronet.s4e.bean.Schema;
 import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.data.repository.SchemaRepository;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 class SceneAcceptorTestHelper {
-    public static final String SCENE_SCHEMA_PATH = "classpath:schema/Sentinel-1.scene.v1.json";
-    public static final String METADATA_SCHEMA_PATH = "classpath:schema/Sentinel-1.metadata.v1.json";
     public static final String SCENE_KEY = "Sentinel-1/GRDH/2020-02-28/S1A_IW_GRDH_1SDV_20200228T045117_20200228T045142_031448_039EDF_82C8.scene";
 
     private final SchemaRepository schemaRepository;
@@ -23,24 +22,17 @@ class SceneAcceptorTestHelper {
     private final TestResourceHelper testResourceHelper;
 
     public Long setUpProduct() {
-        Schema sceneSchema = schemaRepository.save(Schema.builder()
-                .name("Sentinel-1.scene.v1.json")
-                .type(Schema.Type.SCENE)
-                .content(new String(testResourceHelper.getAsBytes(SCENE_SCHEMA_PATH), StandardCharsets.UTF_8))
-                .build());
-
-        Schema metadataSchema = schemaRepository.save(Schema.builder()
-                .name("Sentinel-1.metadata.v1.json")
-                .type(Schema.Type.METADATA)
-                .content(new String(testResourceHelper.getAsBytes(METADATA_SCHEMA_PATH), StandardCharsets.UTF_8))
-                .build());
+        Map<String, Schema> schemas = SchemaTestHelper.SCENE_AND_METADATA_SCHEMA_NAMES.stream()
+                .map(path -> SchemaTestHelper.schemaBuilder(path, testResourceHelper).build())
+                .map(schemaRepository::save)
+                .collect(Collectors.toMap(Schema::getName, s -> s));
 
         return productRepository.save(Product.builder()
                 .name("Sentinel-1-GRDH")
                 .displayName("Sentinel-1-GRDH")
                 .layerName("sentinel_1_grdh")
-                .sceneSchema(sceneSchema)
-                .metadataSchema(metadataSchema)
+                .sceneSchema(schemas.get("Sentinel-1.scene.v1.json"))
+                .metadataSchema(schemas.get("Sentinel-1.metadata.v1.json"))
                 .granuleArtifactRule(Map.of("default", "quicklook", "COG", "RGBs_8b"))
                 .build()).getId();
     }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExistTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExistTest.java
@@ -19,8 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static pl.cyfronet.s4e.bean.Schema.SCENE_SCHEMA_ARTIFACTS_KEY;
 import static pl.cyfronet.s4e.sync.Error.*;
-import static pl.cyfronet.s4e.sync.step.VerifyAllArtifactsExist.SCENE_ARTIFACTS_PROPERTY;
 
 class VerifyAllArtifactsExistTest extends BaseStepTest<BaseContext> {
     @Mock
@@ -53,7 +53,7 @@ class VerifyAllArtifactsExistTest extends BaseStepTest<BaseContext> {
                 "key_2", new TestJsonString("/path_2")
         );
         when(artifactsJsonObject.entrySet()).thenReturn(artifacts.entrySet());
-        when(sceneJson.getJsonObject(SCENE_ARTIFACTS_PROPERTY)).thenReturn(artifactsJsonObject);
+        when(sceneJson.getJsonObject(SCENE_SCHEMA_ARTIFACTS_KEY)).thenReturn(artifactsJsonObject);
 
         when(sceneStorage.exists("path_1")).thenReturn(true);
         when(sceneStorage.exists("path_2")).thenReturn(true);
@@ -73,7 +73,7 @@ class VerifyAllArtifactsExistTest extends BaseStepTest<BaseContext> {
                 "key_2", new TestJsonString("/path_2")
         );
         when(artifactsJsonObject.entrySet()).thenReturn(artifacts.entrySet());
-        when(sceneJson.getJsonObject(SCENE_ARTIFACTS_PROPERTY)).thenReturn(artifactsJsonObject);
+        when(sceneJson.getJsonObject(SCENE_SCHEMA_ARTIFACTS_KEY)).thenReturn(artifactsJsonObject);
 
         Error error = step.apply(context);
 
@@ -92,7 +92,7 @@ class VerifyAllArtifactsExistTest extends BaseStepTest<BaseContext> {
                 "key_3", new TestJsonString("/path_3")
         );
         when(artifactsJsonObject.entrySet()).thenReturn(artifacts.entrySet());
-        when(sceneJson.getJsonObject(SCENE_ARTIFACTS_PROPERTY)).thenReturn(artifactsJsonObject);
+        when(sceneJson.getJsonObject(SCENE_SCHEMA_ARTIFACTS_KEY)).thenReturn(artifactsJsonObject);
 
         when(sceneStorage.exists("path_1")).thenReturn(false);
         when(sceneStorage.exists("path_2")).thenReturn(true);
@@ -116,7 +116,7 @@ class VerifyAllArtifactsExistTest extends BaseStepTest<BaseContext> {
                 "key_1", new TestJsonString("/path_1")
         );
         when(artifactsJsonObject.entrySet()).thenReturn(artifacts.entrySet());
-        when(sceneJson.getJsonObject(SCENE_ARTIFACTS_PROPERTY)).thenReturn(artifactsJsonObject);
+        when(sceneJson.getJsonObject(SCENE_SCHEMA_ARTIFACTS_KEY)).thenReturn(artifactsJsonObject);
 
         when(sceneStorage.exists("path_1")).thenThrow(S3ClientException.class);
 


### PR DESCRIPTION
The PR contains changes regarding admin Scene endpoints, as well as improvement of SceneService as a whole, fix of compiler warnings and addition of a MapStruct library.

## Admin endpoints

List and delete endpoints, creation and update should be handled with SceneAcceptor through the queue.

Tests are grouped per endpoint. They cover the functionality of each endpoint excluding Pageable, which is handled internally by Spring MVC. There is no limitation on sort field intentionally.

## Other changes

I fixed a bunch of lingering compiler warnings and improved SceneService method naming. Also, I added check for Product existence in SceneService::list.

Apart from this, I introduced use of MapStruct, a library to automate tedious property mapping - constructing Scene response was the last straw to motivate me to look for a sensible solution to this. Spring's BeanUtils also provide a basic functionality, which can be further extended with PropertyMappers, but it's not that robust. Also, MapStruct generates code during compilation, so there's no performance overhead.
I use the library in a few places yet, but preexisting places could be gradually refactored to make use of it.

Closes: #620.