### PR TITLE
[#808] Give administrator privilidge to user in add insitution form and on people page

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
@@ -40,10 +40,18 @@ public class AppUser extends CreationAndModificationAudited {
     @NotEmpty
     private String password;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @Builder.Default
     @ToString.Exclude
     private Set<UserRole> roles = new HashSet<>();
+
+    public void addRole(UserRole role) {
+        roles.add(role);
+    }
+
+    public void removeRole(UserRole role) {
+        roles.remove(role);
+    }
 
     private boolean enabled;
 
@@ -61,10 +69,6 @@ public class AppUser extends CreationAndModificationAudited {
     private Usage usage;
 
     private String country;
-
-    public void removeRole(UserRole role) {
-        roles.remove(role);
-    }
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Institution.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Institution.java
@@ -49,10 +49,14 @@ public class Institution extends CreationAndModificationAudited {
     @ToString.Exclude
     private Institution parent;
 
-    @OneToMany(mappedBy = "institution", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "institution", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @Builder.Default
     @ToString.Exclude
     private Set<UserRole> membersRoles = new HashSet<>();
+
+    public void addMemberRole(UserRole role) {
+        membersRoles.add(role);
+    }
 
     public void removeMemberRole(UserRole role) {
         membersRoles.remove(role);

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Invitation.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/Invitation.java
@@ -24,6 +24,8 @@ public class Invitation extends CreationAndModificationAudited {
     @NotEmpty
     private String token;
 
+    private boolean forAdmin;
+
     @Enumerated(EnumType.STRING)
     @NotNull
     private InvitationStatus status;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/InvitationController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/InvitationController.java
@@ -62,7 +62,11 @@ public class InvitationController {
             @RequestBody @Valid InvitationRequest request,
             @PathVariable("institution") String institutionSlug
     ) throws Exception {
-        val token = invitationService.createInvitationFrom(request.getEmail(), institutionSlug);
+        val token = invitationService.createInvitationFrom(
+                request.getEmail(),
+                institutionSlug,
+                request.isForAdmin()
+        );
         val invitationEvent = new OnSendInvitationEvent(token, LocaleContextHolder.getLocale());
         eventPublisher.publishEvent(invitationEvent);
 
@@ -92,7 +96,11 @@ public class InvitationController {
                 .orElseThrow(() -> new NotFoundException("Invitation couldn't be found"));
         invitationService.deleteBy(invitation.getToken());
 
-        val newToken = invitationService.createInvitationFrom(request.getNewEmail(), institutionSlug);
+        val newToken = invitationService.createInvitationFrom(
+                request.getNewEmail(),
+                institutionSlug,
+                request.isForAdmin()
+        );
         val invitationEvent = new OnSendInvitationEvent(newToken, LocaleContextHolder.getLocale());
         eventPublisher.publishEvent(invitationEvent);
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/CreateChildInstitutionRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/CreateChildInstitutionRequest.java
@@ -7,7 +7,6 @@ import pl.cyfronet.s4e.controller.validation.Base64;
 import pl.cyfronet.s4e.controller.validation.ContentType;
 import pl.cyfronet.s4e.controller.validation.ImageDimensions;
 
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 @Data
@@ -15,9 +14,6 @@ import javax.validation.constraints.NotEmpty;
 public class CreateChildInstitutionRequest {
     @NotEmpty
     private String name;
-
-    @Email
-    private String institutionAdminEmail;
 
     @Base64
     @ContentType(pattern = "image/(jpeg|png|gif)")

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/CreateInstitutionRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/CreateInstitutionRequest.java
@@ -7,7 +7,6 @@ import pl.cyfronet.s4e.controller.validation.Base64;
 import pl.cyfronet.s4e.controller.validation.ContentType;
 import pl.cyfronet.s4e.controller.validation.ImageDimensions;
 
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 @Data
@@ -31,7 +30,4 @@ public class CreateInstitutionRequest {
     private String phone;
 
     private String secondaryPhone;
-
-    @Email
-    private String institutionAdminEmail;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/DeleteUserRoleRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/DeleteUserRoleRequest.java
@@ -18,6 +18,4 @@ public class DeleteUserRoleRequest {
     AppRole role;
     @NotEmpty
     String institutionSlug;
-    @NotEmpty
-    String groupSlug;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/InvitationRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/InvitationRequest.java
@@ -12,4 +12,6 @@ public class InvitationRequest {
     @Email
     @NotEmpty
     private String email;
+
+    private boolean forAdmin;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/InvitationResendInvitation.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/InvitationResendInvitation.java
@@ -16,4 +16,6 @@ public class InvitationResendInvitation {
     @Email
     @NotEmpty
     private String newEmail;
+
+    private boolean forAdmin;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/MemberResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/MemberResponse.java
@@ -3,6 +3,8 @@ package pl.cyfronet.s4e.controller.response;
 import java.util.Set;
 
 public interface MemberResponse {
+    Long getId();
+
     String getEmail();
 
     String getName();

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/InstitutionRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/InstitutionRepository.java
@@ -17,7 +17,13 @@ public interface InstitutionRepository extends CrudRepository<Institution, Long>
 
     <T> List<T> findAllBy(Class<T> projection);
 
+    Optional<Institution> findBySlug(String slug);
+
     <T> Optional<T> findBySlug(String slug, Class<T> projection);
+
+    Set<Institution> findAllByParentId(Long ParentId);
+
+    <T> Set<T> findAllByParentId(Long ParentId, Class<T> projection);
 
     @Query(value = "SELECT i.* " +
             "FROM Institution i " +
@@ -31,8 +37,8 @@ public interface InstitutionRepository extends CrudRepository<Institution, Long>
             "FROM AppUser u " +
             "LEFT JOIN FETCH u.roles r " +
             "LEFT JOIN FETCH r.institution i " +
-            "WHERE i.slug = :institutionSlug AND r.role = :role")
-    <T> Set<T> findAllMembers(String institutionSlug, AppRole role, Class<T> projection);
+            "WHERE i.slug = :institutionSlug")
+    <T> Set<T> findAllMembers(String institutionSlug, Class<T> projection);
 
     @Query("SELECT u.email " +
             "FROM UserRole r " +

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
@@ -270,57 +270,108 @@ public class SeedUsers implements ApplicationRunner {
         log.info("Seeding Institutions & Roles");
         try {
             String name = "Zarządzenie kryzysowe - PL";
-            Institution institution = institutionService.save(Institution.builder()
+            Institution zkPlInstitution = institutionService.save(Institution.builder()
                     .name(name)
                     .slug(slugService.slugify(name))
                     .city("Warszawa")
                     .build());
-            institutionService.addMember(institution.getSlug(), "zkMember@mail.pl");
-            institutionService.addMember(institution.getSlug(), "zkAdmin@mail.pl");
-            userRoleService.addRole(AppRole.INST_ADMIN, "zkAdmin@mail.pl", institution.getSlug());
-
-            institutionService.addMember(institution.getSlug(), "zkPLMember@mail.pl");
-            institutionService.addMember(institution.getSlug(), "zkPLAdmin@mail.pl");
-            userRoleService.addRole(AppRole.INST_ADMIN, "zkPLAdmin@mail.pl", institution.getSlug());
-            institutionService.addMember(institution.getSlug(), "admin@mail.pl");
-            userRoleService.addRole(AppRole.INST_ADMIN, "admin@mail.pl", institution.getSlug());
+            userRoleService.addRole(
+                    zkPlInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkMember@mail.pl").get().getId(),
+                    AppRole.INST_MEMBER
+            );
+            userRoleService.addRole(
+                    zkPlInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkAdmin@mail.pl").get().getId(),
+                    AppRole.INST_ADMIN
+            );
+            userRoleService.addRole(
+                    zkPlInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkPLMember@mail.pl").get().getId(),
+                    AppRole.INST_MEMBER
+            );
+            userRoleService.addRole(
+                    zkPlInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkPLAdmin@mail.pl").get().getId(),
+                    AppRole.INST_ADMIN
+            );
+            userRoleService.addRole(
+                    zkPlInstitution.getSlug(),
+                    appUserRepository.findByEmail("admin@mail.pl").get().getId(),
+                    AppRole.INST_ADMIN
+            );
 
             name = "Zarządzanie kryzysowe - Mazowieckie";
             CreateChildInstitutionRequest zkMazRequest = CreateChildInstitutionRequest.builder()
-                    .institutionAdminEmail("zkMazAdmin@mail.pl")
                     .name(name)
                     .city("Warszawa")
                     .build();
-            Institution childInstitution = institutionService.createChildInstitution(zkMazRequest, institution.getSlug());
-            institutionService.addMember(childInstitution.getSlug(), "zkMazMember@mail.pl");
+            Institution zkMazInstitution = institutionService
+                    .createChildInstitution(zkMazRequest, zkPlInstitution.getSlug());
+            userRoleService.addRole(
+                    zkMazInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkMazAdmin@mail.pl").get().getId(),
+                    AppRole.INST_ADMIN
+            );
+            userRoleService.addRole(
+                    zkMazInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkMazMember@mail.pl").get().getId(),
+                    AppRole.INST_MEMBER
+            );
 
             name = "Zarządzanie kryzysowe - Warszawa";
             CreateChildInstitutionRequest zkWawRequest = CreateChildInstitutionRequest.builder()
-                    .institutionAdminEmail("zkWawAdmin@mail.pl")
                     .name(name)
                     .city("Warszawa")
                     .build();
-            Institution child2RowInstitution = institutionService.createChildInstitution(zkWawRequest, childInstitution.getSlug());
-            institutionService.addMember(child2RowInstitution.getSlug(), "zkWawMember@mail.pl");
+            Institution zkWawInstitution = institutionService
+                    .createChildInstitution(zkWawRequest, zkMazInstitution.getSlug());
+            userRoleService.addRole(
+                    zkWawInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkWawAdmin@mail.pl").get().getId(),
+                    AppRole.INST_ADMIN
+            );
+            userRoleService.addRole(
+                    zkWawInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkWawMember@mail.pl").get().getId(),
+                    AppRole.INST_MEMBER
+            );
 
             name = "Zarządzanie kryzysowe - Małopolska";
             CreateChildInstitutionRequest zkMalRequest = CreateChildInstitutionRequest.builder()
-                    .institutionAdminEmail("zkMalAdmin@mail.pl")
                     .name(name)
                     .city("Kraków")
                     .build();
-            childInstitution = institutionService.createChildInstitution(zkMalRequest, institution.getSlug());
-            institutionService.addMember(childInstitution.getSlug(), "zkMalMember@mail.pl");
+            Institution zkMalInstitution = institutionService
+                    .createChildInstitution(zkMalRequest, zkPlInstitution.getSlug());
+            userRoleService.addRole(
+                    zkMalInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkMalAdmin@mail.pl").get().getId(),
+                    AppRole.INST_ADMIN
+            );
+            userRoleService.addRole(
+                    zkMalInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkMalMember@mail.pl").get().getId(),
+                    AppRole.INST_MEMBER
+            );
 
             name = "Zarządzanie kryzysowe - Kraków";
             CreateChildInstitutionRequest zkKrRequest = CreateChildInstitutionRequest.builder()
-                    .institutionAdminEmail("zkKrAdmin@mail.pl")
                     .name(name)
                     .city("Kraków")
                     .build();
-            child2RowInstitution = institutionService.createChildInstitution(zkKrRequest, childInstitution.getSlug());
-            institutionService.addMember(child2RowInstitution.getSlug(), "zkKrAdmin@mail.pl");
-
+            Institution zkKrInstitution = institutionService
+                    .createChildInstitution(zkKrRequest, zkMalInstitution.getSlug());
+            userRoleService.addRole(
+                    zkKrInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkKrAdmin@mail.pl").get().getId(),
+                    AppRole.INST_ADMIN
+            );
+            userRoleService.addRole(
+                    zkKrInstitution.getSlug(),
+                    appUserRepository.findByEmail("zkKrAdmin@mail.pl").get().getId(),
+                    AppRole.INST_MEMBER
+            );
 
         } catch (InstitutionCreationException e) {
             log.warn(e.getMessage(), e);

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/UserRoleService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/UserRoleService.java
@@ -2,6 +2,7 @@ package pl.cyfronet.s4e.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pl.cyfronet.s4e.bean.AppRole;
@@ -25,58 +26,99 @@ public class UserRoleService {
 
     @Transactional(rollbackFor = NotFoundException.class)
     public void addRole(CreateUserRoleRequest request) throws NotFoundException {
-        addRole(request.getRole(), request.getEmail(), request.getInstitutionSlug());
+        Institution institution = institutionRepository.findBySlug(request.getInstitutionSlug(), Institution.class)
+                .orElseThrow(() -> new NotFoundException(
+                        "Institution not found for id " + request.getInstitutionSlug() + "'"
+                ));
+        AppUser appUser = appUserRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new NotFoundException("User not found for mail: '" + request.getEmail() + "'"));
+        addRole(institution, appUser, request.getRole());
     }
 
     @Transactional(rollbackFor = NotFoundException.class)
-    public void addRole(AppRole role, String email, String institutionSlug) throws NotFoundException {
-        Institution institution = institutionRepository.findBySlug(institutionSlug, Institution.class)
-                .orElseThrow(() -> new NotFoundException("Institution not found for id " + institutionSlug + "'"));
-        AppUser appUser = appUserRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException("User not found for mail: '" + email + "'"));
-        if (!AppRole.INST_MEMBER.equals(role) &&
-                userRoleRepository.findByUser_IdAndInstitution_IdAndRole(appUser.getId(), institution.getId(), AppRole.INST_MEMBER).isEmpty()) {
-            UserRole userRole = UserRole.builder().
-                    role(AppRole.INST_MEMBER)
-                    .user(appUser)
+    public void addRole(String institutionSlug, Long appUserId, AppRole role) throws NotFoundException {
+        val appUser = appUserRepository.findById(appUserId)
+                .orElseThrow(() -> new NotFoundException("User not found for id: '" + appUserId + "'"));
+        val institution = institutionRepository.findBySlug(institutionSlug, Institution.class)
+                .orElseThrow(() -> new NotFoundException("Institution not found for slug " + institutionSlug + "'"));
+        addRole(institution, appUser, role);
+    }
+
+    private void addRole(Institution institution, AppUser appUser, AppRole role) {
+        {
+            val optionalUserRole =
+                    userRoleRepository.findByUser_IdAndInstitution_IdAndRole(appUser.getId(), institution.getId(), role);
+
+            if (optionalUserRole.isPresent()) {
+                return;
+            }
+
+            UserRole userRole = UserRole.builder()
                     .institution(institution)
+                    .user(appUser)
+                    .role(role)
                     .build();
-            institution.getMembersRoles().add(userRole);
-            appUser.getRoles().add(userRole);
+
+            institution.addMemberRole(userRole);
+            appUser.addRole(userRole);
         }
-        UserRole userRole = UserRole.builder().
-                role(role)
-                .user(appUser)
-                .institution(institution)
-                .build();
-        institution.getMembersRoles().add(userRole);
-        appUser.getRoles().add(userRole);
+
+        // If role is admin, then try to add an ordinary membership and propagate the admin down the hierarchy.
+        if (role == AppRole.INST_ADMIN) {
+            addRole(institution, appUser, AppRole.INST_MEMBER);
+            for (val childInstitution : institutionRepository.findAllByParentId(institution.getId())) {
+                addRole(childInstitution, appUser, AppRole.INST_ADMIN);
+            }
+        }
     }
 
     @Transactional(rollbackFor = NotFoundException.class)
     public void removeRole(DeleteUserRoleRequest request) throws NotFoundException {
-        removeRole(request.getRole(), request.getEmail(), request.getInstitutionSlug());
+        Institution institution = institutionRepository.findBySlug(request.getInstitutionSlug())
+                .orElseThrow(() -> new NotFoundException(
+                        "Institution not found for id " + request.getInstitutionSlug() + "'"
+                ));
+        AppUser appUser = appUserRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new NotFoundException("User not found for mail: '" + request.getEmail() + "'"));
+        removeRole(institution.getId(), appUser.getId(), request.getRole());
     }
 
     @Transactional(rollbackFor = NotFoundException.class)
-    public void removeRole(AppRole role, String email, String institutionSlug) throws NotFoundException {
-        Institution institution = institutionRepository.findBySlug(institutionSlug, Institution.class)
-                .orElseThrow(() -> new NotFoundException("Institution not found for id " + institutionSlug + "'"));
-        AppUser appUser = appUserRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException("User not found for mail: '" + email + "'"));
-        if (AppRole.INST_MEMBER.equals(role)) {
-            userRoleRepository.findByUser_IdAndInstitution_Id(appUser.getId(), institution.getId()).forEach(userRole -> {
-                institution.removeMemberRole(userRole);
-                appUser.removeRole(userRole);
-                userRoleRepository.delete(userRole);
-            });
-        } else {
-            UserRole userRole = userRoleRepository.findByUser_IdAndInstitution_IdAndRole(appUser.getId(), institution.getId(), role)
-                    .orElseThrow(() -> new NotFoundException("UserRole not found for user: '" + email + "'"));
-            institution.removeMemberRole(userRole);
-            appUser.removeRole(userRole);
-            userRoleRepository.delete(userRole);
+    public void removeRole(
+            String institutionSlug,
+            Long appUserId,
+            AppRole role
+    ) throws NotFoundException {
+        val appUser = appUserRepository.findById(appUserId)
+                .orElseThrow(() -> new NotFoundException("User not found for id: '" + appUserId + "'"));
+        val institution = institutionRepository.findBySlug(institutionSlug, Institution.class)
+                .orElseThrow(() -> new NotFoundException("Institution not found for slug " + institutionSlug + "'"));
+        removeRole(institution.getId(), appUser.getId(), role);
+    }
+
+    private void removeRole(Long institutionId, Long appUserId, AppRole role) {
+        {
+            val optionalUserRole =
+                    userRoleRepository.findByUser_IdAndInstitution_IdAndRole(appUserId, institutionId, role);
+
+            if (optionalUserRole.isEmpty()) {
+                return;
+            }
+
+            UserRole userRole = optionalUserRole.get();
+
+            userRole.getInstitution().removeMemberRole(userRole);
+            userRole.getUser().removeRole(userRole);
         }
 
+        // Try removing admin role as well, if exists.
+        if (role == AppRole.INST_MEMBER) {
+            removeRole(institutionId, appUserId, AppRole.INST_ADMIN);
+        // If removing an admin role then propagate this deletion down the institution hierarchy.
+        } else if (role == AppRole.INST_ADMIN) {
+            for (val childInstitution : institutionRepository.findAllByParentId(institutionId)) {
+                removeRole(childInstitution.getId(), appUserId, AppRole.INST_ADMIN);
+            }
+        }
     }
 }

--- a/s4e-backend/src/main/resources/db/migration/V56__add_admin_invitation_field.sql
+++ b/s4e-backend/src/main/resources/db/migration/V56__add_admin_invitation_field.sql
@@ -1,0 +1,2 @@
+ALTER TABLE invitation
+    ADD COLUMN for_admin BOOLEAN DEFAULT FALSE;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SecurityTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SecurityTest.java
@@ -95,7 +95,6 @@ public class SecurityTest {
         appUserRepository.save(securityAppUser);
         DeleteUserRoleRequest userRoleRequest = DeleteUserRoleRequest.builder()
                 .email("profile@email")
-                .groupSlug("default")
                 .institutionSlug("slugInstitution")
                 .role(AppRole.INST_ADMIN)
                 .build();

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/InstitutionControllerIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/InstitutionControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import pl.cyfronet.s4e.data.repository.InstitutionRepository;
 import pl.cyfronet.s4e.data.repository.UserRoleRepository;
 import pl.cyfronet.s4e.properties.FileStorageProperties;
 import pl.cyfronet.s4e.service.SlugService;
+import pl.cyfronet.s4e.service.UserRoleService;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -52,6 +53,9 @@ public class InstitutionControllerIntegrationTest {
 
     @Autowired
     private UserRoleRepository userRoleRepository;
+
+    @Autowired
+    private UserRoleService userRoleService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -110,7 +114,6 @@ public class InstitutionControllerIntegrationTest {
     public void shouldCreateInstitutionWithEmblem() throws Exception {
         CreateInstitutionRequest request = CreateInstitutionRequest.builder()
                 .name("Test Institution ZK")
-                .institutionAdminEmail(PROFILE_EMAIL)
                 .emblem(testResourceHelper.getAsStringInBase64(IMAGE_PNG_PATH))
                 .build();
 
@@ -154,7 +157,6 @@ public class InstitutionControllerIntegrationTest {
     public void shouldUpdateInstitutionWithEmblem() throws Exception {
         CreateInstitutionRequest request = CreateInstitutionRequest.builder()
                 .name("Test Institution ZK")
-                .institutionAdminEmail(PROFILE_EMAIL)
                 .emblem(testResourceHelper.getAsStringInBase64(IMAGE_PNG_PATH))
                 .build();
         String slugInstitution = slugService.slugify(request.getName());
@@ -206,7 +208,6 @@ public class InstitutionControllerIntegrationTest {
     public void shouldCreateChildInstitutionWithEmblem() throws Exception {
         CreateChildInstitutionRequest request = CreateChildInstitutionRequest.builder()
                 .name("Test Institution ZK")
-                .institutionAdminEmail(PROFILE_EMAIL)
                 .emblem(testResourceHelper.getAsStringInBase64(IMAGE_PNG_PATH))
                 .build();
         String slugInstitution = slugService.slugify(request.getName());

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/UserRoleControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/UserRoleControllerTest.java
@@ -104,7 +104,6 @@ public class UserRoleControllerTest {
 
         DeleteUserRoleRequest userRoleDeleteRequest = DeleteUserRoleRequest.builder()
                 .email(PROFILE_EMAIL)
-                .groupSlug("default")
                 .institutionSlug(slugInstitution)
                 .role(AppRole.INST_ADMIN)
                 .build();

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/InstitutionServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/InstitutionServiceTest.java
@@ -13,14 +13,12 @@ import pl.cyfronet.s4e.bean.AppUser;
 import pl.cyfronet.s4e.bean.Institution;
 import pl.cyfronet.s4e.bean.UserRole;
 import pl.cyfronet.s4e.controller.request.CreateChildInstitutionRequest;
-import pl.cyfronet.s4e.controller.response.AppUserResponse;
 import pl.cyfronet.s4e.data.repository.AppUserRepository;
 import pl.cyfronet.s4e.data.repository.InstitutionRepository;
 import pl.cyfronet.s4e.data.repository.UserRoleRepository;
+import pl.cyfronet.s4e.data.repository.projection.ProjectionWithId;
 import pl.cyfronet.s4e.ex.InstitutionCreationException;
 import pl.cyfronet.s4e.ex.NotFoundException;
-
-import java.util.Set;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -117,24 +115,18 @@ public class InstitutionServiceTest {
 
     @Test
     public void shouldAddChildInstitutionAndParentInstitutionAdmin() throws NotFoundException, InstitutionCreationException {
-        AppUser childAdmin = appUserRepository.save(AppUser.builder()
-                .email(PROFILE_EMAIL3)
-                .name("Get3")
-                .surname("Profile3")
-                .password("{noop}password")
-                .enabled(true)
-                .build());
         CreateChildInstitutionRequest request = CreateChildInstitutionRequest.builder()
                 .name("child-institution")
-                .institutionAdminEmail(childAdmin.getEmail())
                 .build();
 
-        Set<AppUserResponse> result = institutionService.getMembers("child-institution", AppUserResponse.class);
-        assertThat(result, hasSize(0));
+        val members = institutionService.getMembers("child-institution", ProjectionWithId.class);
+        assertThat(members, hasSize(0));
+
         institutionService.createChildInstitution(request, slugInstitution2);
-        result = institutionService.getMembers("child-institution", AppUserResponse.class);
-        // new inst_admin and two from parent
-        assertThat(result, hasSize(3));
+
+        val updatedMembers = institutionService.getMembers("child-institution", ProjectionWithId.class);
+        // Two admins from the parent.
+        assertThat(updatedMembers, hasSize(2));
     }
 
     @Test

--- a/s4e-web/cypress/page-objects/settings/settings-add-institution-form.po.ts
+++ b/s4e-web/cypress/page-objects/settings/settings-add-institution-form.po.ts
@@ -55,10 +55,6 @@ export class AddInstitutionForm extends Core {
       .pageObject
       .getLogoImage()
       .should('be.visible');
-    AddInstitutionForm
-      .pageObject
-      .getEmailInput()
-      .type(institution.institutionAdminEmail);
 
     return AddInstitutionForm;
   }

--- a/s4e-web/src/app/views/login/login.component.html
+++ b/s4e-web/src/app/views/login/login.component.html
@@ -32,16 +32,6 @@
           </ng-container>
           <br>
         </div>
-
-<!-- this part of the form is always visible, also it only handles unhandled errors, someone could elaborate about this? -->
-<!--        <div class="alert alert-danger special__error" *ngIf="!(form.errors | isEmpty)">-->
-<!--          <ul>-->
-<!--            <li *ngFor="let error of (form.errors | errorKeys)" [ngSwitch]="error">-->
-<!--              <ng-container *ngSwitchDefault i18n>Nieoczekiwany błąd</ng-container>-->
-<!--            </li>-->
-<!--          </ul>-->
-<!--        </div>-->
-
         <ul class="form__list">
           <li class="form__element">
             <label for="login-login" i18n>Email</label>

--- a/s4e-web/src/app/views/settings/email-list-validator.spec.ts
+++ b/s4e-web/src/app/views/settings/email-list-validator.spec.ts
@@ -1,0 +1,22 @@
+import {emailListValidator} from './email-list-validator.utils';
+import {FormControl} from '@angular/forms';
+
+describe('emailListValidator', () => {
+  function validateValue(value: string) {
+    const control = new FormControl(value);
+    return emailListValidator(control)
+  }
+
+  it('should work', () => {
+    expect(validateValue('notValid')).toEqual({emails: true});
+    expect(validateValue('admin; admin2 ? admin@mail.pl')).toEqual({emails: true});
+    expect(validateValue('admin, admin@mail.pl')).toEqual({emails: true});
+    expect(validateValue('admin@mail.pl')).toEqual(null);
+    expect(validateValue('admin@mail.pl, admin2@mail.pl')).toEqual(null);
+    expect(validateValue('admin@mail.pl,admin2@mail.pl')).toEqual(null);
+    expect(validateValue('admin@mail.pl,  admin2@mail.pl')).toEqual(null);
+    expect(validateValue('   admin@mail.pl,  admin2@mail.pl   ')).toEqual(null);
+    expect(validateValue('')).toEqual(null);
+    expect(validateValue(null)).toEqual(null);
+  });
+});

--- a/s4e-web/src/app/views/settings/email-list-validator.utils.ts
+++ b/s4e-web/src/app/views/settings/email-list-validator.utils.ts
@@ -1,13 +1,14 @@
 import { AbstractControl } from '@angular/forms';
 
-const COMMA_SEPARATED_EMAILS_EXPRESSION = /((,? ?)((\.?)[a-zA-Z0-9_]+)+@((\.?)[a-zA-Z0-9_]+)+)+/i;
+const COMMA_SEPARATED_EMAILS_EXPRESSION = /^ *((,? *)((\.?)[a-zA-Z0-9_]+)+@((\.?)[a-zA-Z0-9_]+)+)+ *$/i;
 
 interface IValidatorOutput {
   [key: string]: boolean;
 }
 
 export function emailListValidator(control: AbstractControl): IValidatorOutput | null {
-  return _hasMatch(control.value, COMMA_SEPARATED_EMAILS_EXPRESSION) ? null : { emails: true };
+  return !control.value ? null :
+    (_hasMatch(control.value, COMMA_SEPARATED_EMAILS_EXPRESSION) ? null : { emails: true });
 }
 
 function _hasMatch(url: string, regex: RegExp) {

--- a/s4e-web/src/app/views/settings/email-list-validator.utils.ts
+++ b/s4e-web/src/app/views/settings/email-list-validator.utils.ts
@@ -1,0 +1,15 @@
+import { AbstractControl } from '@angular/forms';
+
+const COMMA_SEPARATED_EMAILS_EXPRESSION = /((,? ?)((\.?)[a-zA-Z0-9_]+)+@((\.?)[a-zA-Z0-9_]+)+)+/i;
+
+interface IValidatorOutput {
+  [key: string]: boolean;
+}
+
+export function emailListValidator(control: AbstractControl): IValidatorOutput | null {
+  return _hasMatch(control.value, COMMA_SEPARATED_EMAILS_EXPRESSION) ? null : { emails: true };
+}
+
+function _hasMatch(url: string, regex: RegExp) {
+  return (typeof url === "string") && regex.test(url);
+}

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.html
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.html
@@ -2,28 +2,25 @@
   <h1 i18n>Profil instytucji</h1>
 </header>
 <section class="content__details content__details--75 profile">
-  <ng-container *ngIf="!!(activeInstitution$ | async)">
+  <ng-container *ngIf="(activeInstitution$ | async) as institution">
     <div
       class="profile__content"
       data-e2e="institution-details"
     >
-      <h2 id="institution-title">{{ (activeInstitution$ | async).name }}</h2>
+      <h2 id="institution-title">{{ institution.name }}</h2>
       <ul>
-        <li id="institution-address">{{ (activeInstitution$ | async).address }}</li>
+        <li id="institution-address">{{ institution.address }}</li>
         <li
           id="institution-postal-code"
           data-e2e="postal-code-with-city"
         >
-          {{ (activeInstitution$ | async).postalCode }} {{ (activeInstitution$ | async).city }}
+          {{ institution.postalCode }} {{ institution.city }}
         </li>
-        <li *ngIf="!!(activeInstitution$ | async).institutionAdminEmail" id="institution-email">
-          email: {{ (activeInstitution$ | async).institutionAdminEmail }}
+        <li *ngIf="!!institution.phone" id="institution-phone">
+          Telefon: {{ institution.phone }}
         </li>
-        <li *ngIf="!!(activeInstitution$ | async).phone" id="institution-phone">
-          Telefon: {{ (activeInstitution$ | async).phone }}
-        </li>
-        <li *ngIf="!!(activeInstitution$ | async).secondaryPhone" id="institution-second-phone">
-          Telefon: {{ (activeInstitution$ | async).secondaryPhone }}
+        <li *ngIf="!!institution.secondaryPhone" id="institution-second-phone">
+          Telefon: {{ institution.secondaryPhone }}
         </li>
       </ul>
     </div>

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.spec.ts
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.spec.ts
@@ -78,9 +78,6 @@ describe('InstitutionProfileComponent', () => {
     const postalCode = de.query(By.css('#institution-postal-code'));
     expect(postalCode.nativeElement.innerHTML).toContain(institution.postalCode);
 
-    const institutionAdminEmail = de.query(By.css('#institution-email'));
-    expect(institutionAdminEmail.nativeElement.innerHTML).toContain('email: ' + institution.institutionAdminEmail);
-
     const phone = de.query(By.css('#institution-phone'));
     expect(phone.nativeElement.innerHTML.split(':')[1].trim()).toContain(institution.phone);
 
@@ -121,9 +118,6 @@ describe('InstitutionProfileComponent', () => {
 
     const postalCode = de.query(By.css('#institution-postal-code'));
     expect(postalCode.nativeElement.innerHTML).toContain(institution.postalCode);
-
-    const institutionAdminEmail = de.query(By.css('#institution-email'));
-    expect(institutionAdminEmail.nativeElement.innerHTML).toContain('email: ' + institution.institutionAdminEmail);
 
     const phone = de.query(By.css('#institution-phone'));
     expect(phone.nativeElement.innerHTML.split(':')[1].trim()).toContain(institution.phone);

--- a/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.ts
+++ b/s4e-web/src/app/views/settings/intitution-profile/institution-profile.component.ts
@@ -17,7 +17,7 @@ import { Observable, combineLatest } from 'rxjs';
 })
 export class InstitutionProfileComponent implements OnDestroy {
   public isLoading$: Observable<boolean> = this._institutionQuery.selectLoading();
-  public activeInstitution$ = this._institutionsSearchResultsQuery
+  public activeInstitution$: Observable<Institution> = this._institutionsSearchResultsQuery
     .selectActive$(this._activatedRoute)
     .pipe(untilDestroyed(this));
   public childrenInstitutions$: Observable<Institution[]> = combineLatest(

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.html
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.html
@@ -121,19 +121,29 @@
       <ul s4e-form-error [control]="form.controls.emblem"></ul>
     </section>
     <section>
-      <h2 i18n>Administrator instytucji</h2>
+      <h2 i18n>Administratorzy instytucji</h2>
       <p i18n>
         W tym miejscu możesz dodać osoby, które będą zarządzać instytucją.
         Wpisz e-maile oddzielone przecinkami. Uprawnienia Administratora
         możesz nadać później w zakładce ludzie po uprzednim wybraniu instytucji.
       </p>
-      <ext-input
-        type="email"
-        formControlName="institutionAdminEmail"
-        label="E-mail administratora"
-        [required]="false"
-        i18n-label
-      ></ext-input>
+      <label for="emails" i18n>E-maile administratorów</label>
+      <input
+        type="text"
+        formControlName="adminsEmails"
+      />
+      <ng-container *ngIf="hasErrors('adminsEmails')" >
+        <span
+          class="error"
+          *ngFor="let error of form.controls.adminsEmails.errors | keyvalue"
+          [ngSwitch]="error.key"
+          data-e2e="invalid-url-error"
+        >
+          <ng-container *ngSwitchCase="'emails'" i18n>
+            Email lub emaile nie są poprawne
+          </ng-container>
+        </span>
+      </ng-container>
     </section>
 
     <footer class="form-submit">

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.html
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.html
@@ -123,9 +123,9 @@
     <section>
       <h2 i18n>Administrator instytucji</h2>
       <p i18n>
-        W tym miejscu możesz dodać osobę, która będzie zarządzać instytucją.
-        Wpisz e-mail tej osoby. Możesz jednocześnie wysłać jej powiadomienie o nadaniu
-        uprawnień. Takiej osobie możesz nadać uprawnienia później.
+        W tym miejscu możesz dodać osoby, które będą zarządzać instytucją.
+        Wpisz e-maile oddzielone przecinkami. Uprawnienia Administratora
+        możesz nadać później w zakładce ludzie po uprzednim wybraniu instytucji.
       </p>
       <ext-input
         type="email"

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.spec.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.spec.ts
@@ -134,9 +134,9 @@ describe('InstitutionFormComponent', () => {
   });
 
   it('should validate institution admin email', () => {
-    component.form.controls.institutionAdminEmail.setValue('');
-    expect(component.form.controls.institutionAdminEmail.valid).toBeTruthy();
-    component.form.controls.institutionAdminEmail.setValue(InstitutionFactory.build().institutionAdminEmail);
-    expect(component.form.controls.institutionAdminEmail.valid).toBeTruthy();
+    component.form.controls.adminsEmails.setValue('');
+    expect(component.form.controls.adminsEmails.valid).toBeTruthy();
+    component.form.controls.adminsEmails.setValue(InstitutionFactory.build().adminsEmails);
+    expect(component.form.controls.adminsEmails.valid).toBeTruthy();
   });
 });

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.ts
@@ -71,6 +71,8 @@ export class InstitutionFormComponent extends GenericFormComponent<InstitutionQu
 
   loadLogo($event) {
     const emblem = File.getFirst($event);
+    console.log('emblem', emblem);
+
     if (!emblem) {
       return;
     }

--- a/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.ts
+++ b/s4e-web/src/app/views/settings/manage-institutions/institution-form/institution-form.component.ts
@@ -23,6 +23,7 @@ import {InstitutionService} from '../../state/institution/institution.service';
 import {File, ImageBase64} from './files.utils';
 import {combineLatest, of} from 'rxjs';
 import {ADD_INSTITUTION_PATH, INSTITUTION_PROFILE_PATH, INSTITUTIONS_LIST_PATH} from '../../settings.breadcrumbs';
+import { emailListValidator } from '../../email-list-validator.utils';
 
 @Component({
   selector: 's4e-add-institution',
@@ -128,6 +129,15 @@ export class InstitutionFormComponent extends GenericFormComponent<InstitutionQu
       .subscribe();
   }
 
+  hasErrors(controlName: string) {
+    const formControl = this.form
+      .controls[controlName] as FormControl;
+    return !!formControl
+      && formControl.touched
+      && !!formControl.errors
+      && Object.keys(formControl.errors).length > 0;
+  }
+
   resetForm() {
     !!this.activeInstitution
       ? this._setFormWith(this.form, this.activeInstitution)
@@ -204,7 +214,7 @@ export class InstitutionFormComponent extends GenericFormComponent<InstitutionQu
       phone: new FormControl<string>(),
       emblem: new FormControl<string>(),
       secondaryPhone: new FormControl<string>(),
-      institutionAdminEmail: new FormControl<string>()
+      institutionAdminEmail: new FormControl<string>(null, emailListValidator)
     });
   }
 

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.html
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.html
@@ -20,6 +20,14 @@
             i18n
           ></ext-input>
         </li>
+        <li>
+          <label for="forAdmin" i18n>Zaproś jako administratora</label>
+          <input
+            type="checkbox"
+            id="forAdmin"
+            formControlName="forAdmin"
+          />
+        </li>
       </ul>
     </form>
   </div>

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.spec.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.spec.ts
@@ -76,7 +76,7 @@ describe('InvitationFormComponent', () => {
 
     spyOn(invitationService, 'send').and.callThrough();
     component.send();
-    expect(invitationService.send).toHaveBeenCalledWith(slug, email);
+    expect(invitationService.send).toHaveBeenCalledWith(slug, email, false);
   });
   it('should call invitation resend', () => {
     const name = 'test';
@@ -92,6 +92,6 @@ describe('InvitationFormComponent', () => {
 
     spyOn(invitationService, 'resend').and.callThrough();
     component.send();
-    expect(invitationService.resend).toHaveBeenCalledWith({newEmail: email, oldEmail: email}, component.institution);
+    expect(invitationService.resend).toHaveBeenCalledWith({forAdmin: false, newEmail: email, oldEmail: email}, component.institution);
   });
 });

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.ts
@@ -1,7 +1,6 @@
 import { Validators } from '@angular/forms';
 import { NotificationService } from 'notifications';
 import { Institution } from './../../state/institution/institution.model';
-import { Modal } from '../../../../modal/state/modal.model';
 import { INVITATION_FORM_MODAL_ID, isInvitationFormModal, InvitationFormModal } from './invitation-form-modal.model';
 import { ModalQuery } from 'src/app/modal/state/modal.query';
 import { ModalService } from 'src/app/modal/state/modal.service';
@@ -9,7 +8,6 @@ import {Component, Inject} from '@angular/core';
 import {FormControl, FormGroup} from '@ng-stack/forms';
 import {InstitutionService} from '../../state/institution/institution.service';
 import {ActivatedRoute} from '@angular/router';
-import {untilDestroyed} from 'ngx-take-until-destroy';
 import {AkitaNgFormsManager} from '@datorama/akita-ng-forms-manager';
 import {FormState} from '../../../../state/form/form.model';
 import { FormModalComponent } from 'src/app/modal/utils/modal/modal.component';

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.component.ts
@@ -53,7 +53,8 @@ export class InvitationFormComponent extends FormModalComponent<'invitation'> {
       email: new FormControl<string>(
         !!this.invitation ? this.invitation.email : null,
         Validators.required
-      )
+      ),
+      forAdmin: new FormControl<boolean>(false)
     });
   }
 
@@ -74,11 +75,11 @@ export class InvitationFormComponent extends FormModalComponent<'invitation'> {
       return;
     }
 
-    const email = this.form.controls.email.value;
+    const {email, forAdmin} = this.form.value;
     !!this.invitation
       ? this._invitationService
-        .resend({oldEmail: this.invitation.email, newEmail: email}, this.institution)
-      : this._invitationService.send(this.institution.slug, email);
+        .resend({oldEmail: this.invitation.email, newEmail: email, forAdmin}, this.institution)
+      : this._invitationService.send(this.institution.slug, email, forAdmin);
     this.dismiss();
   }
 }

--- a/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.model.ts
+++ b/s4e-web/src/app/views/settings/people/invitation-form/invitation-form.model.ts
@@ -1,3 +1,4 @@
 export class InvitationForm {
   email: string;
+  forAdmin: boolean;
 }

--- a/s4e-web/src/app/views/settings/people/people.module.ts
+++ b/s4e-web/src/app/views/settings/people/people.module.ts
@@ -1,7 +1,7 @@
 import { INVITATION_FORM_MODAL_ID } from './invitation-form/invitation-form-modal.model';
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {ReactiveFormsModule} from '@angular/forms';
+import {ReactiveFormsModule, FormsModule} from '@angular/forms';
 import {PersonListComponent} from './person-list/person-list.component';
 import {InvitationFormComponent} from './invitation-form/invitation-form.component';
 import {RouterModule} from '@angular/router';

--- a/s4e-web/src/app/views/settings/people/person-list/person-list.component.html
+++ b/s4e-web/src/app/views/settings/people/person-list/person-list.component.html
@@ -22,12 +22,20 @@
   <ng-container table-header>
       <th i18n>Imię i nazwisko</th>
       <th i18n>Email</th>
+      <th i18n>Administrator</th>
       <th i18n class="text--center">Status</th>
       <th i18n>Akcje</th>
   </ng-container>
   <ng-template let-user="item">
     <td i18n>{{user.name}} {{user.surname}}</td>
     <td i18n>{{user.email}}</td>
+    <td *ngIf="!isInvitation(user)">
+      <input
+        type="checkbox"
+        (click)="toggleAdminRoleFor(user)"
+        [checked]="isAdmin(user)"
+      />
+    </td>
     <td class="text--center">
       <ng-container *ngIf="isInvitation(user)">
         <button

--- a/s4e-web/src/app/views/settings/people/person-list/person-list.component.ts
+++ b/s4e-web/src/app/views/settings/people/person-list/person-list.component.ts
@@ -98,12 +98,26 @@ export class PersonListComponent implements OnInit, OnDestroy {
   }
 
   resendTo(invitation: any) {
-    this._invitationService
-      .resend({oldEmail: invitation.email, newEmail: invitation.email}, this.institution);
+    const request = {
+      oldEmail: invitation.email,
+      newEmail: invitation.email,
+      forAdmin: invitation.isAdmin
+    };
+    this._invitationService.resend(request, this.institution);
   }
 
   isInvitation(person: Person) {
     return isInvitation(person);
+  }
+
+  toggleAdminRoleFor(person: Person) {
+    this.isAdmin(person)
+      ? this._personService.removeAdminRoleFor(person)
+      : this._personService.addAdminRoleFor(person);
+  }
+
+  isAdmin(person: Person) {
+    return person.roles.some(role => role.role === 'INST_ADMIN');
   }
 
   async delete(person: Person) {
@@ -122,7 +136,7 @@ export class PersonListComponent implements OnInit, OnDestroy {
     const description = 'Czy na pewno chcesz usunąć tę osobę z instytucji? Operacja jest nieodwracalna.';
     const hasBeenConfirmed = await this._modalService.confirm(title, description);
     if (hasBeenConfirmed) {
-      // this._personService.deleteMember(userId);
+      this._personService.delete(person);
     }
   }
 

--- a/s4e-web/src/app/views/settings/people/state/invitation/invitation.model.ts
+++ b/s4e-web/src/app/views/settings/people/state/invitation/invitation.model.ts
@@ -3,6 +3,7 @@ import { Person } from './../person/person.model';
 export interface InvitationResendRequest {
   oldEmail: string;
   newEmail: string;
+  forAdmin: boolean;
 }
 
 type stateType = 'waiting' | `rejected`;

--- a/s4e-web/src/app/views/settings/people/state/invitation/invitation.service.ts
+++ b/s4e-web/src/app/views/settings/people/state/invitation/invitation.service.ts
@@ -64,10 +64,10 @@ export class InvitationService {
       .subscribe();
   }
 
-  public send(institutionSlug: string, email: string): void {
+  public send(institutionSlug: string, email: string, forAdmin = false): void {
     const notificationMessage = 'Zaproszenie zostało wysłane';
     const url = `${environment.apiPrefixV1}/institutions/${institutionSlug}/invitations`;
-    this._http.post<Invitation>(url, {email})
+    this._http.post<Invitation>(url, {email, forAdmin})
       .pipe(
         handleHttpRequest$(this._store),
         tap(() => this._notificationService.addGeneral({

--- a/s4e-web/src/app/views/settings/people/state/person/person.model.ts
+++ b/s4e-web/src/app/views/settings/people/state/person/person.model.ts
@@ -1,13 +1,18 @@
 export const DEFAULT_GROUP_NAME = '__default__';
 export const DEFAULT_GROUP_SLUG = 'default';
 
+export interface UserRole {
+  institutionSlug: string;
+  role: 'INST_MEMBER' | 'INST_ADMIN';
+}
+
 export interface Person {
-  // this is ID
+  id: number;
   email: string;
   name: string;
   surname: string;
-  roles: any[],
-  // createDate: string
+  roles: UserRole[];
+  isAdmin: boolean;
 }
 
 /**

--- a/s4e-web/src/app/views/settings/state/institution/institution.factory.spec.ts
+++ b/s4e-web/src/app/views/settings/state/institution/institution.factory.spec.ts
@@ -1,7 +1,7 @@
-import { Institution } from './institution.model';
+import {Institution, InstitutionForm} from './institution.model';
 import * as Factory from 'factory.ts';
 
-export const InstitutionFactory = Factory.makeFactory<Institution>({
+export const InstitutionFactory = Factory.makeFactory<InstitutionForm>({
   id: Factory.each(i => `institution:${i}`),
 
   parentName : null,
@@ -15,5 +15,5 @@ export const InstitutionFactory = Factory.makeFactory<Institution>({
   phone: '+48 000 000 000',
   secondaryPhone: '+48 000 000 000',
   emblem: 'logo_um.png',
-  institutionAdminEmail: 'zkMember@mail.pl'
+  adminsEmails: 'zkMember@mail.pl'
 });

--- a/s4e-web/src/app/views/settings/state/institution/institution.model.ts
+++ b/s4e-web/src/app/views/settings/state/institution/institution.model.ts
@@ -13,7 +13,10 @@ export interface Institution {
   phone: string;
   secondaryPhone: string;
   emblem: string;
-  institutionAdminEmail: string;
+}
+
+export interface InstitutionForm extends Institution {
+  adminsEmails: string;
 }
 
 /**

--- a/s4e-web/src/app/views/settings/state/institutions-search/institutions-search-results.service.ts
+++ b/s4e-web/src/app/views/settings/state/institutions-search/institutions-search-results.service.ts
@@ -11,7 +11,7 @@ export class InstitutionsSearchResultsService {
 
   constructor(private _store: InstitutionsSearchResultsStore,
               private _guidGenerationService: AkitaGuidService,
-              private _insitutionService: InstitutionService,
+              private _institutionService: InstitutionService,
               private _InstitutionQuery: InstitutionQuery,
               private _http: HttpClient) {
   }
@@ -34,7 +34,7 @@ export class InstitutionsSearchResultsService {
     this._store.update({searchResult: searchResult, isOpen: false});
 
     if (!!searchResult) {
-      this._insitutionService.setActive(searchResult.slug);
+      this._institutionService.setActive(searchResult.slug);
     }
   }
 }


### PR DESCRIPTION
Only the administrator of a specific institution can do listed actions on /people page

- Add institution comma-separated admins emails while adding/editing institutions (/add-insitution)
- Add institution admin to a person in the list (/people) with checkbox in the column is Admin
- Send an invitation to a user with a possibility to add him admin role by checking box in modal

Closes #808