### PR TITLE
[#855] Improve property validation and handle custom static path

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/FileStorageProperties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/FileStorageProperties.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 @ConfigurationProperties("s3.file-storage")
 @Setter
@@ -17,20 +18,30 @@ public class FileStorageProperties {
     private String bucket;
 
     /**
+     * A path prefix for generated links, including the leading and trailing slash.
+     */
+    @NotBlank
+    @Pattern(regexp = "/.+/")
+    private String pathPrefix = "/static/";
+
+    /**
      * A key prefix for thumbnails, including the trailing slash.
      */
     @NotBlank
+    @Pattern(regexp = "[^/].*/")
     private String keyPrefixThumbnail;
 
     /**
      * A key prefix for institutions emblem, including the trailing slash.
      */
     @NotBlank
+    @Pattern(regexp = "[^/].*/")
     private String keyPrefixEmblem;
 
     /**
      * A key prefix for products categories icons, including the trailing slash.
      */
     @NotBlank
+    @Pattern(regexp = "[^/].*/")
     private String keyPrefixProductsCategoriesIcons;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/MailProperties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/MailProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 @ConfigurationProperties("mail")
 @Validated
@@ -15,8 +16,9 @@ public class MailProperties {
     /**
      * The base url for use in mails, for example to fetch images.
      * <p>
-     * Without the trailing slash.
+     * Without the trailing slash, including the protocol.
       */
     @NotBlank
+    @Pattern(regexp = "https?://[^/]+")
     private String urlDomain;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/S3Properties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/S3Properties.java
@@ -17,10 +17,13 @@ import java.time.Duration;
 public class S3Properties {
     @NotBlank
     private String accessKey;
+
     @NotBlank
     private String secretKey;
+
     @NotNull
     private URI endpoint;
+
     /**
      * A bucket name to use.
      *
@@ -29,6 +32,7 @@ public class S3Properties {
      */
     @NotBlank
     private String bucket;
+
     /**
      * The validity duration of a generated download link.
      */

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/InstitutionService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/InstitutionService.java
@@ -158,7 +158,7 @@ public class InstitutionService {
     }
 
     public String getEmblemPath(String slug) {
-        return String.join("/", fileStorageProperties.getBucket(), getEmblemKey(slug));
+        return fileStorageProperties.getPathPrefix() + getEmblemKey(slug);
     }
 
     public String getEmblemKey(String slug) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/ProductCategoryService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/ProductCategoryService.java
@@ -12,11 +12,8 @@ public class ProductCategoryService {
     private final FileStorageProperties fileStorageProperties;
 
     public String getIconPath(String iconName) {
-        return String.join("",
-                fileStorageProperties.getBucket(),
-                "/",
-                fileStorageProperties.getKeyPrefixProductsCategoriesIcons(),
-                iconName + ICON_EXTENSION_WITH_DOT
-        );
+        return fileStorageProperties.getPathPrefix() +
+                fileStorageProperties.getKeyPrefixProductsCategoriesIcons() +
+                iconName + ICON_EXTENSION_WITH_DOT;
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SavedViewService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SavedViewService.java
@@ -71,7 +71,7 @@ public class SavedViewService {
     }
 
     public String getThumbnailPath(UUID id) {
-        return String.join("/", fileStorageProperties.getBucket(), getThumbnailKey(id));
+        return fileStorageProperties.getPathPrefix() + getThumbnailKey(id);
     }
 
     public String getThumbnailKey(UUID id) {

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SavedViewControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SavedViewControllerTest.java
@@ -3,6 +3,7 @@ package pl.cyfronet.s4e.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.support.TransactionTemplate;
 import pl.cyfronet.s4e.BasicTest;
-import pl.cyfronet.s4e.properties.FileStorageProperties;
 import pl.cyfronet.s4e.TestDbHelper;
 import pl.cyfronet.s4e.TestResourceHelper;
 import pl.cyfronet.s4e.bean.AppUser;
@@ -20,6 +20,7 @@ import pl.cyfronet.s4e.bean.SavedView;
 import pl.cyfronet.s4e.controller.request.CreateSavedViewRequest;
 import pl.cyfronet.s4e.data.repository.AppUserRepository;
 import pl.cyfronet.s4e.data.repository.SavedViewRepository;
+import pl.cyfronet.s4e.properties.FileStorageProperties;
 import pl.cyfronet.s4e.service.FileStorage;
 
 import java.time.LocalDateTime;
@@ -121,7 +122,8 @@ public class SavedViewControllerTest {
                 .content(objectMapper.writeValueAsBytes(request))
                 .with(jwtBearerToken(appUser, objectMapper)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.uuid", matchesPattern(UUID_PATTERN)));
+                .andExpect(jsonPath("$.uuid", matchesPattern(UUID_PATTERN)))
+                .andExpect(jsonPath("$.thumbnail", Matchers.startsWith("/static-test/thumbnails-test/")));
 
         val allSavedViews = savedViewRepository.findAllBy(SavedViewProjection.class);
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/ProductCategoryServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/ProductCategoryServiceTest.java
@@ -23,8 +23,7 @@ public class ProductCategoryServiceTest {
     public void shouldReturnUrlToCategoriesFileInS3() {
         val iconName = "test";
         val iconNameWithExtension = iconName + ProductCategoryService.ICON_EXTENSION_WITH_DOT;
-        val bucketWithIconsKey = fileStorageProperties.getBucket()
-                + "/" + fileStorageProperties.getKeyPrefixProductsCategoriesIcons();
+        val bucketWithIconsKey = "/static-test/" + fileStorageProperties.getKeyPrefixProductsCategoriesIcons();
         val iconPath = bucketWithIconsKey + iconNameWithExtension;
 
         assertThat(productCategoryService.getIconPath(iconName), is(iconPath));

--- a/s4e-backend/src/test/resources/application-test.properties
+++ b/s4e-backend/src/test/resources/application-test.properties
@@ -22,6 +22,7 @@ s3.bucket=local-dataset-1
 s3.presigned-get-timeout=1m
 
 s3.file-storage.bucket=static
+s3.file-storage.path-prefix=/static-test/
 s3.file-storage.key-prefix-thumbnail=thumbnails-test/
 s3.file-storage.key-prefix-emblem=emblems-test/
 s3.file-storage.key-prefix-products-categories-icons=categories-test/


### PR DESCRIPTION
Separate static bucket name from path prefix, as they may differ.

Add validation of several properties for more robust configuration.

Fixes: #855.