### PR TITLE
Dependencies update - 2020.11

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -76,7 +76,7 @@ services:
       POSTGRES_USER: ${DB_TEST_POSTGRES_USER:-sat4envi_test}
       POSTGRES_PASSWORD: ${DB_TEST_POSTGRES_PASSWORD:-sat4envi_test}
   broker-test:
-    image: rabbitmq:3.8.3-management
+    image: rabbitmq:3.8.9-management
     ports:
       - ${BROKER_TEST_PORT:-5673}:5672
       - ${BROKER_TEST_PORT_MANAGEMENT:-15673}:15672

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       POSTGRES_USER: ${DB_POSTGRES_USER:-sat4envi}
       POSTGRES_PASSWORD: ${DB_POSTGRES_PASSWORD:-sat4envi}
   broker:
-    image: rabbitmq:3.8.3-management
+    image: rabbitmq:3.8.9-management
     ports:
       - ${BROKER_PORT:-5672}:5672
       - ${BROKER_PORT_MANAGEMENT:-15672}:15672

--- a/gs-gateway/Dockerfile
+++ b/gs-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.8-jdk
+FROM openjdk:11.0.9-jdk
 VOLUME /tmp
 ARG DEPENDENCY=target/dependency
 COPY ${DEPENDENCY}/BOOT-INF/lib /app/BOOT-INF/lib

--- a/gs-gateway/pom.xml
+++ b/gs-gateway/pom.xml
@@ -17,7 +17,9 @@
     <description>GeoServer Gateway</description>
 
     <properties>
-        <spring-cloud.version>Hoxton.SR8</spring-cloud.version>
+        <spring-cloud.version>2020.0.0-M4</spring-cloud.version>
+
+        <spring-boot.version>2.4.0-M4</spring-boot.version>
     </properties>
 
     <dependencyManagement>
@@ -88,7 +90,14 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+        </dependency>
+        <!-- Required since lombok 1.18.16  -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>${lombok-mapstruct-binding.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,22 @@
 
     <name>sat4envi</name>
 
+    <repositories>
+        <repository>
+            <id>repository.spring.milestone</id>
+            <name>Spring Milestone Repository</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repository.spring.milestone</id>
+            <name>Spring Milestone Repository</name>
+            <url>https://repo.spring.io/milestone</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <properties>
         <revision>0.0.0</revision>
         <changelist>-SNAPSHOT</changelist>
@@ -26,27 +42,27 @@
         <java.version>11</java.version>
         <maven.compiler.release>11</maven.compiler.release>
 
-        <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
+        <spring-boot.version>2.4.0-RC1</spring-boot.version>
 
-        <awssdk.version>2.15.2</awssdk.version>
+        <awssdk.version>2.15.19</awssdk.version>
         <commonmark.version>0.15.2</commonmark.version>
         <commons-email.version>1.5</commons-email.version>
         <geotools.version>23.2</geotools.version>
         <greenmail.version>1.6.0</greenmail.version>
-        <guava.version>29.0-jre</guava.version>
-        <hibernate-types.version>2.9.13</hibernate-types.version>
-        <jakarta.json-api.version>2.0.0-RC3</jakarta.json-api.version>
+        <guava.version>30.0-jre</guava.version>
+        <hibernate-types.version>2.10.0</hibernate-types.version>
+        <jakarta.json-api.version>2.0.0</jakarta.json-api.version>
         <jjwt.version>0.11.2</jjwt.version>
-        <joy.version>2.0.0-RC2</joy.version>
-        <justify.version>3.0.0-RC2</justify.version>
-        <mapstruct.version>1.4.0.Final</mapstruct.version>
+        <joy.version>2.0.0</joy.version>
+        <justify.version>3.0.0</justify.version>
+        <lombok-mapstruct-binding.version>0.1.0</lombok-mapstruct-binding.version>
+        <mapstruct.version>1.4.1.Final</mapstruct.version>
         <poiooxml.version>4.1.2</poiooxml.version>
         <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
         <slugify.version>2.4</slugify.version>
         <springdoc-openapi.version>1.4.8</springdoc-openapi.version>
-        <unirest.version>3.11.00</unirest.version>
+        <unirest.version>3.11.03</unirest.version>
         <bucket4j-starter.version>0.2.0</bucket4j-starter.version>
-        <caffeine.version>2.8.5</caffeine.version>
         <!--
         update sentry version only when fid instance is updated
         -->
@@ -161,12 +177,12 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.10.0</version>
+                    <version>1.10.3</version>
                 </plugin>
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>4.0.2</version>
+                    <version>4.0.3</version>
                     <configuration>
                         <verbose>true</verbose>
                         <!-- Don't fail for example when building based on a zip from a release. -->

--- a/s4e-backend/Dockerfile
+++ b/s4e-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.8-jdk-slim
+FROM openjdk:11.0.9-jdk-slim
 
 RUN mkdir /app
 WORKDIR /app

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -89,12 +89,10 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>${caffeine.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>jcache</artifactId>
-            <version>${caffeine.version}</version>
         </dependency>
 
         <dependency>
@@ -298,7 +296,14 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+        </dependency>
+        <!-- Required since lombok 1.18.16  -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>${lombok-mapstruct-binding.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Spring boot 2.4.0-RC1 version, to hop on the new version before going to
production. I haven't noticed any regressions, except gs-gateway, which
needs to use 2.4.0-M4 for now.

Caffeine has version management in spring-boot, so it's not necessary to manage its version independently.

lombok-mapstruct-binding dependency is required since Lombok 1.18.16 for cooperation with MapStruct.