### PR TITLE
[#776] Allow accessing on the hour EUMETSAT scenes in gs-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The most recent changes are on top, in each type of changes category.
 
 ### Fixed
 
+- Allow accessing on the hour EUMETSAT scenes in gs-gateway [#776](https://github.com/cyfronet-fid/sat4envi/issues/776) 
 - GHSA-mfwh-5m23-j46w github actions vulnerability [#762](https://github.com/cyfronet-fid/sat4envi/issues/762)
 
 ### Updated

--- a/gs-gateway/src/test/java/pl/cyfronet/gsg/security/LayerSecurityGatewayFilterTest.java
+++ b/gs-gateway/src/test/java/pl/cyfronet/gsg/security/LayerSecurityGatewayFilterTest.java
@@ -115,6 +115,18 @@ class LayerSecurityGatewayFilterTest {
 
     private static Stream<Arguments> shouldHandleEumetsatLicense() {
         return Stream.of(
+                Arguments.of("2007-12-03T10:01:00.00Z", null,              true,  HttpStatus.UNAUTHORIZED),
+                Arguments.of("2007-12-03T10:01:00.00Z", Set.of(),          true,  HttpStatus.FORBIDDEN),
+                Arguments.of("2007-12-03T10:00:59.99Z", null,              false, null),
+                Arguments.of("2007-12-03T10:00:59.99Z", Set.of(),          false, null),
+                Arguments.of("2007-12-03T10:00:00.00Z", null,              false, null),
+                Arguments.of("2007-12-03T10:00:00.00Z", Set.of(),          false, null),
+                Arguments.of("2007-12-03T09:59:59.99Z", null,              true,  HttpStatus.UNAUTHORIZED),
+                Arguments.of("2007-12-03T09:59:59.99Z", Set.of(),          true,  HttpStatus.FORBIDDEN),
+                Arguments.of("2007-12-03T09:00:00.00Z", null,              false, null),
+                Arguments.of("2007-12-03T09:00:00.00Z", Set.of(),          false, null),
+                Arguments.of("2007-12-03T08:00:00.00Z", null,              false, null),
+                Arguments.of("2007-12-03T08:00:00.00Z", Set.of(),          false, null),
                 Arguments.of("2007-12-03T07:15:31.00Z", null,              true,  HttpStatus.UNAUTHORIZED),
                 Arguments.of("2007-12-03T07:15:31.00Z", Set.of(),          true,  HttpStatus.FORBIDDEN),
                 Arguments.of("2007-12-03T07:15:31.00Z", Set.of("layer_1"), false, null),


### PR DESCRIPTION
Add the missed requirement of an EUMETSAT license, that scenes with
hourly time resolution are available without license regardless of
ordinary temporal constraints.

Closes: #776.