### PR TITLE
[#453] E2E tests for Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- E2E tests for Settings [#453])(https://github.com/cyfronet-fid/sat4envi/issues/453)
+
 ### Changed
 
 ### Fixed

--- a/s4e-web/cypress/integration/settings/settings-breadcrumbs.spec.ts
+++ b/s4e-web/cypress/integration/settings/settings-breadcrumbs.spec.ts
@@ -1,0 +1,44 @@
+import { SideNav } from './../../page-objects/settings/settings-side-nav.po';
+import { AdminDashboard } from './../../page-objects/settings/settings-dashboard.po';
+import { Login } from '../../page-objects/login/login.po';
+import { Breadcrumbs } from '../../page-objects/settings/settings-breadcrumbs.po';
+
+context('Breadcrumbs', () => {
+  beforeEach(() => {
+    cy.fixture('users/zkMember.json').as('zkMember');
+    cy.fixture('users/zkAdmin.json').as('zkAdmin');
+    cy.fixture('users/admin.json').as('admin');
+  });
+
+  it('should display admin user profile breadcrumb and go to start page', function () {
+    Login
+      .loginAs(this.zkAdmin)
+      .goToSettingsAs(this.zkAdmin)
+      .goToUserProfile()
+      .changeContextTo(Breadcrumbs)
+      .shouldHaveTexts('Tablica menedżera', 'Mój profil')
+      .goToBreadcrumbWithLabel('Tablica menedżera', '/settings/dashboard', AdminDashboard)
+      .changeContextTo(SideNav)
+      .logout();
+  });
+  it('should display super admin user profile breadcrumb and go to start page', function () {
+    Login
+      .loginAs(this.admin)
+      .goToSettingsAs(this.admin)
+      .goToUserProfile()
+      .changeContextTo(Breadcrumbs)
+      .shouldHaveTexts('Tablica administratora', 'Mój profil')
+      .goToBreadcrumbWithLabel('Tablica administratora', '/settings/dashboard', AdminDashboard)
+      .changeContextTo(SideNav)
+      .logout();
+  });
+  it('should display member user profile breadcrumb and go to start page', function () {
+    Login
+      .loginAs(this.zkMember)
+      .goToSettingsAs(this.zkMember)
+      .changeContextTo(Breadcrumbs)
+      .shouldHaveTexts('Mój profil')
+      .changeContextTo(SideNav)
+      .logout();
+  });
+});

--- a/s4e-web/cypress/integration/settings/settings-dashboard.spec.ts
+++ b/s4e-web/cypress/integration/settings/settings-dashboard.spec.ts
@@ -1,0 +1,42 @@
+import { SideNav } from './../../page-objects/settings/settings-side-nav.po';
+import { InstitutionSearch } from './../../page-objects/settings/settings-institution-search.po';
+import { AdminDashboard, SuperAdminDashboard } from './../../page-objects/settings/settings-dashboard.po';
+import { Login } from './../../page-objects/login/login.po';
+context('Dashboard', () => {
+  beforeEach(() => {
+    cy.fixture('users/zkAdmin.json').as('zkAdmin');
+    cy.fixture('users/admin.json').as('admin');
+  });
+
+  it('should display admin dashboard', async function () {
+    Login
+      .loginAs(this.zkAdmin)
+      .goToSettingsAs(this.zkAdmin);
+
+    await AdminDashboard
+      .tilesShouldContainHeadersDescriptionsAndImages();
+
+    InstitutionSearch
+      .selectNthInstitutionResult(0)
+      .changeContextTo(AdminDashboard)
+      .goToInstitutionProfile();
+
+    SideNav
+      .goToDashboardAs(this.zkAdmin)
+      .changeContextTo(AdminDashboard)
+      .goToPeopleList()
+      .changeContextTo(SideNav)
+      .logout();
+  });
+  it('should display super admin dashboard', async function () {
+    Login
+      .loginAs(this.admin)
+      .goToSettingsAs(this.admin);
+
+    await SuperAdminDashboard
+      .tilesShouldContainHeadersDescriptionsAndImages();
+
+    SuperAdminDashboard
+      .goToInstitutionsList();
+  });
+});

--- a/s4e-web/cypress/page-objects/settings/settings-add-institution-form.po.ts
+++ b/s4e-web/cypress/page-objects/settings/settings-add-institution-form.po.ts
@@ -20,7 +20,7 @@ export class AddInstitutionForm extends Core {
     getLogoInput:  () => cy.get('[data-e2e="emblem-input"]'),
     getEmailInput:  () => cy.get('#institutionAdminEmail'),
     getSubmitBtn:  () => cy.get('[data-e2e="submit-btn"]'),
-  }
+  };
 
   static openParentInstitutionModal() {
     return ParentInstitutionModal;

--- a/s4e-web/cypress/page-objects/settings/settings-breadcrumbs.po.ts
+++ b/s4e-web/cypress/page-objects/settings/settings-breadcrumbs.po.ts
@@ -1,0 +1,36 @@
+import { Core } from '../core.po';
+
+export class Breadcrumbs extends Core {
+  static pageObject = {
+    getItems: () => cy.get('[data-e2e="breadcrumb-item"]')
+  };
+
+  static shouldHaveTexts(...texts: string[]) {
+    Breadcrumbs
+      .pageObject
+      .getItems()
+      .should('be.visible');
+
+    texts
+      .forEach(text => {
+        Breadcrumbs
+          .pageObject
+          .getItems()
+          .should('contain', text);
+      });
+
+    return Breadcrumbs;
+  }
+
+  static goToBreadcrumbWithLabel<T>(label: string, path: string, context: T) {
+    Breadcrumbs
+      .pageObject
+      .getItems()
+      .contains(label)
+      .click({ force: true });
+
+    cy.location('pathname').should('eq', path);
+
+    return context;
+  }
+}

--- a/s4e-web/cypress/page-objects/settings/settings-dashboard.po.ts
+++ b/s4e-web/cypress/page-objects/settings/settings-dashboard.po.ts
@@ -1,0 +1,124 @@
+import { UserProfile } from './settings-user-profile.po';
+import { InstitutionProfile } from './settings-institution-profile.po';
+import { InstitutionPeople } from './settings-institution-people.po';
+import { Core } from '../core.po';
+import promisify from 'cypress-promise';
+
+export class AdminDashboard extends Core {
+  static pageObject = {
+    getTiles: () => cy.get('s4e-tile'),
+
+    getGoToPeopleListTile: () => cy
+      .get('[data-e2e="go-to-people-list-tile"]'),
+    getGoToPeopleListBtn: () => AdminDashboard
+      .pageObject
+      .getGoToPeopleListTile()
+      .find('button'),
+
+    getGoToInstitutionProfileTile: () => cy
+      .get('[data-e2e="go-to-institution-profile-tile"]'),
+    getGoToInstitutionProfileBtn: () => AdminDashboard
+      .pageObject
+      .getGoToPeopleListTile()
+      .find('button'),
+  };
+
+  static async tilesShouldContainHeadersDescriptionsAndImages() {
+    const tilesNumber = (await promisify(
+      AdminDashboard
+        .pageObject
+        .getTiles()
+    )).length;
+
+    AdminDashboard
+      .pageObject
+      .getTiles()
+      .should('be.visible')
+      .find('header')
+      .should('be.visible')
+      .should('have.length', tilesNumber);
+
+    AdminDashboard
+      .pageObject
+      .getTiles()
+      .should('be.visible')
+      .find('p')
+      .should('be.visible')
+      .should('have.length', tilesNumber);
+
+    AdminDashboard
+      .pageObject
+      .getTiles()
+      .should('be.visible')
+      .find('img')
+      .should('be.visible')
+      .should('have.length', tilesNumber);
+  }
+
+  static goToPeopleList() {
+    return InstitutionPeople.goTo(
+      AdminDashboard.pageObject.getGoToPeopleListBtn(),
+      '/settings/profile',
+      UserProfile
+    );
+  }
+
+  static goToInstitutionProfile() {
+    return InstitutionPeople.goTo(
+      AdminDashboard.pageObject.getGoToInstitutionProfileBtn(),
+      '/settings/institution',
+      InstitutionProfile
+    );
+  }
+}
+
+export class SuperAdminDashboard extends Core {
+  static pageObject = {
+    getInstitutionSearchTile: () => cy.get('[data-e2e="institution-search-tile"]'),
+    getGoToInstitutionsTile: () => cy.get('[data-e2e="go-to-institutions-list-tile"]'),
+    getGoToInstitutionsListBtn: () => SuperAdminDashboard
+      .pageObject
+      .getGoToInstitutionsTile()
+      .find('buttton')
+  };
+
+  static goToInstitutionsList() {
+    return InstitutionPeople.goTo(
+      AdminDashboard.pageObject.getGoToPeopleListBtn(),
+      '/settings/institutions',
+      InstitutionProfile
+    );
+  }
+
+  static async tilesShouldContainHeadersDescriptionsAndImages() {
+    const tilesNumber = (await promisify(
+      AdminDashboard
+        .pageObject
+        .getTiles()
+    )).length;
+
+    AdminDashboard
+      .pageObject
+      .getTiles()
+      .should('be.visible')
+      .find('header')
+      .should('be.visible')
+      .should('have.length', tilesNumber);
+
+    AdminDashboard
+      .pageObject
+      .getTiles()
+      .should('be.visible')
+      .find('p')
+      .should('be.visible')
+      .should('have.length', tilesNumber);
+
+    AdminDashboard
+      .pageObject
+      .getTiles()
+      .should('be.visible')
+      .find('img')
+      .should('be.visible')
+      .should('have.length', tilesNumber);
+  }
+}

--- a/s4e-web/cypress/page-objects/settings/settings-side-nav.po.ts
+++ b/s4e-web/cypress/page-objects/settings/settings-side-nav.po.ts
@@ -1,3 +1,5 @@
+import { AdminDashboard, SuperAdminDashboard } from './settings-dashboard.po';
+import { User } from './../login/login.po';
 import { InstitutionSearch } from './settings-institution-search.po';
 import { InstitutionProfile } from './settings-institution-profile.po';
 import { Login } from '../login/login.po';
@@ -12,6 +14,7 @@ export class SideNav extends Core {
     // TODO: update elements with data-e2e attributes
     getAddInstitutionBtn: () => cy.get('[data-e2e="addInstitution"]'),
     getProfileBtn: () => cy.get('li[data-e2e="profile"] a'),
+    getGoToDashboardBtn: () => cy.get('[data-e2e="go-to-dashboard"]').find('a'),
     getLogoutBtn: () => cy.get('.login a'),
     getInstitutionListBtn: () => cy.get('li[data-e2e="institutions"] a'),
     getInstitutionProfileBtn: () => cy.get('[data-e2e="go-to-institution-profile-btn"]'),
@@ -58,5 +61,11 @@ export class SideNav extends Core {
 
   static goToInstitutionPeople() {
     return SideNav.goTo(SideNav.pageObject.getInstitutionPeopleBtn(), '/settings/people', InstitutionPeople);
+  }
+
+  static goToDashboardAs(user: User) {
+    const isAdmin = user.email.startsWith('zkAdmin');
+    const actualContext = isAdmin ? AdminDashboard : SuperAdminDashboard;
+    return SideNav.goTo(SideNav.pageObject.getGoToDashboardBtn(), '/settings/dashboard', actualContext);
   }
 }

--- a/s4e-web/src/app/views/settings/admin-dashboard/admin-dashboard.component.html
+++ b/s4e-web/src/app/views/settings/admin-dashboard/admin-dashboard.component.html
@@ -5,7 +5,7 @@
     Oprócz zarządzania ludźmi i grupami możesz również m. in. edytować instytucje:
   </p>
   <ng-container dashboard-tiles>
-    <s4e-tile>
+    <s4e-tile data-e2e="institution-search-tile">
       <header class="panel__header" tile-title>Wybierz instytucję</header>
       <p i18n tile-description>Wybierz instytucję aby móc nią zarządzać</p>
         <s4e-search
@@ -23,7 +23,7 @@
         </s4e-search>
     </s4e-tile>
 
-    <s4e-tile>
+    <s4e-tile data-e2e="go-to-institutions-list-tile">
       <header class="panel__header" tile-title>Zarządzaj instytucjami</header>
       <p i18n tile-description>Lista wszystkich instytucji. W tym miejscu możesz je edytować</p>
       <button

--- a/s4e-web/src/app/views/settings/breadcrumb/breadcrumb.component.html
+++ b/s4e-web/src/app/views/settings/breadcrumb/breadcrumb.component.html
@@ -1,7 +1,7 @@
 <ul class="breadcrumb">
   <li i18n>Tutaj jesteś: </li>
   <ng-container *ngFor="let breadcrumb of breadcrumbs; last as isLast">
-    <li>
+    <li data-e2e="breadcrumb-item">
       <ng-container *ngIf="isLast; else parent">
         {{ breadcrumb.label }}
       </ng-container>

--- a/s4e-web/src/app/views/settings/dashboard/dashboard.component.html
+++ b/s4e-web/src/app/views/settings/dashboard/dashboard.component.html
@@ -5,7 +5,7 @@
     Zobacz jakie masz uprawnienia:
   </p>
   <ng-container dashboard-tiles>
-    <s4e-tile>
+    <s4e-tile data-e2e="go-to-people-list-tile">
       <img src="./assets/images/ico_people.svg" alt="Ikona ludzi" width="50" tile-image />
       <header class="panel__header" tile-title>Ludzie</header>
       <p i18n tile-description>Panel służy do zarządzania osobami, które są pracownikami lub współpracownikami instytucji.</p>
@@ -20,7 +20,7 @@
       </button>
     </s4e-tile>
 
-    <s4e-tile>
+    <s4e-tile data-e2e="go-to-institution-profile-tile">
       <img src="./assets/images/ico_institution.svg" alt="Ikona ludzi" width="50" tile-image />
       <header class="panel__header" tile-title>Profil instytucji</header>
       <p i18n tile-description>To instytucja, której jesteś administratorem. Możesz edytować tam podstawowe informacje.</p>

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-list/institution-list.component.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-list/institution-list.component.ts
@@ -1,4 +1,5 @@
-import {Component, OnInit} from '@angular/core';
+import { untilDestroyed } from 'ngx-take-until-destroy';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import {Observable} from 'rxjs';
 import {Institution} from '../../state/institution/institution.model';
 import {InstitutionQuery} from '../../state/institution/institution.query';
@@ -10,7 +11,7 @@ import {ModalService} from '../../../../modal/state/modal.service';
   templateUrl: './institution-list.component.html',
   styleUrls: ['./institution-list.component.scss']
 })
-export class InstitutionListComponent implements OnInit {
+export class InstitutionListComponent implements OnInit, OnDestroy {
   isLoading$: Observable<boolean>;
   institutions$: Observable<Institution[]>;
   error$: Observable<any>;
@@ -31,7 +32,9 @@ export class InstitutionListComponent implements OnInit {
   async deleteInstitution(slug: string) {
     if(await this._modalService.confirm('Usuń instytucję',
       'Czy na pewno chcesz usunąć tą instytucję? Operacja jest nieodwracalna.')) {
-      this._institutionService.delete(slug);
+      this._institutionService.delete(slug).pipe(untilDestroyed(this)).subscribe();
     }
   }
+
+  ngOnDestroy() {}
 }

--- a/s4e-web/src/app/views/settings/settings.component.html
+++ b/s4e-web/src/app/views/settings/settings.component.html
@@ -14,7 +14,7 @@
     </div>
     <ul class="navigation__list">
       <li *ngIf="showInstitutions$ | async" routerLinkActive="active"
-          data-e2e="dashboard">
+          data-e2e="go-to-dashboard">
         <a [routerLink]="['./dashboard']"
            queryParamsHandling="merge"
            i18n>Start</a>


### PR DESCRIPTION
Dashboards (sanity check)
* Dashboards contain correct tiles
* User can access the appropriate dashboard according to his/her permissions/roles

Breadcrumb
* Should check breadcrumb generation for different users

Institution list
* ~~Should remove an institution~~ (bug: [Fix] DELETE on institution in API #709)

Closes #453