### PR TITLE
Recreate DB index on scene.timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- Recreate DB index on scene.timestamp [#735](https://github.com/cyfronet-fid/sat4envi/issues/735)
 - Fix DELETE on institution in API [#709](https://github.com/cyfronet-fid/sat4envi/issues/709)
 - Remove system affecting sudo calls from seed.sh [#731](https://github.com/cyfronet-fid/sat4envi/issues/731)
 - [Fix] Products seeds categories

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneService.java
@@ -94,7 +94,8 @@ public class SceneService {
         if (!productRepository.existsById(productId)) {
             throw constructNFE("Product", productId);
         }
-        return sceneRepository.findFirstByProductId(productId, Sort.by(Sort.Direction.DESC, "timestamp"), projection);
+        Sort sort = Sort.by(Sort.Order.desc("timestamp"), Sort.Order.asc("id"));
+        return sceneRepository.findFirstByProductId(productId, sort, projection);
     }
 
     private NotFoundException constructNFE(String name, Long id) {

--- a/s4e-backend/src/main/resources/db/migration/V50__add_scene_timestamp_index.sql
+++ b/s4e-backend/src/main/resources/db/migration/V50__add_scene_timestamp_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_scene_timestamp ON scene USING btree (timestamp);


### PR DESCRIPTION
I accidentally removed the index when renormalizing DB schema, affecting
query performance.

Enforce deterministic ordering when timestamps are equal.

Closes: #735.