### PR TITLE
[#762] Fix GHSA-mfwh-5m23-j46w github actions vulnerability

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install jq 1.6
         run: mkdir bin && curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > bin/jq && chmod u+x bin/jq
       - name: Add bin to path
-        run: echo "::add-path::$(pwd)/bin"
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: Maven package
         run: ./mvnw clean package -DskipTests -Dsha1=-${GITHUB_SHA}
       - name: Start containers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- GHSA-mfwh-5m23-j46w github actions vulnerability [#762](https://github.com/cyfronet-fid/sat4envi/issues/762)
+
 ### Updated
 
 ## [v13.1.0]


### PR DESCRIPTION
Replaces use of set-path command in github actions with using configuration file, which mitigates GHSA-mfwh-5m23-j46w.
The set-path command has been marked as deprecated and will be removed in upcoming github actions versions.

Fixes: #762.