### PR TITLE
[#737] Upgrade minio image to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Updated
 
+- Upgrade minio image to 1.2.0 [#737](https://github.com/cyfronet-fid/sat4envi/issues/737)
+
 ## [v12.0.1]
 
 ### Added

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -42,11 +42,9 @@ services:
     depends_on:
       - geoserver-test
   minio-test:
-    image: fiddev/minio-test:1.1.0
+    image: fiddev/minio-test:1.2.0
     ports:
       - ${MINIO_TEST_PORT:-9002}:9000
-    volumes:
-      - ./resources/minio:/data
     networks:
       - net-test
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,11 +39,9 @@ services:
     networks:
       - net
   minio:
-    image: fiddev/minio-test:1.1.0
+    image: fiddev/minio-test:1.2.0
     ports:
       - ${MINIO_PORT:-9001}:9000
-    volumes:
-    - ./resources/minio:/data
     networks:
       - net
     environment:


### PR DESCRIPTION
This version contains `resources/minio/local-dataset-1` contents, needed
for new seeds to work.
Categories icons and legends are present there too.

Closes: #737.