### PR TITLE
[#774] Output info about bucket and schemas in seed.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Changed
 
+- Output info about bucket and schemas in seed.sh [#774](https://github.com/cyfronet-fid/sat4envi/issues/774)
 - Content for invitation form [#629](https://github.com/cyfronet-fid/sat4envi/issues/629)
 - New text for sharing view mail [#790](https://github.com/cyfronet-fid/sat4envi/issues/790)
 


### PR DESCRIPTION
Moreover, redirect categories creating request result to $temp_file, so
that it's not output when there is no error and handled well when there
is one.

Closes: #774.