### PR TITLE
[#816] Add missing eumetsat_license values

### DIFF
--- a/s4e-backend/src/main/resources/db/migration/V54__set_default_to_eumetsat_license_fields.sql
+++ b/s4e-backend/src/main/resources/db/migration/V54__set_default_to_eumetsat_license_fields.sql
@@ -1,0 +1,2 @@
+UPDATE app_user SET eumetsat_license = false WHERE eumetsat_license IS NULL;
+UPDATE institution SET eumetsat_license = false WHERE eumetsat_license IS NULL;


### PR DESCRIPTION
The migration V53__add_eumetsat_license_fields.sql didn't set the
eumetsat_license field, leaving it effectively null after migration.

Reset the fields to false explicitly.

Fixes: #816.