### PR TITLE
[#835] Add scientific domain to AppUser

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
@@ -54,6 +54,14 @@ public class AppUser extends CreationAndModificationAudited {
 
     private boolean eumetsatLicense;
 
+    @Enumerated(EnumType.STRING)
+    private ScientificDomain domain;
+
+    @Enumerated(EnumType.STRING)
+    private Usage usage;
+
+    private String country;
+
     public void removeRole(UserRole role) {
         roles.remove(role);
     }
@@ -65,5 +73,13 @@ public class AppUser extends CreationAndModificationAudited {
     private UserPreferences preferences = UserPreferences.builder()
             .nonVisibleOverlays(List.of())
             .build();
+
+    public enum ScientificDomain {
+        ATMOSPHERE, EMERGENCY, MARINE, LAND, SECURITY, CLIMATE, OTHER
+    }
+
+    public enum Usage {
+        RESEARCH, COMMERCIAL, EDUCATION, OTHER
+    }
 }
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/RegisterRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/RegisterRequest.java
@@ -1,7 +1,10 @@
 package pl.cyfronet.s4e.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.controller.validation.CountryCode;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
@@ -13,11 +16,24 @@ public class RegisterRequest {
     @NotEmpty
     @Email
     private String email;
+
     @NotEmpty
     private String name;
+
     @NotEmpty
     private String surname;
+
     @NotEmpty
     @Size(min=8)
     private String password;
+
+    @Schema(description = "User's scientific domain")
+    private AppUser.ScientificDomain domain;
+
+    @Schema(description = "User's usage scenario")
+    private AppUser.Usage usage;
+
+    @CountryCode
+    @Schema(description = "User's ISO 3166 alpha-2 country code", example = "PL")
+    private String country;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/AppUserResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/AppUserResponse.java
@@ -14,4 +14,10 @@ public interface AppUserResponse {
     String getSurname();
 
     Set<UserRoleResponse> getRoles();
+
+    String getDomain();
+
+    String getUsage();
+
+    String getCountry();
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/CountryCode.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/CountryCode.java
@@ -1,0 +1,17 @@
+package pl.cyfronet.s4e.controller.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = CountryCodeValidator.class)
+public @interface CountryCode {
+    String message() default "{pl.cyfronet.s4e.controller.validation.CountryCode.message}";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/CountryCodeValidator.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/validation/CountryCodeValidator.java
@@ -1,0 +1,16 @@
+package pl.cyfronet.s4e.controller.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Locale;
+
+public class CountryCodeValidator implements ConstraintValidator<CountryCode, String> {
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // Null is fine, but reject empty string.
+        if (value == null) {
+            return true;
+        }
+
+        return Locale.getISOCountries(Locale.IsoCountryCode.PART1_ALPHA2).contains(value);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
@@ -23,6 +23,7 @@ import pl.cyfronet.s4e.service.UserRoleService;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 @Profile({"development", "run-seed-users"})
 @Component
@@ -60,6 +61,9 @@ public class SeedUsers implements ApplicationRunner {
                         .surname("Surname1")
                         .password(passwordEncoder.encode("cat1user"))
                         .enabled(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("cat2user@mail.pl")
@@ -67,6 +71,9 @@ public class SeedUsers implements ApplicationRunner {
                         .surname("Surname2")
                         .password(passwordEncoder.encode("cat2user"))
                         .enabled(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("cat3user@mail.pl")
@@ -74,6 +81,9 @@ public class SeedUsers implements ApplicationRunner {
                         .surname("Surname3")
                         .password(passwordEncoder.encode("cat3user"))
                         .enabled(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("cat4user@mail.pl")
@@ -81,6 +91,9 @@ public class SeedUsers implements ApplicationRunner {
                         .surname("Surname4")
                         .password(passwordEncoder.encode("cat4user"))
                         .enabled(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("zkMember@mail.pl")
@@ -89,6 +102,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkMember"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("zkAdmin@mail.pl")
@@ -97,6 +113,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkAdmin20"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("admin@mail.pl")
@@ -105,6 +124,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("adminPass20"))
                         .enabled(true)
                         .admin(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 // ZK - PL
                 AppUser.builder()
@@ -114,6 +136,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkPLAdmin"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("zkPLMember@mail.pl")
@@ -122,6 +147,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkPLMember"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 // ZK - Maz
                 AppUser.builder()
@@ -131,6 +159,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkMazAdmin"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("zkMazMember@mail.pl")
@@ -139,6 +170,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkMazMember"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 // ZK - Waw
                 AppUser.builder()
@@ -148,6 +182,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkWawAdmin"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("zkWawMember@mail.pl")
@@ -156,6 +193,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkWawMember"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 // ZK - Mał
                 AppUser.builder()
@@ -165,6 +205,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkMalAdmin"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("zkMalMember@mail.pl")
@@ -173,6 +216,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkMalMember"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 // ZK - KR
                 AppUser.builder()
@@ -182,6 +228,9 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkKrAdmin"))
                         .enabled(true)
                         .memberZK(true)
+                        .domain(nextDomain())
+                        .usage(nextUsage())
+                        .country(nextCountry())
                         .build(),
                 AppUser.builder()
                         .email("zkKrMember@mail.pl")
@@ -190,9 +239,31 @@ public class SeedUsers implements ApplicationRunner {
                         .password(passwordEncoder.encode("zkKrMember"))
                         .enabled(true)
                         .memberZK(true)
+                        // Domain, usage and country null until required to be not-null.
+                        .domain(null)
+                        .usage(null)
+                        .country(null)
                         .build(),
         });
         appUserRepository.saveAll(appUsers);
+    }
+
+    private int domainIt = 0;
+
+    private AppUser.ScientificDomain nextDomain() {
+        return AppUser.ScientificDomain.values()[domainIt++ % AppUser.ScientificDomain.values().length];
+    }
+
+    private int usageIt = 0;
+
+    private AppUser.Usage nextUsage() {
+        return AppUser.Usage.values()[usageIt++ % AppUser.Usage.values().length];
+    }
+
+    private int countryIt = 0;
+
+    private String nextCountry() {
+        return Locale.getISOCountries()[countryIt++ % Locale.getISOCountries().length];
     }
 
     private void seedInstitutionsAndRoles() {

--- a/s4e-backend/src/main/resources/db/migration/V55__add_appuser_domain_usage_country_fields.sql
+++ b/s4e-backend/src/main/resources/db/migration/V55__add_appuser_domain_usage_country_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE app_user
+    ADD COLUMN domain VARCHAR,
+    ADD COLUMN usage VARCHAR,
+    ADD COLUMN country VARCHAR;

--- a/s4e-backend/src/main/resources/messages_pl_PL.properties
+++ b/s4e-backend/src/main/resources/messages_pl_PL.properties
@@ -3,6 +3,7 @@ NotEmpty=musi nie być puste
 Size.registerRequest.password=musi mieć co najmniej {2} znaków długości
 pl.cyfronet.s4e.controller.validation.Base64.message=musi być w formacie Base64
 pl.cyfronet.s4e.controller.validation.ContentType.message=ContentType nie pasuje do `{pattern}`
+pl.cyfronet.s4e.controller.validation.CountryCode.message=musi być kodem kraju ISO 3166 (małymi literami)
 pl.cyfronet.s4e.controller.validation.GroupNameValid.message=nie może zawierać podkreśleń ani słowa 'default'
 pl.cyfronet.s4e.controller.validation.ImageDimensions.message=obraz musi być mniejszy niż {maxWidth}x{maxHeight}px
 pl.cyfronet.s4e.controller.validation.JsonString.message=musi być w formacie JSON

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/validation/CountryCodeValidatorTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/validation/CountryCodeValidatorTest.java
@@ -1,0 +1,40 @@
+package pl.cyfronet.s4e.controller.validation;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class CountryCodeValidatorTest {
+    @ParameterizedTest
+    @MethodSource
+    public void shouldValidateCode(String code, boolean correct) {
+        CountryCodeValidator validator = new CountryCodeValidator();
+
+        assertThat(validator.isValid(code, null), is(correct));
+    }
+
+    private static Stream<Arguments> shouldValidateCode() {
+        return Stream.of(
+                // Correct examples.
+                Arguments.of("PL",  true),
+                Arguments.of("GB",  true),
+                // No such country code in standard.
+                Arguments.of("AA",  false),
+                // Incorrect case.
+                Arguments.of("pl",  false),
+                Arguments.of("Pl",  false),
+                Arguments.of("pL",  false),
+                // Incorrect length.
+                Arguments.of("POL", false),
+                Arguments.of("P",   false),
+                Arguments.of("",    false),
+                // Allow null.
+                Arguments.of(null,  true)
+        );
+    }
+}


### PR DESCRIPTION
Add domain, usage and country fields to app_user table, handle them
during registration and return them in user info.

Make the fields optional for now, so that front-end can be developed in
the meantime.

Closes: #835.