### PR TITLE
[#660] Fix resending invitations and refactor endpoints to not operate on tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- Fix resending invitations and refactor endpoints to not operate on tokens [#660](https://github.com/cyfronet-fid/sat4envi/issues/660)
 - Fix circular dependencies while dependency injection [#648](https://github.com/cyfronet-fid/sat4envi/issues/648)
 - Super admin security issues [#551](https://github.com/cyfronet-fid/sat4envi/issues/551)
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/InvitationController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/InvitationController.java
@@ -13,13 +13,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import pl.cyfronet.s4e.bean.Invitation;
 import pl.cyfronet.s4e.controller.request.InvitationRequest;
+import pl.cyfronet.s4e.controller.request.InvitationResendInvitation;
 import pl.cyfronet.s4e.controller.response.BasicInstitutionResponse;
 import pl.cyfronet.s4e.controller.response.BasicInvitationResponse;
 import pl.cyfronet.s4e.event.OnConfirmInvitationEvent;
 import pl.cyfronet.s4e.event.OnDeleteInvitationEvent;
 import pl.cyfronet.s4e.event.OnRejectInvitationEvent;
 import pl.cyfronet.s4e.event.OnSendInvitationEvent;
-import pl.cyfronet.s4e.ex.InvitationInvalidInstitutionException;
 import pl.cyfronet.s4e.ex.NotFoundException;
 import pl.cyfronet.s4e.service.InvitationService;
 
@@ -82,25 +82,47 @@ public class InvitationController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
             @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
     })
-    @PutMapping(value = "/institutions/{institution}/invitations/{token}", consumes = APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/institutions/{institution}/invitations", consumes = APPLICATION_JSON_VALUE)
     public BasicInvitationResponse resend(
-            @RequestBody @Valid InvitationRequest request,
-            @PathVariable("institution") String institutionSlug,
-            @PathVariable String token
+            @RequestBody @Valid InvitationResendInvitation request,
+            @PathVariable("institution") String institutionSlug
     ) throws Exception {
-        val invitation = invitationService.findByToken(token, Invitation.class)
+        val invitation = invitationService
+                .findByEmailAndInstitutionSlug(request.getOldEmail(), institutionSlug, Invitation.class)
                 .orElseThrow(() -> new NotFoundException("Invitation couldn't be found"));
-        if (!institutionSlug.equals(invitation.getInstitution().getSlug())) {
-            throw new InvitationInvalidInstitutionException("Institution in url and invitation institution are different");
-        }
+        invitationService.deleteBy(invitation.getToken());
 
-        val newToken = invitationService.createInvitationFrom(request.getEmail(), invitation.getInstitution().getSlug());
-        invitationService.deleteBy(token);
-
+        val newToken = invitationService.createInvitationFrom(request.getNewEmail(), institutionSlug);
         val invitationEvent = new OnSendInvitationEvent(newToken, LocaleContextHolder.getLocale());
         eventPublisher.publishEvent(invitationEvent);
 
         return invitationService.findByToken(newToken, BasicInvitationResponse.class).get();
+    }
+
+    @Transactional
+    @Operation(summary = "Delete invitation")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Invitation have been removed"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Institution in url and invitation institution are different",
+                    content = @Content
+            ),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
+    })
+    @DeleteMapping(value = "/institutions/{institution}/invitations/{id}")
+    public void delete(
+            @PathVariable("institution") String institutionSlug,
+            @PathVariable Long id
+    ) throws Exception {
+        val invitation = invitationService
+                .findByIdAndInstitutionSlug(id, institutionSlug, Invitation.class)
+                .orElseThrow(() -> new NotFoundException("Invitation couldn't be found"));
+
+        val deleteInvitationEvent = new OnDeleteInvitationEvent(invitation.getToken(), LocaleContextHolder.getLocale());
+        eventPublisher.publishEvent(deleteInvitationEvent);
     }
 
     @Operation(summary = "Confirm invitation")
@@ -132,33 +154,5 @@ public class InvitationController {
         invitationService.rejectInvitation(token);
         val rejectInvitationEvent = new OnRejectInvitationEvent(token, LocaleContextHolder.getLocale());
         eventPublisher.publishEvent(rejectInvitationEvent);
-    }
-
-    @Transactional
-    @Operation(summary = "Delete invitation")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Invitation have been removed"),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Institution in url and invitation institution are different",
-                    content = @Content
-            ),
-            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
-            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
-    })
-    @DeleteMapping(value = "/institutions/{institution}/invitations/{token}")
-    public void delete(
-            @PathVariable("institution") String institutionSlug,
-            @PathVariable("token") String token
-    ) throws Exception {
-        val invitation = invitationService.findByToken(token, Invitation.class)
-            .orElseThrow(() -> new NotFoundException("Invitation couldn't be found"));
-        if (!institutionSlug.equals(invitation.getInstitution().getSlug())) {
-            throw new InvitationInvalidInstitutionException("Institution in url and invitation institution are different");
-        }
-
-        val deleteInvitationEvent = new OnDeleteInvitationEvent(token, LocaleContextHolder.getLocale());
-        eventPublisher.publishEvent(deleteInvitationEvent);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/InvitationResendInvitation.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/InvitationResendInvitation.java
@@ -1,0 +1,19 @@
+package pl.cyfronet.s4e.controller.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Data
+@Builder
+public class InvitationResendInvitation {
+    @Email
+    @NotEmpty
+    private String oldEmail;
+
+    @Email
+    @NotEmpty
+    private String newEmail;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/BasicInvitationResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/BasicInvitationResponse.java
@@ -3,9 +3,9 @@ package pl.cyfronet.s4e.controller.response;
 import pl.cyfronet.s4e.bean.InvitationStatus;
 
 public interface BasicInvitationResponse {
-    public String getEmail();
+    public Long getId();
 
-    public String getToken();
+    public String getEmail();
 
     public InvitationStatus getStatus();
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/InvitationRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/InvitationRepository.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 @Transactional(readOnly = true)
 public interface InvitationRepository extends CrudRepository<Invitation, Long> {
+    <T> Optional<T> findByIdAndInstitutionSlug(Long id, String institutionSlug, Class<T> projection);
     <T> Optional<T> findByEmailAndInstitutionSlug(String email, String institutionSlug, Class<T> projection);
     <T> Optional<T> findByToken(String token, Class<T> projection);
     <T> Optional<T> findById(Long id, Class<T> projection);

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/InvitationService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/InvitationService.java
@@ -74,6 +74,14 @@ public class InvitationService {
         return invitationRepository.findAllByInstitutionSlug(institutionSlug, projection);
     }
 
+    public <T> Optional<T> findByIdAndInstitutionSlug(Long id, String institutionSlug, Class<T> projection) {
+        return invitationRepository.findByIdAndInstitutionSlug(id, institutionSlug, projection);
+    }
+
+    public <T> Optional<T> findByEmailAndInstitutionSlug(String email, String institutionSlug, Class<T> projection) {
+        return invitationRepository.findByEmailAndInstitutionSlug(email, institutionSlug, projection);
+    }
+
     public <T> Optional<T> findInstitutionBy(String token, Class<T> projection) throws NotFoundException {
         val invitation = invitationRepository.findByToken(token, Invitation.class)
                 .orElseThrow(() -> constructNFE("token: " + token));

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/InvitationHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/InvitationHelper.java
@@ -4,6 +4,7 @@ import com.github.slugify.Slugify;
 import lombok.val;
 import pl.cyfronet.s4e.bean.*;
 import pl.cyfronet.s4e.controller.request.InvitationRequest;
+import pl.cyfronet.s4e.controller.request.InvitationResendInvitation;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,6 +39,7 @@ public class InvitationHelper {
         val name = String.format(profileName, COUNT.getAndIncrement());
         val profileEmail = String.format(email, COUNT.getAndIncrement());
         return AppUser.builder()
+                .id((long) COUNT.getAndIncrement())
                 .email(profileEmail)
                 .name(name)
                 .surname(name)
@@ -60,6 +62,14 @@ public class InvitationHelper {
                 .builder()
                 .email(invitationEmail);
 
+    }
+
+    public static InvitationResendInvitation.InvitationResendInvitationBuilder invitationResendInvitationBuilder(String oldEmail) {
+        val newEmail = String.format(email, COUNT.getAndIncrement());
+        return InvitationResendInvitation
+                .builder()
+                .oldEmail(oldEmail)
+                .newEmail(newEmail);
     }
 
     private static String nextUnique(String format) {

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.spec.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.spec.ts
@@ -85,14 +85,13 @@ describe('InvitationFormComponent', () => {
 
     const email = 'test@mail.pl';
     const status = 'waiting';
-    const token = 'test';
-    component.invitation = {email, status, token} as any;
+    component.invitation = {email, status} as any;
 
     fixture.detectChanges();
     component.form.patchValue({email});
 
     spyOn(invitationService, 'resend').and.callThrough();
     component.send();
-    expect(invitationService.resend).toHaveBeenCalledWith(component.invitation, component.institution);
+    expect(invitationService.resend).toHaveBeenCalledWith({newEmail: email, oldEmail: email}, component.institution);
   });
 });

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.ts
@@ -78,7 +78,8 @@ export class InvitationFormComponent extends FormModalComponent<'invitation'> {
 
     const email = this.form.controls.email.value;
     !!this.invitation
-      ? this._invitationService.resend(this.invitation, this.institution)
+      ? this._invitationService
+        .resend({oldEmail: this.invitation.email, newEmail: email}, this.institution)
       : this._invitationService.send(this.institution.slug, email);
     this.dismiss();
   }

--- a/s4e-web/src/app/views/settings/people/person-list/person-list.component.ts
+++ b/s4e-web/src/app/views/settings/people/person-list/person-list.component.ts
@@ -98,7 +98,8 @@ export class PersonListComponent implements OnInit, OnDestroy {
   }
 
   resendTo(invitation: any) {
-    this._invitationService.resend(invitation, this.institution);
+    this._invitationService
+      .resend({oldEmail: invitation.email, newEmail: invitation.email}, this.institution);
   }
 
   isInvitation(person: Person) {

--- a/s4e-web/src/app/views/settings/people/state/invitation/invitation.factory.spec.ts
+++ b/s4e-web/src/app/views/settings/people/state/invitation/invitation.factory.spec.ts
@@ -3,6 +3,6 @@ import { Invitation } from './invitation.model';
 
 export const InvitationFactory = Factory.makeFactory<Invitation>({
   email: Factory.each(i => `email#${i}@mail.pl`),
-  token: Factory.each(i => `token-${i}`),
+  id: Factory.each(i => `${i}`),
   status: 'waiting'
 });

--- a/s4e-web/src/app/views/settings/people/state/invitation/invitation.model.ts
+++ b/s4e-web/src/app/views/settings/people/state/invitation/invitation.model.ts
@@ -1,10 +1,15 @@
 import { Person } from './../person/person.model';
 
+export interface InvitationResendRequest {
+  oldEmail: string;
+  newEmail: string;
+}
+
 type stateType = 'waiting' | `rejected`;
 export interface Invitation {
+  id: string;
   email: string;
   status: stateType;
-  token: string;
 }
 
 const invitationName = 'Invitation';
@@ -12,7 +17,7 @@ export function isInvitation(item: any) {
   return item.roles.length === 0
     && item.name === invitationName
     && !!item.surname
-    && !!item.token;
+    && !!item.id;
 }
 
 export function invitationToPerson(invitation: Invitation): Person {
@@ -21,6 +26,6 @@ export function invitationToPerson(invitation: Invitation): Person {
     name: invitationName,
     surname: `(${invitation.status})`,
     roles: [],
-    token: invitation.token
+    id: invitation.id
   } as any as Person;
 }

--- a/s4e-web/src/app/views/settings/people/state/invitation/invitation.service.spec.ts
+++ b/s4e-web/src/app/views/settings/people/state/invitation/invitation.service.spec.ts
@@ -42,9 +42,9 @@ describe('InvitationService', () => {
 
     const newInvitation = InvitationFactory.build();
     const institution = InstitutionFactory.build();
-    service.resend(invitation, institution);
+    service.resend({oldEmail: invitation.email, newEmail: newInvitation.email}, institution);
 
-    const url = `${environment.apiPrefixV1}/institutions/${institution.slug}/invitations/${invitation.token}`;
+    const url = `${environment.apiPrefixV1}/institutions/${institution.slug}/invitations`;
     const method = 'PUT';
     const req = http.expectOne({method, url});
     req.flush(newInvitation);
@@ -60,7 +60,7 @@ describe('InvitationService', () => {
     const institution = InstitutionFactory.build();
     service.delete(invitation, institution);
 
-    const url = `${environment.apiPrefixV1}/institutions/${institution.slug}/invitations/${invitation.token}`;
+    const url = `${environment.apiPrefixV1}/institutions/${institution.slug}/invitations/${invitation.id}`;
     const method = 'DELETE';
     const req = http.expectOne({method, url});
     req.flush({});


### PR DESCRIPTION
**IMPORTANT!!! Includes changes of #643 !!!**

- Delete old invitation before creating new one
- Change endpoints to operate on invitations as unique of institution slug and email (UI and Backend)

Closes #660