### PR TITLE
[Hotfix] Categories url builder for S3 icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /.env
 /backend-production.env
 /backend-custom.env
+/resources
 
 # maven build
 .flattened-pom.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- [Hotfix] Categories url builder for S3 icons [#711](https://github.com/cyfronet-fid/sat4envi/issues/711)
+
 ### Updated
 
 ## [v12.0.0]

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/ProductCategoryService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/ProductCategoryService.java
@@ -7,17 +7,16 @@ import pl.cyfronet.s4e.properties.FileStorageProperties;
 @Service
 @RequiredArgsConstructor
 public class ProductCategoryService {
-    private final static String ICON_EXTENSION_WITH_DOT = ".svg";
+    public final static String ICON_EXTENSION_WITH_DOT = ".svg";
 
     private final FileStorageProperties fileStorageProperties;
 
     public String getIconPath(String iconName) {
-        return String.join(
-                "/",
+        return String.join("",
                 fileStorageProperties.getBucket(),
+                "/",
                 fileStorageProperties.getKeyPrefixProductsCategoriesIcons(),
-                iconName,
-                ICON_EXTENSION_WITH_DOT
+                iconName + ICON_EXTENSION_WITH_DOT
         );
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/ProductCategoryServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/ProductCategoryServiceTest.java
@@ -1,0 +1,32 @@
+package pl.cyfronet.s4e.service;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.properties.FileStorageProperties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@BasicTest
+@Slf4j
+public class ProductCategoryServiceTest {
+    @Autowired
+    private ProductCategoryService productCategoryService;
+
+    @Autowired
+    private FileStorageProperties fileStorageProperties;
+
+    @Test
+    public void shouldReturnUrlToCategoriesFileInS3() {
+        val iconName = "test";
+        val iconNameWithExtension = iconName + ProductCategoryService.ICON_EXTENSION_WITH_DOT;
+        val bucketWithIconsKey = fileStorageProperties.getBucket()
+                + "/" + fileStorageProperties.getKeyPrefixProductsCategoriesIcons();
+        val iconPath = bucketWithIconsKey + iconNameWithExtension;
+
+        assertThat(productCategoryService.getIconPath(iconName), is(iconPath));
+    }
+}


### PR DESCRIPTION
what happens?
Generated url is incorrect (double backslash and slash before file extension) static/categories//ico_earth/.svg

What will happen?
Generated url will look like: static/categories/ico_earth.svg