### PR TITLE
Update GeoServer image to 1.5.0-GS2.18.0

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -52,7 +52,7 @@ services:
       MINIO_SECRET_KEY: ${MINIO_TEST_SECRET_KEY:-miniotest123}
     command: server /data
   geoserver-test:
-    image: fiddev/geoserver:1.4.0-GS2.17.0
+    image: fiddev/geoserver:1.5.0-GS2.18.0
     ports:
       - ${GEOSERVER_TEST_PORT:-8081}:8080
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minio123}
     command: server /data
   geoserver:
-    image: fiddev/geoserver:1.4.0-GS2.17.0
+    image: fiddev/geoserver:1.5.0-GS2.18.0
     volumes:
       - ./tmp/geoserver-data:/opt/geoserver/data_dir
     ports:


### PR DESCRIPTION
This image update apart from GeoServer update brings two changes:
- enabling of a low-level S3 cache,
- possible fix of the rectangular artifacts in WMS output.

Fixes #564 and provides basis for further cache optimization in #700.