### PR TITLE
[#621] Add admin Scenes synchronization endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Admin scenes synchronization endpoints [#621](https://github.com/cyfronet-fid/sat4envi/issues/621)
 - Create endpoints for existing invitations [#642](https://github.com/cyfronet-fid/sat4envi/issues/642)
 - Admin endpoints for Scenes management [#620](https://github.com/cyfronet-fid/sat4envi/issues/620)
 - Confirm or reject invitation with email URLs [#625](https://github.com/cyfronet-fid/sat4envi/issues/625)
-
 
 ### Changed
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/PrefixScanner.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/PrefixScanner.java
@@ -1,9 +1,7 @@
-package pl.cyfronet.s4e.sync;
+package pl.cyfronet.s4e.admin.sync;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.springframework.stereotype.Component;
-import pl.cyfronet.s4e.properties.S3Properties;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -12,13 +10,11 @@ import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
 import java.util.stream.Stream;
 
 @RequiredArgsConstructor
-@Component
 public class PrefixScanner {
+    private final String bucket;
     private final S3Client s3Client;
-    private final S3Properties s3Properties;
 
     public Stream<S3Object> scan(String prefix) {
-        String bucket =  s3Properties.getBucket();
         val request = ListObjectsV2Request.builder()
                 .bucket(bucket)
                 .prefix(prefix)

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/AdminSyncJobController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/AdminSyncJobController.java
@@ -1,0 +1,163 @@
+package pl.cyfronet.s4e.admin.sync.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import pl.cyfronet.s4e.admin.sync.task.SyncJob;
+import pl.cyfronet.s4e.admin.sync.task.SyncJobManager;
+import pl.cyfronet.s4e.admin.sync.task.SyncJobStore;
+import pl.cyfronet.s4e.ex.NotFoundException;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static pl.cyfronet.s4e.Constants.ADMIN_PREFIX;
+
+@RestController
+@RequestMapping(path = ADMIN_PREFIX + "/sync-jobs", produces = APPLICATION_JSON_VALUE)
+@Tag(name = "admin-sync-jobs", description = "The Admin Scenes Sync Job API")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminSyncJobController {
+    private final SyncJobStore syncJobStore;
+    private final SyncJobManager syncJobManager;
+
+    private final SyncJobMapper syncJobMapper;
+    private final RunningDetailsMapper runningDetailsMapper;
+
+    @Operation(summary = "List all jobs")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @GetMapping
+    public List<SyncJobResponse> get() {
+        return syncJobStore.list().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Operation(summary = "Create a job")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @PutMapping(consumes = APPLICATION_JSON_VALUE)
+    public SyncJobResponse.Extended create(@RequestBody @Valid CreateSyncJobRequest request) {
+        SyncJob syncJob = syncJobManager.create(request.getName(), request.getPrefix(), request.isFailFast());
+        syncJobStore.register(syncJob);
+        return toExtendedResponse(syncJob);
+    }
+
+    @Operation(summary = "Get a job")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
+    })
+    @GetMapping(path = "/{name}")
+    public SyncJobResponse.Extended get(@PathVariable String name) throws NotFoundException {
+        return syncJobStore.find(name)
+                .map(this::toExtendedResponse)
+                .orElseThrow(() -> constructNFE(name));
+    }
+
+    @Operation(summary = "Get a job's errors")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
+    })
+    @GetMapping(path = "/{name}/errors")
+    public ErrorsResponse getErrors(@PathVariable String name) throws NotFoundException {
+        SyncJob syncJob = syncJobStore.find(name)
+                .orElseThrow(() -> constructNFE(name));
+        synchronized (syncJob) {
+            SyncJob.StateDetails details = syncJob.getDetails(SyncJob.State.RUNNING);
+            if (!(details instanceof SyncJob.RunningDetails)) {
+                return null;
+            }
+            SyncJob.RunningDetails runningDetails = (SyncJob.RunningDetails) details;
+            return toResponse(runningDetails);
+        }
+    }
+
+    @Operation(summary = "Delete a job")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
+    })
+    @DeleteMapping(path = "/{name}")
+    public void delete(@PathVariable String name) throws NotFoundException {
+        syncJobStore.delete(name);
+    }
+
+    @Operation(summary = "Run a job")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
+    })
+    @PostMapping(path = "/{name}/run")
+    public SyncJobResponse.Extended run(@PathVariable String name) throws NotFoundException {
+        SyncJob syncJob = syncJobStore.find(name)
+                .orElseThrow(() -> constructNFE(name));
+        syncJobManager.run(syncJob);
+        return toExtendedResponse(syncJob);
+    }
+
+    @Operation(summary = "Cancel a job")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
+    })
+    @PostMapping(path = "/{name}/cancel")
+    public SyncJobResponse.Extended cancel(@PathVariable String name) throws NotFoundException {
+        SyncJob syncJob = syncJobStore.find(name)
+                .orElseThrow(() -> constructNFE(name));
+        syncJobManager.cancel(syncJob);
+        return toExtendedResponse(syncJob);
+    }
+
+    private NotFoundException constructNFE(String name) {
+        return new NotFoundException("SyncJob with name '" + name + "' not found");
+    }
+
+    private SyncJobResponse toResponse(SyncJob syncJob) {
+        synchronized (syncJob) {
+            return syncJobMapper.toResponse(syncJob);
+        }
+    }
+
+    private SyncJobResponse.Extended toExtendedResponse(SyncJob syncJob) {
+        synchronized (syncJob) {
+            return syncJobMapper.toExtendedResponse(syncJob);
+        }
+    }
+
+    private ErrorsResponse toResponse(SyncJob.RunningDetails runningDetails) {
+        return runningDetailsMapper.toErrorsResponse(runningDetails);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/CreateSyncJobRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/CreateSyncJobRequest.java
@@ -1,0 +1,21 @@
+package pl.cyfronet.s4e.admin.sync.api;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+
+@Data
+@Builder
+public class CreateSyncJobRequest {
+    @NotEmpty
+    private String name;
+
+    @NotEmpty
+    @Pattern(regexp = "^[^/].*")
+    private String prefix;
+
+    @Builder.Default
+    private boolean failFast = false;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/ErrorsResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/ErrorsResponse.java
@@ -1,0 +1,22 @@
+package pl.cyfronet.s4e.admin.sync.api;
+
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class ErrorsResponse {
+    private long successesCount;
+    private long runningCount;
+    private long errorsCount;
+    private List<ErrorResponse> errors;
+
+    @Data
+    public static class ErrorResponse {
+        private String sceneKey;
+        private String code;
+        private Exception cause;
+        private Map<String, Object> parameters;
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/RunningDetailsMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/RunningDetailsMapper.java
@@ -1,0 +1,10 @@
+package pl.cyfronet.s4e.admin.sync.api;
+
+import org.mapstruct.Mapper;
+import pl.cyfronet.s4e.admin.sync.task.SyncJob;
+import pl.cyfronet.s4e.config.MapStructCentralConfig;
+
+@Mapper(config = MapStructCentralConfig.class)
+public abstract class RunningDetailsMapper {
+    public abstract ErrorsResponse toErrorsResponse(SyncJob.RunningDetails runningDetails);
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/SyncJobMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/SyncJobMapper.java
@@ -1,0 +1,40 @@
+package pl.cyfronet.s4e.admin.sync.api;
+
+import org.mapstruct.Mapper;
+import pl.cyfronet.s4e.admin.sync.task.SyncJob;
+import pl.cyfronet.s4e.config.MapStructCentralConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Mapper(config = MapStructCentralConfig.class)
+public abstract class SyncJobMapper {
+    public abstract SyncJobResponse toResponse(SyncJob syncJob);
+
+    public abstract SyncJobResponse.Extended toExtendedResponse(SyncJob syncJob);
+
+    private SyncJobResponse.StateDetailsResponse toResponse(SyncJob.StateDetails stateDetails) {
+        if (stateDetails instanceof SyncJob.PendingDetails) {
+            return toResponse((SyncJob.PendingDetails) stateDetails);
+        } else if (stateDetails instanceof SyncJob.RunningDetails) {
+            return toResponse((SyncJob.RunningDetails) stateDetails);
+        } else if (stateDetails instanceof SyncJob.ElapsedDetails) {
+            return toResponse((SyncJob.ElapsedDetails) stateDetails);
+        } else {
+            return null;
+        }
+    }
+
+    protected abstract SyncJobResponse.PendingDetailsResponse toResponse(SyncJob.PendingDetails pendingDetails);
+
+    protected abstract SyncJobResponse.RunningDetailsResponse toResponse(SyncJob.RunningDetails runningDetails);
+
+    protected abstract SyncJobResponse.ElapsedDetailsResponse toResponse(SyncJob.ElapsedDetails elapsedDetails);
+
+    protected List<SyncJobResponse.StateDetailsResponse> mapStateHistory(Map<SyncJob.State, SyncJob.StateDetails> stateHistory) {
+        return stateHistory.values().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/SyncJobResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/SyncJobResponse.java
@@ -1,0 +1,49 @@
+package pl.cyfronet.s4e.admin.sync.api;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class SyncJobResponse {
+    private String name;
+    private String prefix;
+    private boolean failFast;
+    private String state;
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class Extended extends SyncJobResponse {
+        private List<StateDetailsResponse> stateHistory;
+    }
+
+    @Data
+    public abstract static class StateDetailsResponse {
+        private String state;
+        private LocalDateTime since;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class PendingDetailsResponse extends StateDetailsResponse {
+        private long sceneCount;
+        private Duration sceneCountElapsed;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class RunningDetailsResponse extends StateDetailsResponse {
+        private long successesCount;
+        private long runningCount;
+        private long errorsCount;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class ElapsedDetailsResponse extends StateDetailsResponse {
+        private Duration elapsed;
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/task/ChunkedRunner.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/task/ChunkedRunner.java
@@ -1,0 +1,59 @@
+package pl.cyfronet.s4e.admin.sync.task;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ChunkedRunner {
+    private final int chunkSize;
+    private final AsyncTaskExecutor syncJobExecutor;
+
+    public Future<?> run(Iterator<? extends Runnable> iterator, Runnable afterCompletion) {
+        Runnable runnable = () -> {
+            Semaphore chunkSemaphore = new Semaphore(chunkSize);
+            List<Future<?>> futures = new ArrayList<>(chunkSize);
+
+            try {
+                while (iterator.hasNext()) {
+                    chunkSemaphore.acquire();
+                    futures.removeIf(Future::isDone);
+
+                    Runnable next = iterator.next();
+                    Future<?> future = syncJobExecutor.submit(() -> {
+                        try {
+                            next.run();
+                        } catch (RuntimeException e) {
+                            log.warn("Unexpected RuntimeException", e);
+                        } finally {
+                            chunkSemaphore.release();
+                        }
+                    });
+                    futures.add(future);
+                }
+
+                for (Future<?> future : futures) {
+                    try {
+                        future.get();
+                    } catch (ExecutionException e) {
+                        log.info("Exception when waiting for residual tasks", e);
+                    }
+                }
+                afterCompletion.run();
+            } catch (InterruptedException e) {
+                // Don't submit new tasks but allow running ones to finish.
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        return syncJobExecutor.submit(runnable);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/task/SyncJob.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/task/SyncJob.java
@@ -1,0 +1,91 @@
+package pl.cyfronet.s4e.admin.sync.task;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import pl.cyfronet.s4e.sync.Error;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.Future;
+
+@Getter
+public class SyncJob {
+    private final String name;
+    private final String prefix;
+    private final boolean failFast;
+    private final Map<State, StateDetails> stateHistory = new LinkedHashMap<>();
+    @Setter private State state = State.PENDING;
+
+    public SyncJob(String name, String prefix, boolean failFast) {
+        this.name = name;
+        this.prefix = prefix;
+        this.failFast = failFast;
+    }
+
+    public StateDetails getDetails(State state) {
+        return stateHistory.get(state);
+    }
+
+    public void addState(StateDetails stateDetails) {
+        stateHistory.put(stateDetails.getState(), stateDetails);
+    }
+
+    public enum State {
+        PENDING, RUNNING, FINISHED, CANCELLED
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    public static abstract class StateDetails {
+        private final State state;
+        private final LocalDateTime since;
+    }
+
+    @Getter @Setter
+    public static class PendingDetails extends StateDetails {
+        private long sceneCount;
+        private Duration sceneCountElapsed;
+
+        public PendingDetails(LocalDateTime since) {
+            super(State.PENDING, since);
+        }
+    }
+
+    public static class RunningDetails extends StateDetails {
+        @Getter @Setter
+        private long successesCount = 0;
+        @Getter @Setter
+        private long runningCount = 0;
+        private final List<Error> errors = new ArrayList<>();
+        @Getter @Setter
+        private Future<?> future;
+
+        public RunningDetails(LocalDateTime since) {
+            super(State.RUNNING, since);
+        }
+
+        public void addError(Error error) {
+            errors.add(error);
+        }
+
+        public List<Error> getErrors() {
+            return List.copyOf(errors);
+        }
+
+        public long getErrorsCount() {
+            return errors.size();
+        }
+    }
+
+    public static class ElapsedDetails extends StateDetails {
+        @Getter
+        private final Duration elapsed;
+
+        public ElapsedDetails(State state, LocalDateTime since, Duration elapsed) {
+            super(state, since);
+            this.elapsed = elapsed;
+        }
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/task/SyncJobManager.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/task/SyncJobManager.java
@@ -1,0 +1,122 @@
+package pl.cyfronet.s4e.admin.sync.task;
+
+import lombok.RequiredArgsConstructor;
+import pl.cyfronet.s4e.admin.sync.PrefixScanner;
+import pl.cyfronet.s4e.sync.Error;
+import pl.cyfronet.s4e.sync.SceneAcceptor;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.Temporal;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+public class SyncJobManager {
+    private final ChunkedRunner chunkedRunner;
+    private final PrefixScanner prefixScanner;
+    private final SceneAcceptor sceneAcceptor;
+    private final Clock clock;
+
+    public SyncJob create(String name, String prefix, boolean failFast) {
+        SyncJob task = new SyncJob(name, prefix, failFast);
+
+        SyncJob.PendingDetails pendingMetric = new SyncJob.PendingDetails(LocalDateTime.now(clock));
+        task.addState(pendingMetric);
+
+        long sceneCount = sceneKeyStream(prefix).count();
+        pendingMetric.setSceneCountElapsed(elapsedSince(pendingMetric.getSince()));
+        pendingMetric.setSceneCount(sceneCount);
+
+        return task;
+    }
+
+    public void run(SyncJob syncJob) {
+        synchronized (syncJob) {
+            if (syncJob.getState() != SyncJob.State.PENDING) {
+                throw new IllegalArgumentException("You can only run a pending job");
+            }
+
+            syncJob.setState(SyncJob.State.RUNNING);
+            SyncJob.RunningDetails runningMetric = new SyncJob.RunningDetails(LocalDateTime.now(clock));
+            syncJob.addState(runningMetric);
+
+            scheduleTask(syncJob, runningMetric);
+        }
+    }
+
+    public void cancel(SyncJob syncJob) {
+        synchronized (syncJob) {
+            doCancel(syncJob);
+        }
+    }
+
+    private void doCancel(SyncJob syncJob) {
+        if (syncJob.getState() != SyncJob.State.RUNNING) {
+            throw new IllegalArgumentException("You can only cancel a running job");
+        }
+
+        SyncJob.StateDetails stateDetails = syncJob.getDetails(SyncJob.State.RUNNING);
+        if (stateDetails instanceof SyncJob.RunningDetails) {
+            ((SyncJob.RunningDetails) stateDetails).getFuture().cancel(true);
+        }
+
+        toElapsedState(syncJob, SyncJob.State.CANCELLED);
+    }
+
+    private void scheduleTask(SyncJob syncJob, SyncJob.RunningDetails runningMetric) {
+        Iterator<Runnable> iterator = sceneKeyStream(syncJob.getPrefix())
+                .map(sceneKey -> (Runnable) () -> {
+                    synchronized (syncJob) {
+                        runningMetric.setRunningCount(runningMetric.getRunningCount() + 1);
+                    }
+                    Error error = sceneAcceptor.accept(sceneKey);
+                    if (syncJob.isFailFast() && error != null) {
+                        synchronized (syncJob) {
+                            boolean jobCancelledAlready = syncJob.getState() != SyncJob.State.RUNNING;
+                            if (!jobCancelledAlready) {
+                                doCancel(syncJob);
+                            }
+                        }
+                    }
+                    synchronized (syncJob) {
+                        runningMetric.setRunningCount(runningMetric.getRunningCount() - 1);
+                        if (error != null) {
+                            runningMetric.addError(error);
+                        } else {
+                            runningMetric.setSuccessesCount(runningMetric.getSuccessesCount() + 1);
+                        }
+                    }
+                })
+                .iterator();
+        Future<?> future = chunkedRunner.run(iterator, () -> {
+            synchronized (syncJob) {
+                toElapsedState(syncJob, SyncJob.State.FINISHED);
+            }
+        });
+        runningMetric.setFuture(future);
+    }
+
+    private void toElapsedState(SyncJob syncJob, SyncJob.State state) {
+        if (!Set.of(SyncJob.State.CANCELLED, SyncJob.State.FINISHED).contains(state)) {
+            throw new IllegalArgumentException("Only CANCELLED and FINISHED status can be set");
+        }
+        syncJob.setState(state);
+        Duration elapsed = elapsedSince(syncJob.getDetails(SyncJob.State.RUNNING).getSince());
+        syncJob.addState(new SyncJob.ElapsedDetails(syncJob.getState(), LocalDateTime.now(clock), elapsed));
+    }
+
+    private Stream<String> sceneKeyStream(String prefix) {
+        return prefixScanner.scan(prefix)
+                .map(S3Object::key)
+                .filter(key -> key.endsWith(".scene"));
+    }
+
+    private Duration elapsedSince(Temporal temporal) {
+        return Duration.between(temporal, LocalDateTime.now(clock));
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/task/SyncJobStore.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/task/SyncJobStore.java
@@ -1,0 +1,56 @@
+package pl.cyfronet.s4e.admin.sync.task;
+
+import lombok.extern.slf4j.Slf4j;
+import pl.cyfronet.s4e.ex.NotFoundException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class SyncJobStore {
+    private final Map<String, SyncJob> tasks;
+
+    public SyncJobStore() {
+        this(new HashMap<>());
+    }
+
+    public SyncJobStore(Map<String, SyncJob> tasks) {
+        this.tasks = tasks;
+    }
+
+    public List<SyncJob> list() {
+        return tasks.values().stream()
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public List<SyncJob> list(SyncJob.State state) {
+        return tasks.values().stream()
+                .filter(task -> task.getState() == state)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public synchronized void register(SyncJob task) {
+        String name = task.getName();
+        if (tasks.putIfAbsent(name, task) != null) {
+            throw new IllegalArgumentException("Task with name '" + name + "' already exists");
+        }
+    }
+
+    public Optional<SyncJob> find(String name) {
+        return Optional.ofNullable(tasks.get(name));
+    }
+
+    public synchronized void delete(String name) throws NotFoundException {
+        SyncJob task = tasks.get(name);
+        if (task == null) {
+            throw new NotFoundException("Task with name '" + name + "' not found");
+        }
+        if (task.getState() == SyncJob.State.RUNNING) {
+            throw new IllegalArgumentException("Cannot delete a task in state RUNNING, cancel it first to be able to delete it");
+        }
+        tasks.remove(name);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SyncJobsConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SyncJobsConfig.java
@@ -1,0 +1,69 @@
+package pl.cyfronet.s4e.config;
+
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import pl.cyfronet.s4e.admin.sync.PrefixScanner;
+import pl.cyfronet.s4e.admin.sync.task.ChunkedRunner;
+import pl.cyfronet.s4e.admin.sync.task.SyncJobManager;
+import pl.cyfronet.s4e.admin.sync.task.SyncJobStore;
+import pl.cyfronet.s4e.properties.S3Properties;
+import pl.cyfronet.s4e.properties.SyncJobsProperties;
+import pl.cyfronet.s4e.sync.SceneAcceptor;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.time.Clock;
+
+@Configuration
+public class SyncJobsConfig {
+    @Autowired
+    private SyncJobsProperties syncJobsProperties;
+
+    @Autowired
+    private S3Properties s3Properties;
+
+    @Autowired
+    private S3Client s3Client;
+
+    @Autowired
+    private SceneAcceptor sceneAcceptor;
+
+    @Bean
+    public PrefixScanner prefixScanner() {
+        String bucket = s3Properties.getBucket();
+        return new PrefixScanner(bucket, s3Client);
+    }
+
+    @Bean
+    public SyncJobStore syncJobStore() {
+        return new SyncJobStore();
+    }
+
+    @Bean
+    public ChunkedRunner chunkedRunner() {
+        return new ChunkedRunner(syncJobsProperties.getThreadPoolSize() * 2, syncJobExecutor());
+    }
+
+    @Bean
+    public SyncJobManager syncJobManager() {
+        return new SyncJobManager(chunkedRunner(), prefixScanner(), sceneAcceptor, clock());
+    }
+
+    @Bean
+    public AsyncTaskExecutor syncJobExecutor() {
+        val executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(syncJobsProperties.getThreadPoolSize());
+        executor.setAllowCoreThreadTimeOut(true);
+        executor.setKeepAliveSeconds(1);
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/SyncJobsProperties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/SyncJobsProperties.java
@@ -1,0 +1,21 @@
+package pl.cyfronet.s4e.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.Min;
+
+@ConfigurationProperties("sync-jobs")
+@Validated
+@Setter
+@Getter
+public class SyncJobsProperties {
+    /**
+     * Keep in mind that the AWS SDK has a default connection pool size of 50, you can start
+     * receiving errors if you attempt to open more connections in parallel.
+     */
+    @Min(1)
+    private int threadPoolSize = 40;
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/PrefixScannerIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/PrefixScannerIntegrationTest.java
@@ -1,4 +1,4 @@
-package pl.cyfronet.s4e.sync;
+package pl.cyfronet.s4e.admin.sync;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/api/AdminSyncJobControllerIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/api/AdminSyncJobControllerIntegrationTest.java
@@ -1,0 +1,157 @@
+package pl.cyfronet.s4e.admin.sync.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javafaker.Faker;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.cyfronet.s4e.IntegrationTest;
+import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.admin.sync.task.SyncJob;
+import pl.cyfronet.s4e.admin.sync.task.SyncJobStore;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+import pl.cyfronet.s4e.sync.Error;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.Constants.ADMIN_PREFIX;
+import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
+
+@AutoConfigureMockMvc
+@IntegrationTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(properties = {
+        "s3.bucket=scene-acceptor-test"
+})
+@Slf4j
+public class AdminSyncJobControllerIntegrationTest {
+    private Faker faker = new Faker();
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SyncJobStore syncJobStore;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private AppUser user;
+    private AppUser admin;
+
+    @BeforeEach
+    public void beforeAll() {
+        testDbHelper.clean();
+
+        user = appUserRepository.save(AppUser.builder()
+                .email(faker.internet().emailAddress("user"))
+                .name(faker.name().firstName())
+                .surname(faker.name().lastName())
+                .password("{noop}" + faker.internet().password())
+                .enabled(true)
+                .build());
+
+        admin = appUserRepository.save(AppUser.builder()
+                .email(faker.internet().emailAddress("admin"))
+                .name(faker.name().firstName())
+                .surname(faker.name().lastName())
+                .password("{noop}" + faker.internet().password())
+                .enabled(true)
+                .admin(true)
+                .build());
+    }
+
+    @Test
+    @Order(1)
+    public void ensureMethodsAreSecured() throws Exception {
+        mockMvc.perform(get(ADMIN_PREFIX + "/sync-jobs")
+                .with(jwtBearerToken(user, objectMapper)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get(ADMIN_PREFIX + "/sync-jobs"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @Order(2)
+    public void createJob() throws Exception {
+        CreateSyncJobRequest request = CreateSyncJobRequest.builder()
+                .name("test-1")
+                .prefix("Sentinel-1/")
+                .build();
+
+        mockMvc.perform(put(ADMIN_PREFIX + "/sync-jobs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request))
+                .with(jwtBearerToken(admin, objectMapper)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.state", is(equalTo("PENDING"))))
+                .andExpect(jsonPath("$.stateHistory[0].sceneCount", is(equalTo(1))));
+    }
+
+    @Test
+    @Order(3)
+    public void runJob() throws Exception {
+        mockMvc.perform(post(ADMIN_PREFIX + "/sync-jobs/{name}/run", "test-1")
+                .with(jwtBearerToken(admin, objectMapper)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.state", is(equalTo("RUNNING"))))
+                .andExpect(jsonPath("$.stateHistory[1].state", is(equalTo("RUNNING"))));
+    }
+
+    @Test
+    @Order(4)
+    public void listJobs() throws Exception {
+        mockMvc.perform(get(ADMIN_PREFIX + "/sync-jobs")
+                .with(jwtBearerToken(admin, objectMapper)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)));
+    }
+
+    @Test
+    @Order(5)
+    public void showJob() throws Exception {
+        SyncJob syncJob = syncJobStore.find("test-1").get();
+        await().until(() -> syncJob.getState(), is(equalTo(SyncJob.State.FINISHED)));
+
+        mockMvc.perform(get(ADMIN_PREFIX + "/sync-jobs/{name}", "test-1")
+                .with(jwtBearerToken(admin, objectMapper)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stateHistory[1].errorsCount", is(equalTo(1))));
+    }
+
+    @Test
+    @Order(6)
+    public void showErrors() throws Exception {
+        mockMvc.perform(get(ADMIN_PREFIX + "/sync-jobs/{name}/errors", "test-1")
+                .with(jwtBearerToken(admin, objectMapper)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.errors[0].code", is(equalTo(Error.ERR_SCHEMA_NOT_FOUND))));
+    }
+
+    @Test
+    @Order(7)
+    public void deleteJob() throws Exception {
+        mockMvc.perform(delete(ADMIN_PREFIX + "/sync-jobs/{name}", "test-1")
+                .with(jwtBearerToken(admin, objectMapper)))
+                .andExpect(status().isOk());
+
+        assertThat(syncJobStore.list(), hasSize(0));
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/task/ChunkedRunnerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/task/ChunkedRunnerTest.java
@@ -1,0 +1,186 @@
+package pl.cyfronet.s4e.admin.sync.task;
+
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+class ChunkedRunnerTest {
+    private ChunkedRunner chunkedRunner;
+    private ThreadPoolTaskExecutor executor;
+    private List<MockRunnable> jobs;
+
+    @BeforeAll
+    public static void beforeAll() {
+        Awaitility.setDefaultTimeout(Durations.ONE_SECOND);
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.initialize();
+        chunkedRunner = new ChunkedRunner(2, executor);
+
+        jobs = List.of(
+                new MockRunnable(),
+                new MockRunnable(),
+                new MockRunnable(),
+                new MockRunnable(),
+                new MockRunnable()
+        );
+    }
+
+    @AfterEach
+    public void afterEach() {
+        executor.shutdown();
+    }
+
+    public static class MockRunnable implements Runnable {
+        private final Semaphore semaphore = new Semaphore(0);
+        private final AtomicBoolean running = new AtomicBoolean(false);
+        private final AtomicBoolean finished = new AtomicBoolean(false);
+
+        private RuntimeException exception = null;
+
+        @Override
+        public void run() {
+            try {
+                running.set(true);
+
+                semaphore.acquire();
+
+                running.set(false);
+                finished.set(true);
+
+                if (exception != null) {
+                    throw exception;
+                }
+            } catch (InterruptedException e) {
+                fail("Interruption is not expected", e);
+            }
+        }
+    }
+
+    @Test
+    public void happyPath() {
+        Runnable afterCompletion = spy(Runnable.class);
+
+        Future<?> future = chunkedRunner.run(jobs.iterator(), afterCompletion);
+
+        // Wait for the two first jobs to be submitted and running.
+        await().untilAtomic(jobs.get(0).running, is(true));
+        await().untilAtomic(jobs.get(1).running, is(true));
+        assertThat(future.isDone(), is(equalTo(false)));
+
+        // Release the first job
+        jobs.get(0).semaphore.release();
+
+        // and ensure it's finished, and the third is submitted and running.
+        await().untilTrue(jobs.get(0).finished);
+        await().untilTrue(jobs.get(2).running);
+        assertThat(future.isDone(), is(equalTo(false)));
+
+        // Release all the other jobs
+        for (int i = 1; i < 5; i++) {
+            jobs.get(i).semaphore.release();
+        }
+
+        // and wait for the future to be done.
+        await().until(future::isDone, is(true));
+        // When it happens, all jobs should already be finished
+        for (MockRunnable job : jobs) {
+            assertThat(job.finished.get(), is(true));
+        }
+        // and the afterCompletion hook called.
+        verify(afterCompletion).run();
+    }
+
+    @Test
+    public void unexpectedException() {
+        Runnable afterCompletion = spy(Runnable.class);
+
+        Future<?> future = chunkedRunner.run(jobs.iterator(), afterCompletion);
+
+        // Wait for the two first jobs to be submitted and running.
+        await().untilAtomic(jobs.get(0).running, is(true));
+        await().untilAtomic(jobs.get(1).running, is(true));
+        assertThat(future.isDone(), is(equalTo(false)));
+
+        // Release the first job
+        jobs.get(0).semaphore.release();
+
+        // and ensure it's finished, and the third is submitted and running.
+        await().untilTrue(jobs.get(0).finished);
+        await().untilTrue(jobs.get(2).running);
+        assertThat(future.isDone(), is(equalTo(false)));
+
+        // Set the second job to throw a RuntimeException
+        jobs.get(1).exception = new RuntimeException();
+
+        // and release all jobs.
+        for (int i = 1; i < 5; i++) {
+            jobs.get(i).semaphore.release();
+        }
+
+        // The output is the same as if nothing happened, however, info about exception is logged.
+        // All the RE should be caught by the submitted Runnable.
+        await().until(future::isDone, is(true));
+        for (MockRunnable job : jobs) {
+            assertThat(job.finished.get(), is(true));
+        }
+        verify(afterCompletion).run();
+    }
+
+    @Test
+    public void cancellingJob() {
+        Runnable afterCompletion = spy(Runnable.class);
+
+        Future<?> future = chunkedRunner.run(jobs.iterator(), afterCompletion);
+
+        // Wait for the two first jobs to be submitted and running.
+        await().untilAtomic(jobs.get(0).running, is(true));
+        await().untilAtomic(jobs.get(1).running, is(true));
+        assertThat(future.isDone(), is(equalTo(false)));
+
+        // Release the first job
+        jobs.get(0).semaphore.release();
+
+        // and ensure it's finished, and the third is submitted and running.
+        await().untilTrue(jobs.get(0).finished);
+        await().untilTrue(jobs.get(2).running);
+        assertThat(future.isDone(), is(equalTo(false)));
+
+        // Cancel the future.
+        assertThat(future.cancel(true), is(true));
+
+        // Release two enqueued jobs, last two shouldn't be enqueued after cancelling.
+        for (int i = 1; i < 3; i++) {
+            jobs.get(i).semaphore.release();
+        }
+
+        // Ensure the two running jobs manage to finish.
+        await().untilTrue(jobs.get(1).finished);
+        await().untilTrue(jobs.get(2).finished);
+        // By then, the last two jobs shouldn't be enqueued,
+        assertThat(jobs.get(3).running.get(), is(false));
+        assertThat(jobs.get(4).running.get(), is(false));
+        // and the completion callback shouldn't be called.
+        verifyNoMoreInteractions(afterCompletion);
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/task/SyncJobManagerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/task/SyncJobManagerTest.java
@@ -1,0 +1,264 @@
+package pl.cyfronet.s4e.admin.sync.task;
+
+import lombok.experimental.Delegate;
+import org.awaitility.Durations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import pl.cyfronet.s4e.admin.sync.PrefixScanner;
+import pl.cyfronet.s4e.sync.Error;
+import pl.cyfronet.s4e.sync.SceneAcceptor;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.time.*;
+import java.time.temporal.TemporalAmount;
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+class SyncJobManagerTest {
+    private ThreadPoolTaskExecutor executor;
+    private PrefixScanner prefixScanner;
+    private SceneAcceptor sceneAcceptor;
+    private TestClock clock;
+    private SyncJobManager syncJobManager;
+
+    public static class TestClock extends Clock {
+        @Delegate
+        private Clock instance;
+
+        public TestClock(LocalDateTime localDateTime) {
+            instance = Clock.fixed(localDateTime.toInstant(ZoneOffset.UTC), ZoneId.of("UTC"));
+        }
+
+        public void forward(TemporalAmount duration) {
+            instance = Clock.fixed(instance.instant().plus(duration), instance.getZone());
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.initialize();
+        ChunkedRunner chunkedRunner = new ChunkedRunner(2, executor);
+        prefixScanner = mock(PrefixScanner.class);
+        sceneAcceptor = mock(SceneAcceptor.class);
+        clock = new TestClock(LocalDateTime.now());
+        syncJobManager =  new SyncJobManager(chunkedRunner, prefixScanner, sceneAcceptor, clock);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        executor.shutdown();
+    }
+
+    @Test
+    public void runSyncJob() {
+        // 1. Create SyncJob.
+        SyncJob syncJob = createSyncJob(false, () -> Stream.of("a", "b", "c"));
+
+        // 2. Run it.
+        Semaphore semaphoreA = new Semaphore(0);
+        when(sceneAcceptor.accept("a.scene")).thenAnswer(invocationOnMock -> {
+            semaphoreA.acquire();
+            return null;
+        });
+        when(sceneAcceptor.accept("b.scene")).thenReturn(mock(Error.class));
+
+        clock.forward(Durations.ONE_SECOND);
+
+        syncJobManager.run(syncJob);
+
+        assertThat(syncJob.getState(), is(equalTo(SyncJob.State.RUNNING)));
+        SyncJob.RunningDetails runningDetails = (SyncJob.RunningDetails) syncJob.getDetails(SyncJob.State.RUNNING);
+        assertThat(runningDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+
+        await().until(runningDetails::getSuccessesCount, is(equalTo(1L)));
+        await().until(runningDetails::getErrorsCount, is(equalTo(1L)));
+        assertThat(syncJob.getState(), is(equalTo(SyncJob.State.RUNNING)));
+
+        // 3. Allow it to finish.
+        clock.forward(Durations.ONE_SECOND);
+        semaphoreA.release();
+
+        await().until(syncJob::getState, is(equalTo(SyncJob.State.FINISHED)));
+
+        assertThat(runningDetails.getSuccessesCount(), is(equalTo(2L)));
+        assertThat(runningDetails.getErrorsCount(), is(equalTo(1L)));
+
+        SyncJob.ElapsedDetails finishedDetails = (SyncJob.ElapsedDetails) syncJob.getDetails(SyncJob.State.FINISHED);
+        assertThat(finishedDetails.getElapsed(), is(equalTo(Durations.ONE_SECOND)));
+        assertThat(finishedDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+    }
+
+    @Test
+    public void runSyncJobAndFailFast() {
+        // 1. Create SyncJob.
+        SyncJob syncJob = createSyncJob(true, () -> Stream.of("a", "b", "c"));
+
+        // 2. Run it.
+        Semaphore semaphore1 = new Semaphore(0);
+        when(sceneAcceptor.accept("a.scene")).thenAnswer(invocationOnMock -> {
+            semaphore1.acquire();
+            return null;
+        });
+        Semaphore semaphore2 = new Semaphore(0);
+        when(sceneAcceptor.accept("b.scene")).thenAnswer(invocationOnMock -> {
+            semaphore2.acquire();
+            return mock(Error.class);
+        });
+
+        clock.forward(Durations.ONE_SECOND);
+
+        syncJobManager.run(syncJob);
+
+        assertThat(syncJob.getState(), is(equalTo(SyncJob.State.RUNNING)));
+        SyncJob.RunningDetails runningDetails = (SyncJob.RunningDetails) syncJob.getDetails(SyncJob.State.RUNNING);
+        assertThat(runningDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+
+        // 3. Make the second job fail.
+        clock.forward(Durations.ONE_SECOND);
+        semaphore2.release();
+
+        await().until(runningDetails::getErrorsCount, is(equalTo(1L)));
+        await().until(syncJob::getState, is(equalTo(SyncJob.State.CANCELLED)));
+        assertThat(runningDetails.getSuccessesCount(), is(equalTo(0L)));
+
+        SyncJob.ElapsedDetails cancelledDetails = (SyncJob.ElapsedDetails) syncJob.getDetails(SyncJob.State.CANCELLED);
+        assertThat(cancelledDetails.getElapsed(), is(equalTo(Durations.ONE_SECOND)));
+        assertThat(cancelledDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+
+        // 4. Allow the first job to execute.
+        semaphore1.release();
+
+        await().until(runningDetails::getSuccessesCount, is(equalTo(1L)));
+
+        // 5. Ensure the third job is not executed.
+        verify(sceneAcceptor, never()).accept("c.scene");
+    }
+
+    @Test
+    public void runSyncJobAndCancel() {
+        // 1. Create SyncJob.
+        SyncJob syncJob = createSyncJob(false, () -> Stream.of("a", "b", "c", "d"));
+
+        // 2. Run it.
+        Semaphore semaphoreA = new Semaphore(0);
+        Semaphore semaphoreC = new Semaphore(0);
+        when(sceneAcceptor.accept("a.scene")).thenAnswer(invocationOnMock -> {
+            semaphoreA.acquire();
+            return null;
+        });
+        when(sceneAcceptor.accept("b.scene")).thenReturn(mock(Error.class));
+        when(sceneAcceptor.accept("c.scene")).thenAnswer(invocationOnMock -> {
+            semaphoreC.acquire();
+            return null;
+        });
+
+        clock.forward(Durations.ONE_SECOND);
+
+        syncJobManager.run(syncJob);
+
+        assertThat(syncJob.getState(), is(equalTo(SyncJob.State.RUNNING)));
+        SyncJob.RunningDetails runningDetails = (SyncJob.RunningDetails) syncJob.getDetails(SyncJob.State.RUNNING);
+        assertThat(runningDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+
+        // 3. Cancel the job.
+        await().until(runningDetails::getErrorsCount, is(equalTo(1L)));
+        await().until(runningDetails::getRunningCount, is(equalTo(2L)));
+        clock.forward(Durations.ONE_SECOND);
+
+        syncJobManager.cancel(syncJob);
+
+        assertThat(runningDetails.getSuccessesCount(), is(equalTo(0L)));
+        assertThat(syncJob.getState(), is(equalTo(SyncJob.State.CANCELLED)));
+
+        SyncJob.ElapsedDetails cancelledDetails = (SyncJob.ElapsedDetails) syncJob.getDetails(SyncJob.State.CANCELLED);
+        assertThat(cancelledDetails.getElapsed(), is(equalTo(Durations.ONE_SECOND)));
+        assertThat(cancelledDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+
+        // 4. Allow the two other jobs to finish.
+        semaphoreA.release();
+        semaphoreC.release();
+        await().until(runningDetails::getSuccessesCount, is(equalTo(2L)));
+
+        // 5. Ensure the fourth job is not executed.
+        verify(sceneAcceptor, never()).accept("d.scene");
+    }
+
+    @Test
+    public void runSyncJobWithFailFastButCancelAndThenEmitError() {
+        // 1. Create SyncJob.
+        SyncJob syncJob = createSyncJob(true, () -> Stream.of("a", "b", "c"));
+
+        // 2. Run it.
+        Semaphore semaphoreA = new Semaphore(0);
+        Semaphore semaphoreB = new Semaphore(0);
+        when(sceneAcceptor.accept("a.scene")).thenAnswer(invocationOnMock -> {
+            semaphoreA.acquire();
+            return null;
+        });
+        when(sceneAcceptor.accept("b.scene")).thenAnswer(invocationOnMock -> {
+            semaphoreB.acquire();
+            return mock(Error.class);
+        });
+
+        clock.forward(Durations.ONE_SECOND);
+
+        syncJobManager.run(syncJob);
+
+        assertThat(syncJob.getState(), is(equalTo(SyncJob.State.RUNNING)));
+        SyncJob.RunningDetails runningDetails = (SyncJob.RunningDetails) syncJob.getDetails(SyncJob.State.RUNNING);
+        assertThat(runningDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+
+        // 3. Cancel the job.
+        await().until(runningDetails::getRunningCount, is(equalTo(2L)));
+        clock.forward(Durations.ONE_SECOND);
+
+        syncJobManager.cancel(syncJob);
+
+        assertThat(runningDetails.getSuccessesCount(), is(equalTo(0L)));
+        assertThat(syncJob.getState(), is(equalTo(SyncJob.State.CANCELLED)));
+
+        SyncJob.ElapsedDetails cancelledDetails = (SyncJob.ElapsedDetails) syncJob.getDetails(SyncJob.State.CANCELLED);
+        assertThat(cancelledDetails.getElapsed(), is(equalTo(Durations.ONE_SECOND)));
+        assertThat(cancelledDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+
+        // 4. Allow the two jobs to finish.
+        semaphoreA.release();
+        semaphoreB.release();
+        await().until(runningDetails::getSuccessesCount, is(equalTo(1L)));
+        await().until(runningDetails::getErrorsCount, is(equalTo(1L)));
+
+        // 5. Ensure the third job is not executed.
+        verify(sceneAcceptor, never()).accept("c.scene");
+    }
+
+    private SyncJob createSyncJob(boolean failFast, Supplier<Stream<String>> keysPrefixSupplier) {
+        when(prefixScanner.scan("prefix"))
+                .thenAnswer(invocationOnMock -> keysPrefixSupplier.get().map(s -> s + ".scene").map(this::s3ObjectWithKey));
+
+        SyncJob syncJob = syncJobManager.create("some-id", "prefix", failFast);
+
+        assertThat(syncJob.getState(), is(equalTo(SyncJob.State.PENDING)));
+        SyncJob.PendingDetails pendingDetails = (SyncJob.PendingDetails) syncJob.getDetails(SyncJob.State.PENDING);
+        assertThat(pendingDetails.getSince(), is(equalTo(LocalDateTime.now(clock))));
+        assertThat(pendingDetails.getSceneCount(), is(keysPrefixSupplier.get().count()));
+        assertThat(pendingDetails.getSceneCountElapsed(), is(Duration.ZERO));
+        return syncJob;
+    }
+
+    private S3Object s3ObjectWithKey(String key) {
+        return S3Object.builder()
+                .key(key)
+                .build();
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/task/SyncJobStoreTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/task/SyncJobStoreTest.java
@@ -1,0 +1,112 @@
+package pl.cyfronet.s4e.admin.sync.task;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import pl.cyfronet.s4e.ex.NotFoundException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SyncJobStoreTest {
+    private Map<String, SyncJob> tasks;
+    private SyncJobStore store;
+
+    @BeforeEach
+    public void beforeEach() {
+        tasks = new HashMap<>();
+        store = new SyncJobStore(tasks);
+    }
+
+    @Nested
+    class List {
+        @BeforeEach
+        public void beforeEach() {
+            tasks.put("name-1", new SyncJob("name-1", "", true));
+            tasks.put("name-2", new SyncJob("name-2", "", true));
+            SyncJob task3 = new SyncJob("name-3", "", true);
+            task3.setState(SyncJob.State.FINISHED);
+            tasks.put("name-3", task3);
+        }
+
+        @Test
+        public void shouldReturnAll() {
+            assertThat(store.list(), hasSize(3));
+        }
+
+        @Test
+        public void shouldReturnFiltered() {
+            assertThat(store.list(SyncJob.State.FINISHED), hasSize(1));
+        }
+    }
+
+    @Nested
+    class Register {
+        @Test
+        public void shouldRegister() {
+            SyncJob task = new SyncJob("name-1", "", true);
+
+            assertThat(tasks, is(anEmptyMap()));
+
+            store.register(task);
+
+            assertThat(tasks, hasEntry(task.getName(), task));
+        }
+
+        @Test
+        public void shouldThrowIfDuplicate() {
+            SyncJob existingTask = new SyncJob("name-1", "other", false);
+            SyncJob newTask = new SyncJob("name-1", "", true);
+            tasks.put("name-1", existingTask);
+
+            assertThat(tasks, hasEntry("name-1", existingTask));
+
+            assertThrows(IllegalArgumentException.class, () -> store.register(newTask));
+
+            assertThat(tasks, hasEntry("name-1", existingTask));
+        }
+    }
+
+    @Nested
+    class Delete {
+        private SyncJob task;
+
+        @BeforeEach
+        public void beforeEach() {
+            task = new SyncJob("name-1", "", true);
+            tasks.put(task.getName(), task);
+        }
+
+        @Test
+        public void shouldDelete() throws NotFoundException {
+            assertThat(tasks, hasEntry(task.getName(), task));
+
+            store.delete(task.getName());
+
+            assertThat(tasks, is(anEmptyMap()));
+        }
+
+        @Test
+        public void shouldThrowIfNotFound() {
+            assertThat(tasks, hasEntry(task.getName(), task));
+
+            assertThrows(NotFoundException.class, () -> store.delete("other"));
+
+            assertThat(tasks, hasEntry(task.getName(), task));
+        }
+
+        @Test
+        public void shouldThrowIfRunning() {
+            task.setState(SyncJob.State.RUNNING);
+            assertThat(tasks, hasEntry(task.getName(), task));
+
+            assertThrows(IllegalArgumentException.class, () -> store.delete(task.getName()));
+
+            assertThat(tasks, hasEntry(task.getName(), task));
+        }
+    }
+}


### PR DESCRIPTION
The synchronization system is divided into three main parts:
- SyncJobManager: manages jobs state, running operation and details,
- ChunkedRunner: processes a stream of Runnables in chunks,
- SyncJobStore: maintains a list of jobs.

The idea behind using ChunkedRunner is not to load all the scenes keys
into memory, as they can be loaded in chunks while maintaining
parallelism.

During the operation of a job it maintains its state, which is exposed
under GET endpoint - in this way it's possible to monitor the operation
of the job.
For example, it could fail for all keys - in that case it can be
cancelled, and the problem investigated.
All the acceptor Errors are stored in the job for inspection.

The jobs are not persisted to DB, and are the state of a specific
instance of backend.
Memory can be reclaimed by deleting jobs.

Closes: #621.