### PR TITLE
Backend dependencies update - 2020-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Updated
 
+- 2020.10 backend dependencies update (postgis image 12-3.0-alpine -> 13-3.0)
+
 ## [v13.0.0]
 
 ### Added

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -66,7 +66,7 @@ services:
       S3_ACCESS_KEY: ${GEOSERVER_S3_ACCESS_KEY:-miniotest}
       S3_SECRET_KEY: ${GEOSERVER_S3_SECRET_KEY:-miniotest123}
   db-test:
-    image: postgis/postgis:12-3.0-alpine
+    image: postgis/postgis:13-3.0
     ports:
       - ${DB_TEST_PORT:-5434}:5432
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       S3_ACCESS_KEY: ${GEOSERVER_S3_ACCESS_KEY:-minio}
       S3_SECRET_KEY: ${GEOSERVER_S3_SECRET_KEY:-minio123}
   db:
-    image: postgis/postgis:12-3.0-alpine
+    image: postgis/postgis:13-3.0
     ports:
       - ${DB_PORT:-5433}:5432
     networks:

--- a/pom.xml
+++ b/pom.xml
@@ -26,22 +26,25 @@
         <java.version>11</java.version>
         <maven.compiler.release>11</maven.compiler.release>
 
-        <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
+        <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
 
-        <awssdk.version>2.14.7</awssdk.version>
+        <awssdk.version>2.15.2</awssdk.version>
         <commonmark.version>0.15.2</commonmark.version>
         <commons-email.version>1.5</commons-email.version>
         <geotools.version>23.2</geotools.version>
         <greenmail.version>1.6.0</greenmail.version>
         <guava.version>29.0-jre</guava.version>
         <hibernate-types.version>2.9.13</hibernate-types.version>
+        <jakarta.json-api.version>2.0.0-RC3</jakarta.json-api.version>
         <jjwt.version>0.11.2</jjwt.version>
-        <mapstruct.version>1.4.0.CR1</mapstruct.version>
+        <joy.version>2.0.0-RC2</joy.version>
+        <justify.version>3.0.0-RC2</justify.version>
+        <mapstruct.version>1.4.0.Final</mapstruct.version>
         <poiooxml.version>4.1.2</poiooxml.version>
         <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
         <slugify.version>2.4</slugify.version>
-        <springdoc-openapi.version>1.4.5</springdoc-openapi.version>
-        <unirest.version>3.10.00</unirest.version>
+        <springdoc-openapi.version>1.4.8</springdoc-openapi.version>
+        <unirest.version>3.11.00</unirest.version>
         <bucket4j-starter.version>0.2.0</bucket4j-starter.version>
         <caffeine.version>2.8.5</caffeine.version>
         <!--
@@ -166,6 +169,10 @@
                     <version>4.0.2</version>
                     <configuration>
                         <verbose>true</verbose>
+                        <!-- Don't fail for example when building based on a zip from a release. -->
+                        <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                        <!-- Work only on the git information already in the .git directory. Don't fetch. -->
+                        <offline>true</offline>
                         <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
                         <generateGitPropertiesFile>true</generateGitPropertiesFile>
                         <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -137,14 +137,19 @@
         which conflicts with jakarta.json-api.
         -->
         <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <version>${jakarta.json-api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.leadpony.justify</groupId>
             <artifactId>justify</artifactId>
-            <version>2.0.0</version>
+            <version>${justify.version}</version>
         </dependency>
         <dependency>
             <groupId>org.leadpony.joy</groupId>
-            <artifactId>joy</artifactId>
-            <version>1.3.0</version>
+            <artifactId>joy-classic</artifactId>
+            <version>${joy.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/JsonStringValidator.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/JsonStringValidator.java
@@ -1,8 +1,9 @@
 package pl.cyfronet.s4e.controller.validation;
 
-import javax.json.Json;
-import javax.json.JsonReader;
-import javax.json.stream.JsonParsingException;
+import jakarta.json.Json;
+import jakarta.json.JsonReader;
+import jakarta.json.stream.JsonParsingException;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.io.ByteArrayInputStream;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/Prototype.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/Prototype.java
@@ -1,10 +1,9 @@
 package pl.cyfronet.s4e.sync;
 
+import jakarta.json.JsonObject;
 import lombok.Builder;
 import lombok.Value;
 import org.locationtech.jts.geom.Geometry;
-
-import javax.json.JsonObject;
 
 @Builder
 @Value

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/ScenePersister.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/ScenePersister.java
@@ -3,6 +3,7 @@ package pl.cyfronet.s4e.sync;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -12,8 +13,6 @@ import pl.cyfronet.s4e.bean.Scene;
 import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.data.repository.SceneRepository;
 import pl.cyfronet.s4e.ex.NotFoundException;
-
-import javax.json.JsonObject;
 
 @Component
 @RequiredArgsConstructor

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/context/JsonFileContext.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/context/JsonFileContext.java
@@ -1,8 +1,7 @@
 package pl.cyfronet.s4e.sync.context;
 
+import jakarta.json.JsonObject;
 import lombok.Data;
-
-import javax.json.JsonObject;
 
 @Data
 public class JsonFileContext {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/LoadProduct.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/LoadProduct.java
@@ -1,12 +1,12 @@
 package pl.cyfronet.s4e.sync.step;
 
+import jakarta.json.JsonObject;
 import lombok.Builder;
 import lombok.val;
 import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 
-import javax.json.JsonObject;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/LoadSchemaOfCorrectType.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/LoadSchemaOfCorrectType.java
@@ -1,5 +1,8 @@
 package pl.cyfronet.s4e.sync.step;
 
+import jakarta.json.Json;
+import jakarta.json.JsonException;
+import jakarta.json.JsonReader;
 import lombok.Builder;
 import lombok.val;
 import org.leadpony.justify.api.JsonSchema;
@@ -10,9 +13,6 @@ import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 import pl.cyfronet.s4e.sync.context.SchemaData;
 
-import javax.json.Json;
-import javax.json.JsonException;
-import javax.json.JsonReader;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/LoadValidatedJson.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/LoadValidatedJson.java
@@ -1,5 +1,7 @@
 package pl.cyfronet.s4e.sync.step;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 import lombok.Builder;
 import lombok.val;
 import org.leadpony.justify.api.JsonSchema;
@@ -9,8 +11,6 @@ import org.leadpony.justify.api.ProblemHandler;
 import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 
-import javax.json.JsonObject;
-import javax.json.JsonReader;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExist.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExist.java
@@ -1,5 +1,7 @@
 package pl.cyfronet.s4e.sync.step;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
 import lombok.Builder;
 import lombok.val;
 import pl.cyfronet.s4e.ex.S3ClientException;
@@ -7,8 +9,6 @@ import pl.cyfronet.s4e.service.SceneStorage;
 import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 
-import javax.json.JsonObject;
-import javax.json.JsonString;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/metadata/IngestFootprint.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/metadata/IngestFootprint.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.sync.step.metadata;
 
+import jakarta.json.JsonObject;
 import lombok.Builder;
 import lombok.val;
 import org.locationtech.jts.geom.Coordinate;
@@ -11,7 +12,6 @@ import pl.cyfronet.s4e.sync.context.BaseContext;
 import pl.cyfronet.s4e.sync.step.Step;
 import pl.cyfronet.s4e.util.GeometryUtil;
 
-import javax.json.JsonObject;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SchemaTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SchemaTest.java
@@ -1,5 +1,9 @@
 package pl.cyfronet.s4e;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,10 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import pl.cyfronet.s4e.bean.Schema;
 import pl.cyfronet.s4e.data.repository.SchemaRepository;
 
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonValue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/ScenePersisterTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/ScenePersisterTest.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.sync;
 
+import jakarta.json.Json;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,6 @@ import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.data.repository.SceneRepository;
 import pl.cyfronet.s4e.ex.NotFoundException;
 
-import javax.json.Json;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/LoadProductTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/LoadProductTest.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.sync.step;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -7,7 +8,6 @@ import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 
-import javax.json.JsonObject;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/LoadSchemaOfCorrectTypeTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/LoadSchemaOfCorrectTypeTest.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.sync.step;
 
+import jakarta.json.JsonException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.leadpony.justify.api.JsonSchema;
@@ -11,7 +12,6 @@ import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 import pl.cyfronet.s4e.sync.context.SchemaData;
 
-import javax.json.JsonException;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/LoadValidatedJsonTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/LoadValidatedJsonTest.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.sync.step;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.leadpony.justify.api.JsonSchema;
@@ -10,7 +11,6 @@ import org.mockito.Mock;
 import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 
-import javax.json.JsonObject;
 import java.util.function.BiConsumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExistTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/VerifyAllArtifactsExistTest.java
@@ -1,5 +1,8 @@
 package pl.cyfronet.s4e.sync.step;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 import lombok.Value;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,9 +12,6 @@ import pl.cyfronet.s4e.service.SceneStorage;
 import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 
-import javax.json.JsonObject;
-import javax.json.JsonString;
-import javax.json.JsonValue;
 import java.util.Map;
 import java.util.function.BiConsumer;
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/metadata/IngestFootprintTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/step/metadata/IngestFootprintTest.java
@@ -1,5 +1,6 @@
 package pl.cyfronet.s4e.sync.step.metadata;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -9,7 +10,6 @@ import pl.cyfronet.s4e.sync.context.BaseContext;
 import pl.cyfronet.s4e.sync.step.BaseStepTest;
 import pl.cyfronet.s4e.util.GeometryUtil;
 
-import javax.json.JsonObject;
 import java.util.function.BiConsumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
Update postgis docker image to 13-3.0 as new postgresql version has been
released.

Update of justify and joy to new major versions required switching to
jakarta.json-api from javax.json, which is carried out throughout the
code.

Keep current GeoTools version until hibernate-spatial is compatible with
JTS 1.17.x (it introduces a breaking API change).

Make git-commit-id-plugin more forgiving: don't fail if .git directory
isn't available and don't fetch repo information.