### PR TITLE
[#799] Add live scene loading

### DIFF
--- a/s4e-web/src/app/views/map-view/map-view.component.ts
+++ b/s4e-web/src/app/views/map-view/map-view.component.ts
@@ -180,7 +180,7 @@ export class MapViewComponent implements OnInit, OnDestroy {
   }
 
   setDate($event: string) {
-    this.sceneService.get(this.productQuery.getActive(), $event, 'first');
+    this.sceneService.get(this.productQuery.getActive(), $event, 'first').subscribe();
     this.productService.setSelectedDate($event);
   }
 

--- a/s4e-web/src/app/views/map-view/state/product/product.service.spec.ts
+++ b/s4e-web/src/app/views/map-view/state/product/product.service.spec.ts
@@ -18,6 +18,7 @@ import environment from '../../../../../environments/environment';
 import {SceneFactory} from '../scene/scene.factory.spec';
 import {distinctUntilChanged, map, take, toArray} from 'rxjs/operators';
 import {LocalStorageTestingProvider} from '../../../../app.configuration.spec';
+import {of} from 'rxjs';
 
 describe('ProductService', () => {
   let productService: ProductService;
@@ -104,7 +105,7 @@ describe('ProductService', () => {
       ).toPromise();
 
       spyOn(productService, 'setSelectedDate')
-      spyOn(sceneService, 'get').and.stub()
+      spyOn(sceneService, 'get').and.returnValue(of(true))
       spyOn(sceneService, 'setActive').and.stub()
 
       productService.getLastAvailableScene();

--- a/s4e-web/src/app/views/map-view/state/product/product.service.ts
+++ b/s4e-web/src/app/views/map-view/state/product/product.service.ts
@@ -71,8 +71,8 @@ export class ProductService {
       }
 
       this.setSelectedDate(data.timestamp);
-      this.sceneService.get(product, data.timestamp.substr(0, 10));
-      this.sceneService.setActive(data.sceneId);
+      this.sceneService.get(product, data.timestamp.substr(0, 10))
+        .subscribe(() => this.sceneService.setActive(data.sceneId));
     });
   }
 
@@ -159,7 +159,7 @@ export class ProductService {
       )
       .subscribe(data => {
         this.updateAvailableDays(data);
-        this.sceneService.get(activeProduct, ui.selectedDate);
+        this.sceneService.get(activeProduct, ui.selectedDate).subscribe();
       });
   }
 
@@ -216,14 +216,14 @@ export class ProductService {
     let newDate = moment(this.query.getValue().ui.selectedDate);
     newDate.subtract(1, 'day');
     this.setSelectedDate(yyyymmdd(newDate.toDate()));
-    this.sceneService.get(this.query.getActive(), yyyymmdd(newDate.toDate()), 'last');
+    this.sceneService.get(this.query.getActive(), yyyymmdd(newDate.toDate()), 'last').subscribe();
   }
 
   nextDay() {
     let newDate = moment(this.query.getValue().ui.selectedDate);
     newDate.add(1, 'day');
     this.setSelectedDate(yyyymmdd(newDate.toDate()));
-    this.sceneService.get(this.query.getActive(), yyyymmdd(newDate.toDate()), 'first');
+    this.sceneService.get(this.query.getActive(), yyyymmdd(newDate.toDate()), 'first').subscribe();
   }
 
   moveResolution(direction: -1 | 1) {

--- a/s4e-web/src/app/views/map-view/state/scene/scene.service.spec.ts
+++ b/s4e-web/src/app/views/map-view/state/scene/scene.service.spec.ts
@@ -84,7 +84,7 @@ describe('SceneService', () => {
           done();
         });
 
-      sceneService.get(product, dateF);
+      sceneService.get(product, dateF).subscribe();
 
       const urlParams = `date=${dateF}&timeZone=${timezone()}`;
       const url = `${environment.apiPrefixV1}/products/${product.id}/scenes?${urlParams}`;
@@ -96,7 +96,7 @@ describe('SceneService', () => {
       const productId = 1;
       const product = ProductFactory.build({id: productId});
       const dateF = '2019-10-01';
-      sceneService.get(product, dateF);
+      sceneService.get(product, dateF).subscribe();
 
       const urlParams = `date=${dateF}&timeZone=${timezone()}`;
       const url = `${environment.apiPrefixV1}/products/${product.id}/scenes?${urlParams}`;
@@ -119,7 +119,7 @@ describe('SceneService', () => {
           done();
         });
 
-      sceneService.get(product, dateF);
+      sceneService.get(product, dateF).subscribe();
 
       const urlParams = `date=${dateF}&timeZone=${timezone()}`;
       const url = `${environment.apiPrefixV1}/products/${product.id}/scenes?${urlParams}`;

--- a/s4e-web/src/app/views/map-view/state/scene/scene.store.service.ts
+++ b/s4e-web/src/app/views/map-view/state/scene/scene.store.service.ts
@@ -2,14 +2,16 @@ import { Injectable } from '@angular/core';
 import {ActiveState, EntityState, EntityStore, StoreConfig} from '@datorama/akita';
 import { Scene } from './scene.model';
 
-export interface SceneState extends EntityState<Scene>, ActiveState<number> {}
+export interface SceneState extends EntityState<Scene>, ActiveState<number> {
+  isLiveMode: boolean;
+}
 
 @Injectable({ providedIn: 'root' })
 @StoreConfig({ name: 'Scene', idKey: 'id' })
 export class SceneStore extends EntityStore<SceneState, Scene> {
 
   constructor() {
-    super();
+    super({isLiveMode: false});
   }
 }
 

--- a/s4e-web/src/app/views/map-view/state/scene/timeline.service.spec.ts
+++ b/s4e-web/src/app/views/map-view/state/scene/timeline.service.spec.ts
@@ -1,0 +1,49 @@
+import {TestBed} from '@angular/core/testing';
+import {TimelineService} from './timeline.service';
+import {LocalStorageTestingProvider} from '../../../../app.configuration.spec';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {ProductService} from '../product/product.service';
+
+describe('SceneService', () => {
+  let timelineService: TimelineService;
+  let productService: ProductService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TimelineService,
+        LocalStorageTestingProvider
+      ],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule
+      ]
+    })
+      .compileComponents();
+    timelineService = TestBed.get(TimelineService);
+    productService = TestBed.get(ProductService);
+  });
+
+  it('should create', () => {
+    expect(timelineService).toBeTruthy();
+  });
+
+  it('should turn on live mode', () => {
+    const spyLoadingLatestScene = spyOn(productService, 'getLastAvailableScene')
+      .and.returnValue(null);
+    timelineService.toggleLiveMode();
+    expect(spyLoadingLatestScene).toHaveBeenCalled();
+    expect((timelineService as any)._updaterIntervalID).not.toBe(null);
+  });
+  it('should turn off live mode', () => {
+    const spyLoadingLatestScene = spyOn(productService, 'getLastAvailableScene')
+      .and.returnValue(null);
+    timelineService.toggleLiveMode();
+    expect(spyLoadingLatestScene).toHaveBeenCalled();
+    expect((timelineService as any)._updaterIntervalID).not.toBe(null);
+
+    timelineService.toggleLiveMode();
+    expect((timelineService as any)._updaterIntervalID).toBe(null);
+  });
+});

--- a/s4e-web/src/app/views/map-view/state/scene/timeline.service.ts
+++ b/s4e-web/src/app/views/map-view/state/scene/timeline.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@angular/core';
+import {ModalService} from '../../../../modal/state/modal.service';
+import {filter, map, tap} from 'rxjs/operators';
+import {ProductService} from '../product/product.service';
+import Timer = NodeJS.Timer;
+import {SceneStore} from './scene.store.service';
+import {SceneQuery} from './scene.query';
+import environment from '../../../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class TimelineService {
+  private _updaterIntervalID: Timer;
+  private _handleUpdater$ = this._sceneQuery.selectLoading()
+    .pipe(
+      filter(isLoading => !isLoading),
+      map(() => this._sceneQuery.getValue().isLiveMode),
+      tap(isLiveMode => isLiveMode ? this._turnOnUpdater() : this._turnOffUpdater())
+    );
+
+  constructor(
+    private _sceneStore: SceneStore,
+    private _sceneQuery: SceneQuery,
+    private _modalService: ModalService,
+    private _productService: ProductService
+  ) {
+    this._handleUpdater$.subscribe();
+  }
+
+  toggleLiveMode(isLiveMode?: boolean) {
+    this._sceneStore.setLoading(true);
+    isLiveMode = isLiveMode != null
+      ? isLiveMode
+      : !this._sceneQuery.getValue().isLiveMode;
+
+    this._sceneStore.update({...this._sceneQuery.getValue(), isLiveMode});
+    this._sceneStore.setLoading(false);
+  }
+
+  async confirmTurningOfLiveMode(): Promise<boolean> {
+    this._sceneStore.setLoading(true);
+
+    const isLiveMode = this._sceneQuery.getValue().isLiveMode;
+    if (!isLiveMode) {
+      this._sceneStore.setLoading(false);
+      return true;
+    }
+
+    const isLeavingLiveMode = await this._modalService.confirm(
+      'Wychodzisz z trybu podglądu scen na żywo',
+      'Czy na pewno chcesz wyjść?'
+    );
+    if (isLeavingLiveMode) {
+        this._sceneStore.update({isLiveMode: false});
+    }
+
+    this._sceneStore.setLoading(false);
+    return isLeavingLiveMode;
+  }
+
+  private _turnOnUpdater() {
+    if (!!this._updaterIntervalID) {
+      return;
+    }
+
+    this._productService.getLastAvailableScene();
+    this._updaterIntervalID = setInterval(
+      () => this._productService.getLastAvailableScene(),
+      environment.liveSceneUpdateRateInMs
+    );
+  }
+
+  private _turnOffUpdater() {
+    if (!this._updaterIntervalID) {
+      return;
+    }
+
+    clearInterval(this._updaterIntervalID);
+    this._updaterIntervalID = null;
+  }
+}

--- a/s4e-web/src/app/views/map-view/timeline/timeline.component.html
+++ b/s4e-web/src/app/views/map-view/timeline/timeline.component.html
@@ -1,7 +1,13 @@
 <div>
   <section class="timeline__manager">
+    <div class="timecontrol timecontrol--live">
+      <label for="live" i18n>
+        <p id="live--dot" [ngClass]="{active: isLive$ | async}"></p> <span>Na żywo</span>
+      </label>
+      <input type="checkbox" id="live" name="live" (change)="toggleLiveMode()" />
+    </div>
     <div class="timecontrol timecontrol--date">
-      <span (click)="previousDay.emit()" class="timecontrol__button timecontrol__button--prev"></span>
+      <span (click)="goToPreviousDay()" class="timecontrol__button timecontrol__button--prev"></span>
       <span [owlDateTimeTrigger]="datepicker">{{currentDate}}</span>
       <input style="visibility: hidden; width: 1px; display: inline-block;" [owlDateTimeFilter]="filterInactiveDays"
              (dateTimeChange)="selectDate($event)"
@@ -14,12 +20,12 @@
                      (afterPickerClosed)="setPickerOpenState(false)"
                      [pickerMode]="'popup'" [pickerType]="'calendar'"
                      (monthSelected)="monthSelected($event)"></owl-date-time>
-      <span (click)="nextDay.emit()" class="timecontrol__button timecontrol__button--next"></span>
+      <span (click)="goToNextDay()" class="timecontrol__button timecontrol__button--next"></span>
     </div>
     <div class="timecontrol timecontrol--clock">
-      <span (click)="previousScene.emit()" class="timecontrol__button timecontrol__button--prev"></span>
+      <span (click)="goToPreviousScene()" class="timecontrol__button timecontrol__button--prev"></span>
       <span>{{activeScene?.timestamp | hour}}</span>
-      <span (click)="nextScene.emit()" class="timecontrol__button timecontrol__button--next"></span>
+      <span (click)="goToNextScene()" class="timecontrol__button timecontrol__button--next"></span>
     </div>
     <div class="timecontrol timecontrol--interval">
       <span (click)="decreaseResolution.emit()" class="timecontrol__button timecontrol__button--minus"></span>
@@ -30,7 +36,7 @@
 
   <ul class="timeline__grid">
     <li class="timeline__item timeline__item--noproduct" *ngIf="!((scenes$ | async)?.length) && !loading" i18n>Brak
-      scen w tym dniu, wybierz inną datę, lub <a href="javascript:void(0)" (click)="lastAvailableScene.emit()">przejdź
+      scen w tym dniu, wybierz inną datę, lub <a href="javascript:void(0)" (click)="goToLastAvailableScene()">przejdź
         do ostatniej zarejestrowanej sceny</a></li>
 
     <ng-container *ngFor="let scenePoint of (scenes$ | async)">
@@ -41,7 +47,7 @@
           [attr.data-active-id]="activeScene?.id"
           [ngClass]="{active: scenePoint.selected}"
           [style.left.%]="scenePoint.points[0].position"
-          (click)="selectedScene.emit(scenePoint.points[0])">
+          (click)="selectScene(scenePoint.points[0])">
         <span>{{ scenePoint.points[0].timestamp | date : 'shortTime' }}</span>
       </li>
       <ng-template #aggregatePoint>
@@ -57,7 +63,7 @@
                   title=""
                   [attr.data-scene-id]="scene.id"
                   [attr.data-hour]="scene.timestamp | hour : true"
-                  (click)="selectedScene.emit(scene); activeStackedPoint = null;">
+                  (click)="selectScene(scene)">
                 {{scene.timestamp | hour : true}}
               </li>
             </ul>

--- a/s4e-web/src/app/views/map-view/timeline/timeline.component.scss
+++ b/s4e-web/src/app/views/map-view/timeline/timeline.component.scss
@@ -1,0 +1,44 @@
+.timecontrol--live {
+  background: whitesmoke;
+  float: left;
+
+  input[type="checkbox"] {
+    display: none;
+  }
+
+  label[for="live"] {
+    cursor: pointer;
+
+    span {
+      margin-bottom: 5px;
+    }
+  }
+
+  #live--dot {
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    background-color: gray;
+    display: inline-block;
+    margin-bottom: 0px;
+
+    &.active {
+      @keyframes pulse {
+        0% {
+          background-color: gray;
+        }
+        25% {
+          background-color: red;
+        }
+        50% {
+          background-color: red;
+        }
+        75% {
+          background-color: gray;
+        }
+      }
+
+      animation: pulse 3s infinite;
+    }
+  }
+}

--- a/s4e-web/src/app/views/map-view/timeline/timeline.component.spec.ts
+++ b/s4e-web/src/app/views/map-view/timeline/timeline.component.spec.ts
@@ -4,7 +4,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MapModule} from '../map.module';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {RemoteConfigurationTestingProvider} from '../../../app.configuration.spec';
+import {LocalStorageTestingProvider, RemoteConfigurationTestingProvider} from '../../../app.configuration.spec';
 import {SimpleChange} from '@angular/core';
 import {Scene, SceneWithUI} from '../state/scene/scene.model';
 import {convertToSceneWithPosition, SceneFactory} from '../state/scene/scene.factory.spec';
@@ -69,8 +69,16 @@ describe('TimelineComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MapModule, NoopAnimationsModule, HttpClientTestingModule, RouterTestingModule],
-      providers: [RemoteConfigurationTestingProvider]
+      imports: [
+        MapModule,
+        NoopAnimationsModule,
+        HttpClientTestingModule,
+        RouterTestingModule
+      ],
+      providers: [
+        LocalStorageTestingProvider,
+        RemoteConfigurationTestingProvider
+      ]
     })
       .compileComponents();
   }));

--- a/s4e-web/src/app/views/map-view/view-manager/view-manager.component.spec.ts
+++ b/s4e-web/src/app/views/map-view/view-manager/view-manager.component.spec.ts
@@ -2,14 +2,14 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MapModule} from '../map.module';
 import {RouterTestingModule} from '@angular/router/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
-import {MapViewComponent} from '../map-view.component';
-import {ActivatedRoute} from '@angular/router';
 import {ProductService} from '../state/product/product.service';
 import {ProductStore} from '../state/product/product.store';
 import {ProductQuery} from '../state/product/product.query';
 import {ViewManagerComponent} from './view-manager.component';
 import {ProductFactory} from '../state/product/product.factory.spec';
 import {LocalStorageTestingProvider} from '../../../app.configuration.spec';
+import {TimelineService} from '../state/scene/timeline.service';
+import {of} from 'rxjs';
 
 describe('ViewManagerComponent', () => {
   let fixture: ComponentFixture<ViewManagerComponent>;
@@ -17,6 +17,7 @@ describe('ViewManagerComponent', () => {
   let productQuery: ProductQuery;
   let productStore: ProductStore;
   let productService: ProductService;
+  let timelineService: TimelineService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -27,6 +28,7 @@ describe('ViewManagerComponent', () => {
     productQuery = TestBed.get(ProductQuery);
     productStore = TestBed.get(ProductStore);
     productService = TestBed.get(ProductService);
+    timelineService = TestBed.get(TimelineService);
   }));
 
   beforeEach(() => {
@@ -35,20 +37,24 @@ describe('ViewManagerComponent', () => {
     fixture.detectChanges();
   });
 
-  it('selectProduct should set product', () => {
+  it('selectProduct should set product', async () => {
     const product = ProductFactory.build();
     productStore.set([product]);
     const spy = spyOn(productService, 'setActive');
-    component.selectProduct(product.id);
+    spyOn(timelineService, 'confirmTurningOfLiveMode')
+      .and.returnValue(of(true).toPromise());
+    await component.selectProduct(product.id);
     expect(spy).toHaveBeenCalledWith(product.id);
   });
 
-  it('selectProduct should unset product if active one is selected', () => {
+  it('selectProduct should unset product if active one is selected', async () => {
     const product = ProductFactory.build();
     productStore.set([product]);
     productStore.setActive(product.id);
     const spy = spyOn(productService, 'setActive');
-    component.selectProduct(product.id);
+    spyOn(timelineService, 'confirmTurningOfLiveMode')
+      .and.returnValue(of(true).toPromise());
+    await component.selectProduct(product.id);
     expect(spy).toHaveBeenCalledWith(null);
   });
 });

--- a/s4e-web/src/app/views/map-view/view-manager/view-manager.component.ts
+++ b/s4e-web/src/app/views/map-view/view-manager/view-manager.component.ts
@@ -28,6 +28,7 @@ import {ResizeEvent} from 'angular-resizable-element';
 import {InjectorModule} from 'src/app/common/injector.module';
 import {ModalService} from '../../../modal/state/modal.service';
 import {OVERLAY_LIST_MODAL_ID} from './overlay-list-modal/overlay-list-modal.model';
+import {TimelineService} from '../state/scene/timeline.service';
 
 @Component({
   selector: 's4e-view-manager',
@@ -69,7 +70,8 @@ export class ViewManagerComponent implements OnInit, OnDestroy {
     private searchResultsService: SearchResultsService,
     private sessionQuery: SessionQuery,
     private _renderer: Renderer2,
-    private _modalService: ModalService
+    private _modalService: ModalService,
+    private timelineService: TimelineService
   ) {
   }
 
@@ -93,7 +95,12 @@ export class ViewManagerComponent implements OnInit, OnDestroy {
     this.searchResultsService.toggleSearchResults(show);
   }
 
-  selectProduct(productId: number) {
+  async selectProduct(productId: number) {
+    const turnOfLiveMode = await this.timelineService.confirmTurningOfLiveMode();
+    if (!turnOfLiveMode) {
+      return;
+    }
+
     if (this.productQuery.getActiveId() === productId) {
       productId = null;
     }

--- a/s4e-web/src/environments/environment.common.ts
+++ b/s4e-web/src/environments/environment.common.ts
@@ -5,6 +5,12 @@ export const commonEnvironmentVariables = {
   projection: {toProjection: 'EPSG:3857', coordinates: [19, 52] as [number, number]},
   maxZoom: 12,
   timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+
+  /*
+  * IMPORTANT!!! Too large frequency can provide to drastically slow down of application
+  * Every nth MS UI will send request to API for latest scene
+  * */
+  liveSceneUpdateRateInMs: 60000
 };
 
 export default commonEnvironmentVariables;


### PR DESCRIPTION
Where to find feature?

1. Go to `/map`
2. Turn on any of products
3. Click button `Na żywo` near timeline

- Add checkbox on `/map` page to display the latest scenes of the product (send a request for new scenes every 15 minutes)
- Reload the latest scene on the map, when new occur
- When live mode is turn on ask if user is sure while
  - changing between products
  - trying to change scene (by hour/date or on time axis)

Closes #799