### PR TITLE
[#858] Handle delete S3 object notifications

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/AmqpConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/AmqpConfig.java
@@ -11,6 +11,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import pl.cyfronet.s4e.properties.AmqpProperties;
+import pl.cyfronet.s4e.service.SceneService;
+import pl.cyfronet.s4e.sync.NotificationDispatcher;
 import pl.cyfronet.s4e.sync.QueueReceiver;
 import pl.cyfronet.s4e.sync.SceneAcceptor;
 
@@ -30,6 +32,9 @@ public class AmqpConfig {
     @Autowired
     private SceneAcceptor sceneAcceptor;
 
+    @Autowired
+    private SceneService sceneService;
+
     @Bean
     public String incomingQueueName() {
         return amqpProperties.getQueues().getIncoming();
@@ -48,7 +53,12 @@ public class AmqpConfig {
     }
 
     @Bean
+    public NotificationDispatcher notificationDispatcher() {
+        return new NotificationDispatcher(sceneAcceptor, sceneService);
+    }
+
+    @Bean
     public QueueReceiver queueReceiver() {
-        return new QueueReceiver(sceneAcceptor);
+        return new QueueReceiver(notificationDispatcher());
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepository.java
@@ -28,6 +28,8 @@ public interface SceneRepository extends JpaRepository<Scene, Long>, SceneReposi
 
     Optional<Scene> findBySceneKey(String sceneKey);
 
+    boolean existsBySceneKey(String sceneKey);
+
     <T> Optional<T> findFirstByProductId(Long productId, Sort sort, Class<T> projection);
 
     List<Scene> findAllByProductId(Long productId);
@@ -50,4 +52,7 @@ public interface SceneRepository extends JpaRepository<Scene, Long>, SceneReposi
 
     @Transactional
     void deleteAllByProductId(Long productId);
+
+    @Transactional
+    void deleteBySceneKey(String sceneKey);
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SceneService.java
@@ -90,6 +90,14 @@ public class SceneService {
     }
 
     @Transactional
+    public void deleteBySceneKey(String sceneKey) throws NotFoundException {
+        if (!sceneRepository.existsBySceneKey(sceneKey)) {
+            throw constructNFE("Scene", "sceneKey", sceneKey);
+        }
+        sceneRepository.deleteBySceneKey(sceneKey);
+    }
+
+    @Transactional
     public void deleteProductScenes(Long productId) throws NotFoundException {
         if (!productRepository.existsById(productId)) {
             throw constructNFE("Product", productId);
@@ -140,6 +148,10 @@ public class SceneService {
     }
 
     private NotFoundException constructNFE(String name, Long id) {
-        return new NotFoundException(name + " with id '" + id + "' not found");
+        return constructNFE(name, "id", id.toString());
+    }
+
+    private NotFoundException constructNFE(String name, String idType, String id) {
+        return new NotFoundException(name + " with " + idType + " '" + id + "' not found");
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/NotificationDispatcher.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/NotificationDispatcher.java
@@ -1,0 +1,58 @@
+package pl.cyfronet.s4e.sync;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import pl.cyfronet.s4e.ex.NotFoundException;
+import pl.cyfronet.s4e.service.SceneService;
+
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationDispatcher {
+    // These events correspond to event types listed for example here:
+    // https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/.
+    private static final Set<String> ACCEPT_EVENTS = Set.of("s3:ObjectCreated:Put", "s3:ObjectCreated:Post");
+    private static final Set<String> DELETE_EVENTS = Set.of("s3:ObjectRemoved:Delete");
+
+    private final SceneAcceptor sceneAcceptor;
+    private final SceneService sceneService;
+
+    public void dispatch(Notification notification) {
+        if (notification == null) {
+            return;
+        }
+
+        val eventName = notification.getEventName();
+        val objectKey = notification.getObjectKey();
+
+        if (ACCEPT_EVENTS.contains(eventName)) {
+            accept(objectKey);
+        } else if (DELETE_EVENTS.contains(eventName)) {
+            delete(objectKey);
+        } else {
+            log.warn(
+                    "Notification with unsupported eventName: objectKey='{}', eventName='{}'",
+                    objectKey,
+                    eventName
+            );
+        }
+    }
+
+    private void accept(String sceneKey) {
+        Error error = sceneAcceptor.accept(sceneKey);
+        if (error != null) {
+            throw new AmqpRejectAndDontRequeueException(error.getCode());
+        }
+    }
+
+    private void delete(String sceneKey) {
+        try {
+            sceneService.deleteBySceneKey(sceneKey);
+        } catch (NotFoundException e) {
+            log.warn("An unsupported attempt to delete a non-existent scene: sceneKey='{}'", sceneKey);
+        }
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/QueueReceiver.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/QueueReceiver.java
@@ -2,20 +2,16 @@ package pl.cyfronet.s4e.sync;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 
 @RequiredArgsConstructor
 @Slf4j
 public class QueueReceiver {
-    private final SceneAcceptor sceneAcceptor;
+    private final NotificationDispatcher notificationDispatcher;
 
     @RabbitListener(queues = "#{incomingQueueName}")
     public void handle(Notification notification) {
         log.debug("Received notification: objectKey='{}', eventName='{}'", notification.getObjectKey(), notification.getEventName());
-        Error error = sceneAcceptor.accept(notification.getObjectKey());
-        if (error != null) {
-            throw new AmqpRejectAndDontRequeueException(error.getCode());
-        }
+        notificationDispatcher.dispatch(notification);
     }
 }


### PR DESCRIPTION
Add a NotificationDispatcher with the eventType based handling logic,
which includes removing a scene for s3:ObjectDeleted:Delete eventType.

Warnings are raised on purpose to make problems with queue configuration
easier to find.

Closes: #858