### PR TITLE
[Fix] Products seeds categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- [Fix] Products seeds categories
+
 ### Updated
 
 ## [v12.0.1]

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Product.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Product.java
@@ -96,9 +96,10 @@ public class Product extends CreationAndModificationAudited {
     private Set<AppUser> favourites = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_category_id", insertable = false)
+    @JoinColumn(name = "product_category_id", nullable = false)
+    @Builder.Default
     @ToString.Exclude
-    private ProductCategory productCategory;
+    private ProductCategory productCategory = ProductCategory.builder().id(1L).build();
 
     public void addFavourite(AppUser appUser) {
         this.favourites.add(appUser);


### PR DESCRIPTION
- [fix] set category from the request while creating a new product

What has happened?

For DB
Hibernate has replaced category with the default one while creating a new record.

For UI
All products are in this same category no matter of products seeds categories.