### PR TITLE
[#907] Add endpoint count for front-search and API

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
@@ -133,7 +133,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .access("isAuthenticated() && @licensePermissionEvaluator.allowSceneRead(#id, principal)")
 
                 .mvcMatchers(GET, prefix("/search")).permitAll()
+                .mvcMatchers(GET, prefix("/search/count")).permitAll()
                 .mvcMatchers(GET, prefix("/dhus/search")).authenticated()
+                .mvcMatchers(GET, prefix("/dhus/search/count")).authenticated()
                 // This rule calling allowSceneRead is correct: in OData DHUS nomenclature a Product is our Scene.
                 .mvcMatchers(GET, prefix("/dhus/odata/v1/Products('{sceneId}')/**"))
                     .access("isAuthenticated() && @licensePermissionEvaluator.allowSceneRead(#sceneId, principal)")

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SearchController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SearchController.java
@@ -41,8 +41,19 @@ public class SearchController {
     public List<SearchResponse> getScenes(@RequestParam Map<String, Object> params)
             throws SQLException, QueryException {
         ZoneId zoneId = ZoneId.of(String.valueOf(params.getOrDefault("timeZone", "UTC")));
-            return searchService.getScenesBy(params).stream()
-                    .map(scene -> responseExtender.toResponse(scene, zoneId))
-                    .collect(Collectors.toList());
+        return searchService.getScenesBy(params).stream()
+                .map(scene -> responseExtender.toResponse(scene, zoneId))
+                .collect(Collectors.toList());
+    }
+
+    @Operation(summary = "View a list of scenes")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved count"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request", content = @Content),
+    })
+    @GetMapping("/search/count")
+    public Long getCount(@RequestParam Map<String, Object> params)
+            throws SQLException, QueryException {
+        return searchService.getCountBy(params);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepositoryExt.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepositoryExt.java
@@ -10,4 +10,5 @@ import java.util.Map;
 //an interface with the methods you wish to use with EntityManger.
 public interface SceneRepositoryExt {
     List<MappedScene> findAllByParamsMap(Map<String, Object> params) throws SQLException, QueryException;
+    Long countAllByParamsMap(Map<String, Object> params) throws SQLException, QueryException;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepositoryImpl.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRepositoryImpl.java
@@ -67,10 +67,27 @@ public class SceneRepositoryImpl implements SceneRepositoryExt {
         }
     }
 
+    public Long countAllByParamsMap(Map<String, Object> params) throws SQLException, QueryException {
+        PreparedStatement preparedStatement = prepareCountQuery(params);
+        try {
+            return jdbcTemplate.query(connection -> preparedStatement, (rs, rowNum) -> rs.getLong(1)).get(0);
+        } catch (DataAccessException e) {
+            MapBindingResult mapBindingResult = new MapBindingResult(new HashMap<>(), "params");
+            mapBindingResult.addError(
+                    new ObjectError("params", "Cannot execute query" + e.getMessage()));
+            throw new QueryException(mapBindingResult);
+        }
+    }
+
     private PreparedStatement prepareQuery(Map<String, Object> params) throws SQLException, QueryException {
         PreparedStatement ps = preparedStatementBuilder.preparedStatement(connection, params);
         log.trace(ps.toString());
         return ps;
     }
 
+    private PreparedStatement prepareCountQuery(Map<String, Object> params) throws SQLException, QueryException {
+        PreparedStatement ps = preparedStatementBuilder.preparedCountStatement(connection, params);
+        log.trace(ps.toString());
+        return ps;
+    }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/PreparedStatementBuilder.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/PreparedStatementBuilder.java
@@ -26,11 +26,32 @@ public class PreparedStatementBuilder {
         return ps;
     }
 
+    public PreparedStatement preparedCountStatement(Connection connection,
+                                               Map<String, Object> params) throws SQLException, QueryException {
+        List<Object> parameters = new ArrayList<>();
+        PreparedStatement ps = connection.prepareStatement(prepareCountQueryAndParameters(params, parameters));
+        addParametersToStatement(ps, parameters);
+        return ps;
+    }
+
     private String prepareQueryAndParameters(Map<String, Object> params,
                                              List<Object> parameters) throws QueryException {
         StringBuilder resultQuery = new StringBuilder();
         MapBindingResult errors = new MapBindingResult(new HashMap<>(), "params");
         queryBuilder.prepareQueryAndParameters(params, parameters, resultQuery, errors);
+        if (errors.hasErrors()) {
+            throw new QueryException(errors);
+        }
+        // [] inputAuxiliaryFiles -> ...
+        // [] polygon -> field[footprint]
+        return resultQuery.toString();
+    }
+
+    private String prepareCountQueryAndParameters(Map<String, Object> params,
+                                                  List<Object> parameters) throws QueryException {
+        StringBuilder resultQuery = new StringBuilder();
+        MapBindingResult errors = new MapBindingResult(new HashMap<>(), "params");
+        queryBuilder.prepareCountQueryAndParameters(params, parameters, resultQuery, errors);
         if (errors.hasErrors()) {
             throw new QueryException(errors);
         }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryBuilder.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryBuilder.java
@@ -10,4 +10,9 @@ public interface QueryBuilder {
                                    List<Object> parameters,
                                    StringBuilder resultQuery,
                                    Errors errors);
+
+    void prepareCountQueryAndParameters(Map<String, Object> params,
+                                        List<Object> parameters,
+                                        StringBuilder resultQuery,
+                                        Errors errors);
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderImpl.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderImpl.java
@@ -30,4 +30,9 @@ public class QueryBuilderImpl implements QueryBuilder {
         resultQuery.append(String.join(",", columns));
         resultQuery.append(" FROM Scene WHERE true ");
     }
+
+    @Override
+    public void prepareCountQueryAndParameters(Map<String, Object> params, List<Object> parameters, StringBuilder resultQuery, Errors errors) {
+        resultQuery.append("SELECT COUNT(*) FROM Scene WHERE true ");
+    }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryDecorator.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryDecorator.java
@@ -16,6 +16,13 @@ public abstract class QueryDecorator implements QueryBuilder {
                                                         StringBuilder resultQuery,
                                                         Errors errors);
 
+    protected void doPrepareCountQueryAndParameters(Map<String, Object> params,
+                                                        List<Object> parameters,
+                                                        StringBuilder resultQuery,
+                                                        Errors errors){
+        doPrepareQueryAndParameters(params, parameters, resultQuery, errors);
+    }
+
     @Override
     public final void prepareQueryAndParameters(Map<String, Object> params,
                                                 List<Object> parameters,
@@ -23,5 +30,14 @@ public abstract class QueryDecorator implements QueryBuilder {
                                                 Errors errors) {
         queryBuilder.prepareQueryAndParameters(params, parameters, resultQuery, errors);
         doPrepareQueryAndParameters(params, parameters, resultQuery, errors);
+    }
+
+    @Override
+    public final void prepareCountQueryAndParameters(Map<String, Object> params,
+                                                List<Object> parameters,
+                                                StringBuilder resultQuery,
+                                                Errors errors) {
+        queryBuilder.prepareCountQueryAndParameters(params, parameters, resultQuery, errors);
+        doPrepareCountQueryAndParameters(params, parameters, resultQuery, errors);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryEnding.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryEnding.java
@@ -28,6 +28,11 @@ public class QueryEnding extends QueryDecorator {
         parameters.add(getOffset(params, errors));
     }
 
+    @Override
+    protected void doPrepareCountQueryAndParameters(Map<String, Object> params, List<Object> parameters, StringBuilder resultQuery, Errors errors) {
+        resultQuery.append(" ;");
+    }
+
     private String getOrderByField(Map<String, Object> params,
                                    Errors errors) {
         switch (String.valueOf(params.getOrDefault(SORT_BY, "id"))) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SearchService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/SearchService.java
@@ -22,6 +22,18 @@ public class SearchService {
         return repository.findAllByParamsMap(params);
     }
 
+    public Long getCountBy(Map<String, Object> params) throws SQLException, QueryException {
+        return repository.countAllByParamsMap(params);
+    }
+
+    public Map<String, Object> countParseToParamMap(String query) {
+        Map<String, Object> result = new HashMap<>();
+        if (query != null) {
+            result.putAll(converter.convert(query));
+        }
+        return result;
+    }
+
     public Map<String, Object> parseToParamMap(String rowsSize, String rowStart, String orderby, String query) {
         Map<String, Object> result = new HashMap<>();
         if (query != null) {


### PR DESCRIPTION
endpoint /count for front-end and API 
works like search but with fewer parameters.
both endpoints return count(number-long) for query(q=? or params)
Closes #907 