### PR TITLE
[#689] Enable actuator endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Enable actuator endpoints [#689](https://github.com/cyfronet-fid/sat4envi/issues/689)
 - Added full (basic) functionality to the timeline [#653](https://github.com/cyfronet-fid/sat4envi/issues/653)
 - Categories in sidebar [#599](https://github.com/cyfronet-fid/sat4envi/issues/599)
 - Add Products seed script [#665](https://github.com/cyfronet-fid/sat4envi/issues/665)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ Related properties list and their defaults:
   exist or be created by setting `amqp.create-queues=true`.
 
 
+#### Actuator endpoints
+
+There are several HTTP actuator endpoints exposed:
+- /actuator/health
+- /actuator/info
+- /actuator/prometheus
+
+See [Actuator API docs](https://docs.spring.io/spring-boot/docs/current/actuator-api/html/) for more information.
+
+
 #### Custom docker-compose local configurations
 
 To customize the docker-compose configuration locally use [multiple Compose files](https://docs.docker.com/compose/extends/).
@@ -358,6 +368,16 @@ EUMETSAT layers. Property: `gateway.eumetsat-layers` or envvar `GATEWAY_EUMETSAT
 A comma delimited list of layers with access type EUMETSAT.
 
 An example of configuration can be found in `docker-compose.yml`.
+
+
+#### Actuator endpoints
+
+There are several HTTP actuator endpoints exposed:
+- /actuator/health
+- /actuator/info
+- /actuator/prometheus
+
+See [Actuator API docs](https://docs.spring.io/spring-boot/docs/current/actuator-api/html/) for more information.
 
 
 ## Development & Docker

--- a/gs-gateway/pom.xml
+++ b/gs-gateway/pom.xml
@@ -46,6 +46,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>${jjwt.version}</version>
@@ -100,6 +109,12 @@
                             <goal>repackage</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -127,6 +142,17 @@
                                 <argument>../${project.build.finalName}.${project.packaging}</argument>
                             </arguments>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/gs-gateway/src/main/resources/application.properties
+++ b/gs-gateway/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 gateway.allowed-params=SERVICE,VERSION,REQUEST,LAYERS,BBOX,WIDTH,HEIGHT,CRS,SRS,FORMAT,TIME,TRANSPARENT
+
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoints.jmx.exposure.include=

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,17 @@
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>1.10.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>4.0.2</version>
+                    <configuration>
+                        <verbose>true</verbose>
+                        <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
+                        <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                        <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -63,6 +63,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
             <artifactId>bucket4j-spring-boot-starter</artifactId>
@@ -331,6 +341,12 @@
                             <goal>repackage</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
                 </executions>
                 <configuration>
                     <mainClass>pl.cyfronet.s4e.Application</mainClass>
@@ -371,6 +387,17 @@
                 <configuration>
                     <processDependencyManagement>false</processDependencyManagement>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/LoggingMailSender.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/LoggingMailSender.java
@@ -39,4 +39,7 @@ public class LoggingMailSender extends JavaMailSenderImpl {
             throw new MailParseException(e);
         }
     }
+
+    @Override
+    public void testConnection() { }
 }

--- a/s4e-backend/src/main/resources/application.properties
+++ b/s4e-backend/src/main/resources/application.properties
@@ -16,3 +16,6 @@ spring.thymeleaf.enabled=false
 
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.tagsSorter=alpha
+
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoints.jmx.exposure.include=


### PR DESCRIPTION
Enable info, health and prometheus endpoints without authorization as
they don't contain sensitive information.

Generate git and build info during build, for /actuator/info to present.

Implement a noop LoggingMailSender::testConnection, so that
/actuator/health endpoint reports correct status in development.

Closes: #689.