### PR TITLE
[#598] Dynamic institutions name in settings panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Dynamic institutions name in settings panel [#598](https://github.com/cyfronet-fid/sat4envi/issues/598)
 - E2E tests for Settings [#453])(https://github.com/cyfronet-fid/sat4envi/issues/453)
 
 ### Fixed

--- a/s4e-web/cypress/integration/settings/settings-user-profile.spec.ts
+++ b/s4e-web/cypress/integration/settings/settings-user-profile.spec.ts
@@ -22,4 +22,9 @@ context('Settings user profile', () => {
       .userDetailsShouldContain(this.zkMember.email)
       .goToPasswordChange();
   });
+  it('should display and navigate to institutions', function () {
+    UserProfile
+      .goToNthMemberInstitution(0)
+      .actionsBtnsAndChildrenShouldBeHidden();
+  });
 });

--- a/s4e-web/cypress/page-objects/settings/settings-institution-profile.po.ts
+++ b/s4e-web/cypress/page-objects/settings/settings-institution-profile.po.ts
@@ -10,6 +10,20 @@ export class InstitutionProfile extends Core {
     getChildren: () => cy.get('[data-e2e="entity-row"]')
   };
 
+  static actionsBtnsAndChildrenShouldBeHidden() {
+    InstitutionProfile
+      .pageObject
+      .getAddChildBtn()
+      .should('not.be.visible');
+
+    InstitutionProfile
+      .pageObject
+      .getChildren()
+      .should('not.be.visible');
+
+    return InstitutionProfile;
+  }
+
   static removeNthChild(nth: number) {
     InstitutionProfile
       .pageObject

--- a/s4e-web/cypress/page-objects/settings/settings-user-profile.po.ts
+++ b/s4e-web/cypress/page-objects/settings/settings-user-profile.po.ts
@@ -1,10 +1,12 @@
+import { InstitutionProfile } from './settings-institution-profile.po';
 import { Core } from './../core.po';
 import { UserPasswordChange } from './settings-user-password-change.po';
 
 export class UserProfile extends Core {
   static pageObject = {
     getGoToChangePasswordBtn: () => cy.get('[data-e2e="go-to-password-change"]'),
-    getUserDetails: () => cy.get('[data-e2e="user-details"]')
+    getUserDetails: () => cy.get('[data-e2e="user-details"]'),
+    getMemberInstitutions: () => cy.get('[data-e2e="member-institutions-tile"]').find('a')
   };
 
   static goToPasswordChange() {
@@ -22,6 +24,19 @@ export class UserProfile extends Core {
       });
 
     return UserProfile;
+  }
+
+  static goToNthMemberInstitution(nth: number) {
+    UserProfile
+      .pageObject
+      .getMemberInstitutions()
+      .eq(nth)
+      .should('be.visible')
+      .click();
+
+    cy.location('pathname').should('eq', '/settings/institution');
+
+    return InstitutionProfile;
   }
 }
 

--- a/s4e-web/src/app/views/settings/guards/is-manager/is-manager.guard.ts
+++ b/s4e-web/src/app/views/settings/guards/is-manager/is-manager.guard.ts
@@ -12,7 +12,9 @@ export class IsManagerGuard implements CanActivate {
   }
 
   canActivate(
-    next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     return this.sessionQuery.selectCanSeeInstitutions().pipe(take(1),
       map(manager => manager ? true : this.router.parseUrl('/settings/profile')));
   }

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.html
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.html
@@ -37,31 +37,50 @@
     </aside>
   </ng-container>
   <footer>
-    <button
-      class="button button--default button--small"
-      [routerLink]="['/settings/edit-institution']"
-      queryParamsHandling="merge"
-      i18n
-    >
-      Edytuj dane
-    </button>
-    <button
-      class="button button--secondary button--small"
-      [routerLink]="['/settings/add-institution']"
-      [queryParams]="{'add_child': true}"
-      queryParamsHandling="merge"
-      data-e2e="add-child-btn"
-      i18n
-    >
-      Dodaj jednostkę podrzędną
-    </button>
+    <ng-container *ngIf="isManager$ | async; else returnToUserProfile">
+      <button
+        class="button button--default button--small"
+        [routerLink]="['/settings/edit-institution']"
+        queryParamsHandling="merge"
+        data-ut="edit-institution"
+        i18n
+      >
+        Edytuj dane
+      </button>
+      <button
+        class="button button--secondary button--small"
+        [routerLink]="['/settings/add-institution']"
+        [queryParams]="{'add_child': true}"
+        queryParamsHandling="merge"
+        data-e2e="add-child-btn"
+        data-ut="add-child-btn"
+        i18n
+      >
+        Dodaj jednostkę podrzędną
+      </button>
+    </ng-container>
+    <ng-template #returnToUserProfile>
+      <button
+        class="button button--secondary button--small"
+        [routerLink]="['/settings/profile']"
+        data-e2e="go-to-user-profile"
+        data-ut="go-to-user-profile"
+        i18n
+      >
+        Wróć do mojego profilu
+      </button>
+    </ng-template>
   </footer>
 </section>
 
-<s4e-generic-list-view [loading]="isLoading$ | async"
-                       [items]="institutions$ | async"
-                       [error]="error$ | async"
-                       [searchable]="true">
+<s4e-generic-list-view
+  *ngIf="isManager$ | async"
+  [loading]="isLoading$ | async"
+  [items]="childrenInstitutions$ | async"
+  [error]="error$ | async"
+  [searchable]="true"
+  data-ut="institution-children"
+>
   <ng-container description></ng-container>
   <h3 caption-inside i18n>
     <ng-container>Jednostki podległe</ng-container>

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.spec.ts
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.spec.ts
@@ -1,3 +1,4 @@
+import { SessionService } from './../../../state/session/session.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { By } from '@angular/platform-browser';
@@ -59,6 +60,7 @@ describe('InstitutionProfileComponent', () => {
     const institution = InstitutionFactory.build();
     const spyFindBy = spyOn(institutionService, 'findBy').and.returnValue(of(institution));
     route.queryParamMap.next(convertToParamMap({ institution: institution.slug }));
+    component.isManager$ = of(true);
     tick();
     fixture.detectChanges();
 
@@ -85,5 +87,62 @@ describe('InstitutionProfileComponent', () => {
 
     const secondaryPhone = de.query(By.css('#institution-second-phone'));
     expect(secondaryPhone.nativeElement.innerHTML.split(':')[1].trim()).toContain(institution.secondaryPhone);
+
+    const editInstitutionBtn = de.query(By.css('[data-ut="edit-institution"]'));
+    expect(editInstitutionBtn).toBeTruthy();
+
+    const addChildBtn = de.query(By.css('[data-ut="add-child-btn"]'));
+    expect(addChildBtn).toBeTruthy();
+
+    const goToProfileBtn = de.query(By.css('[data-ut="go-to-user-profile"]'));
+    expect(goToProfileBtn).toBeFalsy();
+
+    const institutionChildren = de.query(By.css('[data-ut="institution-children"]'));
+    expect(institutionChildren).toBeTruthy();
+  }));
+
+  it('Should display only institution details when user is only member', fakeAsync(() => {
+    const institution = InstitutionFactory.build();
+    const spyFindBy = spyOn(institutionService, 'findBy').and.returnValue(of(institution));
+    component.isManager$ = of(false);
+    route.queryParamMap.next(convertToParamMap({ institution: institution.slug }));
+    tick();
+    fixture.detectChanges();
+
+    expect(spyFindBy).toHaveBeenCalledWith(institution.slug);
+    expect(component.activeInstitution).toEqual(institution);
+
+    const image = de.query(By.css('.institution__logo img'));
+    expect(image).toBeTruthy();
+
+    const title = de.query(By.css('#institution-title'));
+    expect(title.nativeElement.innerHTML).toContain(institution.name);
+
+    const address = de.query(By.css('#institution-address'));
+    expect(address.nativeElement.innerHTML).toContain(institution.address);
+
+    const postalCode = de.query(By.css('#institution-postal-code'));
+    expect(postalCode.nativeElement.innerHTML).toContain(institution.postalCode);
+
+    const institutionAdminEmail = de.query(By.css('#institution-email'));
+    expect(institutionAdminEmail.nativeElement.innerHTML).toContain('email: ' + institution.institutionAdminEmail);
+
+    const phone = de.query(By.css('#institution-phone'));
+    expect(phone.nativeElement.innerHTML.split(':')[1].trim()).toContain(institution.phone);
+
+    const secondaryPhone = de.query(By.css('#institution-second-phone'));
+    expect(secondaryPhone.nativeElement.innerHTML.split(':')[1].trim()).toContain(institution.secondaryPhone);
+
+    const editInstitutionBtn = de.query(By.css('[data-ut="edit-institution"]'));
+    expect(editInstitutionBtn).toBeFalsy();
+
+    const addChildBtn = de.query(By.css('[data-ut="add-child-btn"]'));
+    expect(addChildBtn).toBeFalsy();
+
+    const goToProfileBtn = de.query(By.css('[data-ut="go-to-user-profile"]'));
+    expect(goToProfileBtn).toBeTruthy();
+
+    const institutionChildren = de.query(By.css('[data-ut="institution-children"]'));
+    expect(institutionChildren).toBeFalsy();
   }));
 });

--- a/s4e-web/src/app/views/settings/profile/profile.component.html
+++ b/s4e-web/src/app/views/settings/profile/profile.component.html
@@ -1,33 +1,76 @@
-<header class="content__header">
-  <h1 i18n>Twój profil</h1>
-</header>
+<s4e-tiles-dashboard>
+  <h1 dashboard-title i18n>Twój profil</h1>
+  <p dashboard-description i18n></p>
+  <ng-container dashboard-tiles>
+    <s4e-tile data-e2e="user-details">
+      <img src="./assets/images/ico_people.svg" alt="Ikona ludzi" width="50" tile-image />
+      <header class="panel__header" tile-title>Moje dane</header>
+      <div tile-description>
+        <p i18n>Imie: Jan</p>
+        <p i18n>Nazwisko: Kowalski</p>
+        <p i18n>Email: {{ userEmail$ | async }}</p>
+      </div>
+      <button
+        class="button button--secondary button--small"
+        routerLink="/settings/change-password"
+        queryParamsHandling="merge"
+        data-e2e="go-to-password-change"
+        footer-navigation
+      >
+        Zmień hasło
+      </button>
+    </s4e-tile>
 
-<section class="content__details content__details--50 profile">
-  <div
-    class="profile__content"
-    data-e2e="user-details"
-  >
-    <p *ngIf="!(isLoggedIn$ | async); else userDetails" i18n>
-      Zaloguj się by zobaczyć swój profil
-    </p>
-    <ng-template #userDetails>
-      <h2>Jan Kowalski</h2>
-      <p i18n>Email: {{ userEmail$ | async }}</p>
-      <p>
-        Jesteś administratorem instytucji <a href="#">Ochotnicza Straż Pożarna, Kraków i 5 innych</a>
-      </p>
-    </ng-template>
-
-  </div>
-  <footer>
-    <button
-      class="button button--secondary button--small"
-      routerLink="/settings/change-password"
-      queryParamsHandling="merge"
-      data-e2e="go-to-password-change"
+    <s4e-tile
+      *ngIf="(administrationInstitutions$ | async).length > 0"
+      data-e2e="administrative-institutions-tile"
+      data-ut="administrative-institutions-tile"
     >
-      Zmień hasło
-    </button>
-  </footer>
-</section>
+      <img src="./assets/images/ico_institution.svg" alt="Ikona instytucji" width="50" tile-image />
+      <header class="panel__header" tile-title>Instytucje administrowane</header>
+      <div tile-description>
+        <p *ngFor="let institution of (administrationInstitutions$ | async).slice(0, MAX_ADMINISTRATION_INSTITUTIONS_TO_DISPLAY)">
+          <a
+            routerLink="/settings/institution"
+            [queryParams]="{institution: institution.slug}"
+            queryParamsHandling="merge"
+          >
+            {{ institution.name }}
+          </a>
+        </p>
+      </div>
+      <button
+        *ngIf="hasMoreAdministrationInstitutionsThanMax$ | async"
+        class="button button--secondary button--small"
+        routerLink="/settings/institutions"
+        queryParamsHandling="merge"
+        data-ut="go-to-institutions"
+        data-e2e="go-to-institutions"
+        footer-navigation
+      >
+        Pokaż więcej
+      </button>
+    </s4e-tile>
+
+    <s4e-tile
+      *ngIf="(memberInstitutions$ | async).length > 0"
+      data-e2e="member-institutions-tile"
+      data-ut="member-institutions-tile"
+    >
+      <img src="./assets/images/ico_institution.svg" alt="Ikona instytucji" width="50" tile-image />
+      <header class="panel__header" tile-title>Instytucje członkowskie</header>
+      <div tile-description>
+        <p *ngFor="let institution of (memberInstitutions$ | async)">
+          <a
+            routerLink="/settings/institution"
+            [queryParams]="{institution: institution.slug}"
+            queryParamsHandling="merge"
+          >
+            {{ institution.name }}
+          </a>
+        </p>
+      </div>
+    </s4e-tile>
+  </ng-container>
+</s4e-tiles-dashboard>
 <div class="content__image content__image--profile"></div>

--- a/s4e-web/src/app/views/settings/profile/profile.component.spec.ts
+++ b/s4e-web/src/app/views/settings/profile/profile.component.spec.ts
@@ -1,4 +1,7 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { InstitutionFactory } from './../state/institution/institution.factory.spec';
+import { of } from 'rxjs';
+import { InstitutionQuery } from './../state/institution/institution.query';
+import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 import {SessionService} from '../../../state/session/session.service';
 import {ProfileComponent} from './profile.component';
@@ -6,6 +9,8 @@ import {SessionQuery} from '../../../state/session/session.query';
 import {SessionStore} from '../../../state/session/session.store';
 import {ProfileModule} from './profile.module';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
 
 describe('ProfileComponent', () => {
   let component: ProfileComponent;
@@ -13,10 +18,16 @@ describe('ProfileComponent', () => {
   let sessionService: SessionService;
   let sessionQuery: SessionQuery;
   let sessionStore: SessionStore;
+  let institutionQuery: InstitutionQuery;
+  let de: DebugElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ProfileModule, HttpClientTestingModule, RouterTestingModule]
+      imports: [
+        ProfileModule,
+        HttpClientTestingModule,
+        RouterTestingModule
+      ]
     })
       .compileComponents();
   }));
@@ -24,25 +35,44 @@ describe('ProfileComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ProfileComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    de = fixture.debugElement;
     sessionService = TestBed.get(SessionService);
     sessionQuery = TestBed.get(SessionQuery);
     sessionStore = TestBed.get(SessionStore);
+
+    institutionQuery = TestBed.get(InstitutionQuery);
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
-  it('should tell user to log in if it isnt', () => {
-    sessionStore.update(state => ({...state, email: null}));
-    fixture.detectChanges();
-    expect(fixture.debugElement.nativeElement.textContent).toContain('Zaloguj się by zobaczyć swój profil');
-  });
+  it('should display administrative and member institutions', () => {
+    const institutions = InstitutionFactory.buildList(5);
+    const administrativeInstitutions = institutions.splice(0, 3);
+    component.administrationInstitutions$ = of(administrativeInstitutions);
+    const memberInstitutions = institutions;
+    component.memberInstitutions$ = of(memberInstitutions);
 
-  it('should show user email if he\'s logged in', () => {
-    sessionStore.update(state => ({...state, email: 'email@domain'}));
     fixture.detectChanges();
-    expect(fixture.debugElement.nativeElement.textContent).toContain('Email: email@domain');
+
+    const administrativeInstitutionsTile = de.query(By.css('s4e-tile[data-ut="administrative-institutions-tile"]'));
+    const administrativeInstitutionsTileText = administrativeInstitutionsTile.nativeElement.textContent;
+    administrativeInstitutions
+      .forEach(institution => expect(administrativeInstitutionsTileText.indexOf(institution.name) > -1).toBeTruthy());
+
+    const memberInstitutionsTile = de.query(By.css('s4e-tile[data-ut="member-institutions-tile"]'));
+    const memberInstitutionsTileText = memberInstitutionsTile.nativeElement.textContent;
+    memberInstitutions
+        .forEach(institution => expect(memberInstitutionsTileText.indexOf(institution.name) > -1).toBeTruthy());
+  });
+  it('should display get more button on more than max institutions', () => {
+    component.hasMoreAdministrationInstitutionsThanMax$ = of(true);
+
+    fixture.detectChanges();
+
+    const goToInstitutionsListBtn = de.queryAll(By.css('button[data-ut="go-to-institutions"]'));
+    expect(goToInstitutionsListBtn).toBeTruthy();
   });
 });

--- a/s4e-web/src/app/views/settings/profile/profile.component.ts
+++ b/s4e-web/src/app/views/settings/profile/profile.component.ts
@@ -1,20 +1,30 @@
+import { map } from 'rxjs/operators';
+import { InstitutionQuery } from './../state/institution/institution.query';
 import { Component, OnInit } from '@angular/core';
 import {SessionQuery} from '../../../state/session/session.query';
 import {Observable} from 'rxjs';
+import { Institution } from '../state/institution/institution.model';
 
 @Component({
   selector: 's4e-profile',
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.scss']
 })
-export class ProfileComponent implements OnInit {
-  public isLoggedIn$: Observable<boolean>;
-  public userEmail$: Observable<string>;
+export class ProfileComponent {
+  public MAX_ADMINISTRATION_INSTITUTIONS_TO_DISPLAY = 10;
 
-  constructor(private _sessionQuery: SessionQuery) {}
+  public userEmail$: Observable<string> = this._sessionQuery.select(state => state.email);
 
-  ngOnInit(): void {
-    this.isLoggedIn$ = this._sessionQuery.isLoggedIn$();
-    this.userEmail$ = this._sessionQuery.select(state => state.email);
-  }
+  public administrationInstitutions$: Observable<Institution[]> = this._institutionQuery
+    .getAdministrationInstitutions$();
+  public hasMoreAdministrationInstitutionsThanMax$ = this.administrationInstitutions$
+    .pipe(map(institutions => institutions.length > this.MAX_ADMINISTRATION_INSTITUTIONS_TO_DISPLAY));
+
+  public memberInstitutions$: Observable<Institution[]> = this._institutionQuery
+    .getMemberInstitutions$();
+
+  constructor(
+    private _sessionQuery: SessionQuery,
+    private _institutionQuery: InstitutionQuery
+  ) {}
 }

--- a/s4e-web/src/app/views/settings/profile/profile.module.ts
+++ b/s4e-web/src/app/views/settings/profile/profile.module.ts
@@ -1,3 +1,4 @@
+import { TilesDashboardModule } from './../../../components/tiles-dashboard/tiles-dashboard.module';
 import {NgModule} from '@angular/core';
 
 import {ShareModule} from '../../../common/share.module';
@@ -14,7 +15,8 @@ import { FormErrorModule } from 'src/app/components/form-error/form-error.module
   imports: [
     ShareModule,
     S4EFormsModule,
-    FormErrorModule
+    FormErrorModule,
+    TilesDashboardModule
   ],
   exports: [
     ProfileComponent,

--- a/s4e-web/src/app/views/settings/settings.routes.ts
+++ b/s4e-web/src/app/views/settings/settings.routes.ts
@@ -61,7 +61,7 @@ export const settingsRoutes: Routes = [
       {
         path: INSTITUTION_PROFILE_PATH,
         component: InstitutionProfileComponent,
-        canActivate: [IsManagerGuard],
+        canActivate: [IsLoggedIn],
         data: {
           breadcrumbs: [
             {

--- a/s4e-web/src/app/views/settings/state/institution/institution.query.ts
+++ b/s4e-web/src/app/views/settings/state/institution/institution.query.ts
@@ -2,13 +2,35 @@ import { Injectable } from '@angular/core';
 import { QueryEntity } from '@datorama/akita';
 import { InstitutionStore, InstitutionState } from './institution.store';
 import { Institution } from './institution.model';
+import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { SessionQuery } from 'src/app/state/session/session.query';
 
 @Injectable({
   providedIn: 'root'
 })
 export class InstitutionQuery extends QueryEntity<InstitutionState, Institution> {
+  public getAdministrationInstitutions$(): Observable<Institution[]> {
+    return this.selectAll()
+    .pipe(map(institutions => {
+      const administratorInstitutionsSlugs = this._sessionQuery.getAdministratorInstitutionsSlugs();
+      return institutions
+        .filter(institution => administratorInstitutionsSlugs.some(slug => slug === institution.slug));
+    }));
+  }
+  public getMemberInstitutions$(): Observable<Institution[]> {
+    return this.selectAll()
+    .pipe(map(institutions => {
+      const memberInstitutionSlugs = this._sessionQuery.getMemberInstitutionSlugs();
+      return institutions
+        .filter(institution => memberInstitutionSlugs.some(slug => slug === institution.slug));
+    }));
+  }
 
-  constructor(protected store: InstitutionStore) {
+  constructor(
+    protected store: InstitutionStore,
+    private _sessionQuery: SessionQuery
+  ) {
     super(store);
   }
 }


### PR DESCRIPTION
- Separate user profile to tiles: user details, institutions user administrate, institutions where the user is a member
- Add show more, if there are more institutions than 3 and redirect to institutions list on click
- Redirect to institution profile on click on it (member can see institution details without action buttons and children institution) 

e2e
- Member shouldn't see action buttons and list of children institutions
- User should have the possibility to go to the institution profile

Closes #598

Beneath tasks will be continue in **UI rights system for different types of users #722**
- ~~Show rights to institutions in list~~
- ~~Hide from institution member actions buttons when go to institution profile~~
- ~~Add return to `mój profil` on institution profile page when visiting as institution member~~