### PR TITLE
[#722] Hide actions in settings by institution roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Added
 
+- Hide actions in settings by institution roles [#722](https://github.com/cyfronet-fid/sat4envi/issues/722)
 - Add application loader [#729](https://github.com/cyfronet-fid/sat4envi/issues/729)
 - Return scene key in SearchResponse [#743](https://github.com/cyfronet-fid/sat4envi/issues/743)
 

--- a/s4e-web/cypress.json
+++ b/s4e-web/cypress.json
@@ -2,5 +2,9 @@
   "baseUrl": "https://localhost:4200",
   "viewportWidth": 1400,
   "viewportHeight": 1000,
-  "testFiles": "**/*.spec.ts"
+  "testFiles": "**/*.spec.ts",
+  "retries": {
+    "runMode": 2,
+    "openMode": 1
+  }
 }

--- a/s4e-web/src/app/views/settings/dashboard/dashboard.component.html
+++ b/s4e-web/src/app/views/settings/dashboard/dashboard.component.html
@@ -13,7 +13,7 @@
         routerLink="../people"
         queryParamsHandling="merge"
         class="button button--secondary"
-        [disabled]="!(isInstitutionActive$ | async)"
+        [disabled]="!((isInstitutionActive$ | async) && (isManagerOfActive$ | async))"
         footer-navigation
       >
         Zarządzaj ludźmi

--- a/s4e-web/src/app/views/settings/dashboard/dashboard.component.spec.ts
+++ b/s4e-web/src/app/views/settings/dashboard/dashboard.component.spec.ts
@@ -9,7 +9,7 @@ import { DebugElement } from '@angular/core';
 import { Router, convertToParamMap, ParamMap, ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
-import { Subject, ReplaySubject } from 'rxjs';
+import { Subject, ReplaySubject, of } from 'rxjs';
 
 class ActivatedRouteStub {
   queryParamMap: Subject<ParamMap> = new ReplaySubject(1);
@@ -58,6 +58,7 @@ describe('DashboardComponent', () => {
 
   it('should enable buttons on known institution', fakeAsync( () => {
     activatedRoute.queryParamMap.next(convertToParamMap({ institution: 'test '}));
+    component.isManagerOfActive$ = of(true);
     tick();
     fixture.detectChanges();
 

--- a/s4e-web/src/app/views/settings/dashboard/dashboard.component.ts
+++ b/s4e-web/src/app/views/settings/dashboard/dashboard.component.ts
@@ -2,6 +2,8 @@ import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { InstitutionsSearchResultsQuery } from '../state/institutions-search/institutions-search-results.query';
+import { Institution } from '../state/institution/institution.model';
+import { InstitutionQuery } from '../state/institution/institution.query';
 
 @Component({
   selector: 's4e-dashboard',
@@ -9,13 +11,16 @@ import { InstitutionsSearchResultsQuery } from '../state/institutions-search/ins
   styleUrls: ['./dashboard.component.scss']
 })
 export class DashboardComponent {
-  public isInstitutionActive$: Observable<boolean>;
+  public isInstitutionActive$: Observable<boolean> = this._institutionsSearchResultsQuery
+  .isAnyInstitutionActive$(this._activatedRoute);;
+  public activeInstitution$: Observable<Institution> = this._institutionsSearchResultsQuery
+    .selectActive$(this._activatedRoute);
+  public isManagerOfActive$ = this._institutionQuery
+    .isManagerOf$(this.activeInstitution$);
 
   constructor(
     private _institutionsSearchResultsQuery: InstitutionsSearchResultsQuery,
-    private _activatedRoute: ActivatedRoute
-  ) {
-    this.isInstitutionActive$ = this._institutionsSearchResultsQuery
-      .isAnyInstitutionActive$(this._activatedRoute);
-  }
+    private _activatedRoute: ActivatedRoute,
+    private _institutionQuery: InstitutionQuery
+  ) {}
 }

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.html
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.html
@@ -2,42 +2,42 @@
   <h1 i18n>Profil instytucji</h1>
 </header>
 <section class="content__details content__details--75 profile">
-  <ng-container *ngIf="!!activeInstitution">
+  <ng-container *ngIf="!!(activeInstitution$ | async)">
     <div
       class="profile__content"
       data-e2e="institution-details"
     >
-      <h2 id="institution-title">{{ activeInstitution.name }}</h2>
+      <h2 id="institution-title">{{ (activeInstitution$ | async).name }}</h2>
       <ul>
-        <li id="institution-address">{{ activeInstitution.address }}</li>
+        <li id="institution-address">{{ (activeInstitution$ | async).address }}</li>
         <li
           id="institution-postal-code"
           data-e2e="postal-code-with-city"
         >
-          {{ activeInstitution.postalCode }} {{ activeInstitution.city }}
+          {{ (activeInstitution$ | async).postalCode }} {{ (activeInstitution$ | async).city }}
         </li>
-        <li *ngIf="!!activeInstitution.institutionAdminEmail" id="institution-email">
-          email: {{ activeInstitution.institutionAdminEmail }}
+        <li *ngIf="!!(activeInstitution$ | async).institutionAdminEmail" id="institution-email">
+          email: {{ (activeInstitution$ | async).institutionAdminEmail }}
         </li>
-        <li *ngIf="!!activeInstitution.phone" id="institution-phone">
-          Telefon: {{ activeInstitution.phone }}
+        <li *ngIf="!!(activeInstitution$ | async).phone" id="institution-phone">
+          Telefon: {{ (activeInstitution$ | async).phone }}
         </li>
-        <li *ngIf="!!activeInstitution.secondaryPhone" id="institution-second-phone">
-          Telefon: {{ activeInstitution.secondaryPhone }}
+        <li *ngIf="!!(activeInstitution$ | async).secondaryPhone" id="institution-second-phone">
+          Telefon: {{ (activeInstitution$ | async).secondaryPhone }}
         </li>
       </ul>
     </div>
     <aside class="institution__logo">
       <img
-        *ngIf="!!activeInstitution && activeInstitution.emblem"
-        [src]="activeInstitution.emblem"
+        *ngIf="!!(activeInstitution$ | async) && (activeInstitution$ | async).emblem"
+        [src]="(activeInstitution$ | async).emblem"
         alt="Logo instytucji"
         data-e2e="institution-emblem"
       />
     </aside>
   </ng-container>
   <footer>
-    <ng-container *ngIf="isManager$ | async; else returnToUserProfile">
+    <ng-container *ngIf="isManagerOfActive$ | async; else returnToUserProfile">
       <button
         class="button button--default button--small"
         [routerLink]="['/settings/edit-institution']"
@@ -74,7 +74,7 @@
 </section>
 
 <s4e-generic-list-view
-  *ngIf="isManager$ | async"
+  *ngIf="isManagerOfActive$ | async"
   [loading]="isLoading$ | async"
   [items]="childrenInstitutions$ | async"
   [error]="error$ | async"
@@ -94,17 +94,19 @@
     <td [style.padding-left.px]="(inst.ancestorDepth || 0) * 30 + 15">
       <a routerLink="../institution" queryParamsHandling="merge"
          [queryParams]="{institution: inst.slug}">{{inst.name}}</a></td>
-    <td >
-      <a routerLink="../institution" queryParamsHandling="merge"
-         data-e2e="edit"
-         [queryParams]="{institution: inst.slug}">
-        <img src="/assets/images/ico_edit.svg" alt="Edit" width="15"/>
-      </a>
-      <a href="javascript:void(0)"
-         data-e2e="delete"
-         (click)="deleteInstitution(inst.slug)">
-        <img src="/assets/images/ico_delete.svg" alt="Delete" width="15"/>
-      </a>
+    <td>
+      <ng-container *ngIf="isManagerOf(inst)">
+        <a routerLink="../institution" queryParamsHandling="merge"
+          data-e2e="edit"
+          [queryParams]="{institution: inst.slug}">
+          <img src="/assets/images/ico_edit.svg" alt="Edit" width="15"/>
+        </a>
+        <a href="javascript:void(0)"
+          data-e2e="delete"
+          (click)="deleteInstitution(inst.slug)">
+          <img src="/assets/images/ico_delete.svg" alt="Delete" width="15"/>
+        </a>
+      </ng-container>
     </td>
   </ng-template>
 </s4e-generic-list-view>

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.spec.ts
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.spec.ts
@@ -60,12 +60,11 @@ describe('InstitutionProfileComponent', () => {
     const institution = InstitutionFactory.build();
     const spyFindBy = spyOn(institutionService, 'findBy').and.returnValue(of(institution));
     route.queryParamMap.next(convertToParamMap({ institution: institution.slug }));
-    component.isManager$ = of(true);
+    component.isManagerOfActive$ = of(true);
     tick();
     fixture.detectChanges();
 
     expect(spyFindBy).toHaveBeenCalledWith(institution.slug);
-    expect(component.activeInstitution).toEqual(institution);
 
     const image = de.query(By.css('.institution__logo img'));
     expect(image).toBeTruthy();
@@ -104,13 +103,12 @@ describe('InstitutionProfileComponent', () => {
   it('Should display only institution details when user is only member', fakeAsync(() => {
     const institution = InstitutionFactory.build();
     const spyFindBy = spyOn(institutionService, 'findBy').and.returnValue(of(institution));
-    component.isManager$ = of(false);
+    component.isManagerOfActive$ = of(false);
     route.queryParamMap.next(convertToParamMap({ institution: institution.slug }));
     tick();
     fixture.detectChanges();
 
     expect(spyFindBy).toHaveBeenCalledWith(institution.slug);
-    expect(component.activeInstitution).toEqual(institution);
 
     const image = de.query(By.css('.institution__logo img'));
     expect(image).toBeTruthy();

--- a/s4e-web/src/app/views/settings/manage-institutions/add-institution/add-institution.component.scss
+++ b/s4e-web/src/app/views/settings/manage-institutions/add-institution/add-institution.component.scss
@@ -1,2 +1,0 @@
-@import "src/scss/settings";
-

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-list/institution-list.component.html
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-list/institution-list.component.html
@@ -24,15 +24,21 @@
     >
       <a routerLink="../institution" queryParamsHandling="merge"
          [queryParams]="{institution: inst.slug}">{{inst.name}}</a></td>
-    <td >
-      <a routerLink="../institution" queryParamsHandling="merge"
-         data-e2e="edit"
-         [queryParams]="{institution: inst.slug}">
+    <td>
+      <a
+        *ngIf="isManagerOf(inst) || isAdmin"
+        routerLink="../institution"
+        queryParamsHandling="merge"
+        data-e2e="edit"
+        [queryParams]="{institution: inst.slug}"
+      >
         <img src="/assets/images/ico_edit.svg" alt="Edit" width="15"/>
       </a>
-      <a href="javascript:void(0)"
-         data-e2e="delete"
-         (click)="deleteInstitution(inst.slug)">
+      <a
+        *ngIf="isAdmin"
+        href="javascript:void(0)"
+        data-e2e="delete"
+        (click)="deleteInstitution(inst.slug)">
         <img src="/assets/images/ico_delete.svg" alt="Delete" width="15"/>
       </a>
     </td>

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-list/institution-list.component.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-list/institution-list.component.ts
@@ -1,3 +1,4 @@
+import { SessionQuery } from 'src/app/state/session/session.query';
 import { untilDestroyed } from 'ngx-take-until-destroy';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import {Observable} from 'rxjs';
@@ -12,21 +13,27 @@ import {ModalService} from '../../../../modal/state/modal.service';
   styleUrls: ['./institution-list.component.scss']
 })
 export class InstitutionListComponent implements OnInit, OnDestroy {
-  isLoading$: Observable<boolean>;
-  institutions$: Observable<Institution[]>;
-  error$: Observable<any>;
+  isAdmin = false;
+
+  isLoading$ = this._institutionQuery.selectLoading();
+  institutions$ = this._institutionQuery.selectAll();
+  error$ = this._institutionQuery.selectError();
 
   institutionId = (item: Institution) => item.slug;
 
-  constructor(private _institutionQuery: InstitutionQuery,
-              private _institutionService: InstitutionService,
-              private _modalService: ModalService) {
-  }
+  constructor(
+    private _institutionQuery: InstitutionQuery,
+    private _institutionService: InstitutionService,
+    private _sessionQuery: SessionQuery,
+    private _modalService: ModalService
+  ) {}
 
   ngOnInit() {
-    this.isLoading$ = this._institutionQuery.selectLoading();
-    this.institutions$ = this._institutionQuery.selectAll();
-    this.error$ = this._institutionQuery.selectError();
+    this.isAdmin = this._sessionQuery.isAdmin();
+  }
+
+  isManagerOf(institution: Institution) {
+    return this._institutionQuery.isManagerOf(institution);
   }
 
   async deleteInstitution(slug: string) {

--- a/s4e-web/src/app/views/settings/manage-institutions/parent-institution-modal/parent-institution-modal.component.spec.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/parent-institution-modal/parent-institution-modal.component.spec.ts
@@ -54,7 +54,7 @@ describe('ParentInstitutionModalComponent', () => {
       {name: 'Straz pozarna'},
       {name: 'Pogotowie'}
     ];
-    spyOn(institutionQuery, 'selectAll').and.returnValue(of(institutions));
+    spyOn(institutionQuery, 'getAdministrationInstitutions$').and.returnValue(of(institutions));
 
     fixture.detectChanges();
 
@@ -74,7 +74,7 @@ describe('ParentInstitutionModalComponent', () => {
       searchedInstitution,
       {name: 'Pogotowie'}
     ];
-    spyOn(institutionQuery, 'selectAll').and.returnValue(of(institutions));
+    spyOn(institutionQuery, 'getAdministrationInstitutions$').and.returnValue(of(institutions));
 
     fixture.detectChanges();
 
@@ -93,7 +93,7 @@ describe('ParentInstitutionModalComponent', () => {
       {name: 'Straz pozarna'},
       {name: 'Pogotowie'}
     ];
-    spyOn(institutionQuery, 'selectAll').and.returnValue(of(institutions));
+    spyOn(institutionQuery, 'getAdministrationInstitutions$').and.returnValue(of(institutions));
 
     fixture.detectChanges();
 

--- a/s4e-web/src/app/views/settings/manage-institutions/parent-institution-modal/parent-institution-modal.component.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/parent-institution-modal/parent-institution-modal.component.ts
@@ -49,7 +49,7 @@ export class ParentInstitutionModalComponent extends ModalComponent<Partial<Inst
 
   ngOnInit() {
     combineLatest(
-      this._institutionQuery.selectAll(),
+      this._institutionQuery.getAdministrationInstitutions$(),
       this.institutionsSearch.valueChanges
     )
     .pipe(untilDestroyed(this))

--- a/s4e-web/src/app/views/settings/profile/profile.component.html
+++ b/s4e-web/src/app/views/settings/profile/profile.component.html
@@ -40,6 +40,7 @@
         </p>
       </div>
       <button
+       style="z-index: 999"
         *ngIf="hasMoreAdministrationInstitutionsThanMax$ | async"
         class="button button--secondary button--small"
         routerLink="/settings/institutions"
@@ -53,6 +54,7 @@
     </s4e-tile>
 
     <s4e-tile
+      style="z-index: 999"
       *ngIf="(memberInstitutions$ | async).length > 0"
       data-e2e="member-institutions-tile"
       data-ut="member-institutions-tile"

--- a/s4e-web/src/app/views/settings/settings.component.html
+++ b/s4e-web/src/app/views/settings/settings.component.html
@@ -56,11 +56,11 @@
             </ng-template>
           </s4e-search>
       </li>
-      <li *ngIf="showInstitutions$ | async" routerLinkActive="active">
+      <li *ngIf="(showInstitutions$ | async)" routerLinkActive="active">
         <a
           [routerLink]="['./people']"
           queryParamsHandling="merge"
-          [class.disabled]="!(isInstitutionActive$ | async)"
+          [class.disabled]="!((isInstitutionActive$ | async) && (isManagerOfActive$ | async))"
           data-e2e="go-to-institution-people-btn"
           i18n
         >

--- a/s4e-web/src/app/views/settings/settings.component.ts
+++ b/s4e-web/src/app/views/settings/settings.component.ts
@@ -26,6 +26,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
     .selectCanSeeInstitutions();
   public isInstitutionActive$: Observable<boolean> = this.institutionsSearchResultsQuery
     .isAnyInstitutionActive$(this._activatedRoute);
+  public activeInstitution$: Observable<Institution> = this.institutionsSearchResultsQuery
+    .selectActive$(this._activatedRoute);
+  public isManagerOfActive$ = this._institutionQuery
+    .isManagerOf$(this.activeInstitution$);
 
   constructor(
     private _institutionsSearchResultsService: InstitutionsSearchResultsService,

--- a/s4e-web/src/app/views/settings/state/institution/institution.query.ts
+++ b/s4e-web/src/app/views/settings/state/institution/institution.query.ts
@@ -26,6 +26,14 @@ export class InstitutionQuery extends QueryEntity<InstitutionState, Institution>
         .filter(institution => memberInstitutionSlugs.some(slug => slug === institution.slug));
     }));
   }
+  public isManagerOf$(institution$: Observable<Institution>): Observable<boolean> {
+    return institution$
+      .pipe(map(institution => this.isManagerOf(institution)));
+  }
+  public isManagerOf(institution: Institution): boolean {
+    const administratorInstitutionsSlugs = this._sessionQuery.getAdministratorInstitutionsSlugs();
+    return administratorInstitutionsSlugs.some(slug => slug === institution.slug);
+  }
 
   constructor(
     protected store: InstitutionStore,


### PR DESCRIPTION
Functionalities tested on zkAdmin with additional institution Zarządzanie kryzysowe - Mazowieckie as a member (can be added from super admin account)

- When the user has only a member role in a selected institution in sidebar search
  - Disable Ludzie button in settings sidebar
  - Disable Zarządzaj ludźmi button in settings dashboard
  - Hide dodaj dziecko action and list of children in institution profile

- Setting an institutions list
  - Hide delete action when the user isnt super admin
  - Hide edit action when the user has only member role to a specific institution

- Settings institution profile
  - Hide action of children for which the user has only member role

Closes #722