### PR TITLE
[#773] Add private product access management

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminCreateLicenseGrantRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminCreateLicenseGrantRequest.java
@@ -1,0 +1,19 @@
+package pl.cyfronet.s4e.admin.license;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+class AdminCreateLicenseGrantRequest {
+    @NotEmpty
+    private String institutionSlug;
+
+    @NotNull
+    private Long productId;
+
+    private boolean owner;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantController.java
@@ -1,0 +1,100 @@
+package pl.cyfronet.s4e.admin.license;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pl.cyfronet.s4e.ex.LicenseGrantException;
+import pl.cyfronet.s4e.ex.NotFoundException;
+
+import javax.validation.Valid;
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static pl.cyfronet.s4e.Constants.ADMIN_PREFIX;
+
+@RestController
+@RequestMapping(path = ADMIN_PREFIX + "/license-grants", produces = APPLICATION_JSON_VALUE)
+@Tag(name = "admin-license", description = "The Admin LicenseGrant API")
+@RequiredArgsConstructor
+public class AdminLicenseGrantController {
+    private final LicenseGrantService licenseGrantService;
+    private final AdminLicenseGrantMapper adminLicenseGrantMapper;
+
+    @Operation(summary = "Create LicenseGrant")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @PostMapping(consumes = APPLICATION_JSON_VALUE)
+    public AdminLicenseGrantResponse create(@RequestBody @Valid AdminCreateLicenseGrantRequest request) throws LicenseGrantException {
+        LicenseGrantService.CreateDTO createDTO = adminLicenseGrantMapper.toCreateDTO(request);
+        Long newId = licenseGrantService.create(createDTO);
+        return licenseGrantService.findByIdFetchInstitutionAndProduct(newId, AdminLicenseGrantResponse.class).get();
+    }
+
+    @Operation(summary = "List LicenseGrants")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @GetMapping
+    public List<AdminLicenseGrantResponse> list() {
+        return licenseGrantService.findAllFetchInstitutionAndProduct(AdminLicenseGrantResponse.class);
+    }
+
+    @Operation(summary = "Return LicenseGrant")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "LicenseGrant doesn't exist", content = @Content)
+    })
+    @GetMapping("/{id}")
+    public AdminLicenseGrantResponse read(@PathVariable Long id) throws NotFoundException {
+        return licenseGrantService.findByIdFetchInstitutionAndProduct(id, AdminLicenseGrantResponse.class)
+                .orElseThrow(() -> constructNFE(id));
+    }
+
+    @Operation(summary = "Update LicenseGrant")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "LicenseGrant doesn't exist", content = @Content)
+    })
+    @PatchMapping(path = "/{id}", consumes = APPLICATION_JSON_VALUE)
+    public AdminLicenseGrantResponse update(
+            @PathVariable Long id,
+            @RequestBody @Valid AdminUpdateLicenseGrantRequest request
+    ) throws NotFoundException {
+        return licenseGrantService.updateOwner(id, request.isOwner(), AdminLicenseGrantResponse.class)
+                .orElseThrow(() -> constructNFE(id));
+    }
+
+    @Operation(summary = "Delete LicenseGrant")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "LicenseGrant doesn't exist", content = @Content)
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id) throws NotFoundException {
+        if (!licenseGrantService.delete(id)) {
+            throw constructNFE(id);
+        }
+        return ResponseEntity.noContent().build();
+    }
+
+    private NotFoundException constructNFE(Long id) {
+        return new NotFoundException("LicenseGrant with id '" + id + "' not found");
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantMapper.java
@@ -1,0 +1,9 @@
+package pl.cyfronet.s4e.admin.license;
+
+import org.mapstruct.Mapper;
+import pl.cyfronet.s4e.config.MapStructCentralConfig;
+
+@Mapper(config = MapStructCentralConfig.class)
+public interface AdminLicenseGrantMapper {
+    LicenseGrantService.CreateDTO toCreateDTO(AdminCreateLicenseGrantRequest request);
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantResponse.java
@@ -1,0 +1,15 @@
+package pl.cyfronet.s4e.admin.license;
+
+import org.springframework.beans.factory.annotation.Value;
+
+interface AdminLicenseGrantResponse {
+    Long getId();
+
+    @Value("#{target.institution.slug}")
+    String getInstitutionSlug();
+
+    @Value("#{target.product.id}")
+    Long getProductId();
+
+    Boolean getOwner();
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminUpdateLicenseGrantRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/AdminUpdateLicenseGrantRequest.java
@@ -1,0 +1,10 @@
+package pl.cyfronet.s4e.admin.license;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AdminUpdateLicenseGrantRequest {
+    private boolean owner;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/LicenseGrantService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/license/LicenseGrantService.java
@@ -1,0 +1,156 @@
+package pl.cyfronet.s4e.admin.license;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.MapBindingResult;
+import pl.cyfronet.s4e.bean.LicenseGrant;
+import pl.cyfronet.s4e.bean.Product;
+import pl.cyfronet.s4e.data.repository.InstitutionRepository;
+import pl.cyfronet.s4e.data.repository.LicenseGrantRepository;
+import pl.cyfronet.s4e.data.repository.ProductRepository;
+import pl.cyfronet.s4e.ex.LicenseGrantException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LicenseGrantService {
+    private static final String INSTITUTION_NOT_FOUND_CODE = "pl.cyfronet.s4e.admin.license.LicenseGrantService.institution-not-found";
+    private static final String PRODUCT_NOT_FOUND_CODE = "pl.cyfronet.s4e.admin.license.LicenseGrantService.product-not-found";
+    private static final String PRODUCT_NOT_PRIVATE_CODE = "pl.cyfronet.s4e.admin.license.LicenseGrantService.product-not-private";
+    private static final String LICENSE_GRANT_ALREADY_EXISTS_CODE = "pl.cyfronet.s4e.admin.license.LicenseGrantService.already-exists";
+    private static final String CANNOT_DELETE_OWNER_CODE = "pl.cyfronet.s4e.admin.license.LicenseGrantService.cannot-delete-owner";
+
+    private final LicenseGrantRepository licenseGrantRepository;
+
+    private final ProductRepository productRepository;
+
+    private final InstitutionRepository institutionRepository;
+
+    private final ObjectMapper objectMapper;
+
+    @Data
+    @Builder
+    public static class CreateDTO {
+        private String institutionSlug;
+
+        private Long productId;
+
+        private boolean owner;
+    }
+
+    @Transactional
+    public Long create(CreateDTO dto) throws LicenseGrantException {
+        val licenseGrantBuilder = LicenseGrant.builder();
+
+        BindingResult bindingResult = new MapBindingResult(objectMapper.convertValue(dto, Map.class), "createDTO");
+
+        if (licenseGrantRepository.existsByProductIdAndInstitutionSlug(dto.getProductId(), dto.getInstitutionSlug())) {
+            bindingResult.reject(LICENSE_GRANT_ALREADY_EXISTS_CODE);
+        }
+
+        {
+            val institutionSlug = dto.getInstitutionSlug();
+            institutionRepository.findBySlug(institutionSlug)
+                    .ifPresentOrElse(
+                            licenseGrantBuilder::institution,
+                            () -> bindingResult.rejectValue("institutionSlug", INSTITUTION_NOT_FOUND_CODE)
+                    );
+        }
+
+        {
+            val productId = dto.getProductId();
+            val product = productRepository.findById(productId).orElse(null);
+            if (product == null) {
+                bindingResult.rejectValue("productId", PRODUCT_NOT_FOUND_CODE);
+            } else if (product.getAccessType() != Product.AccessType.PRIVATE) {
+                bindingResult.rejectValue("productId", PRODUCT_NOT_PRIVATE_CODE);
+            } else {
+                licenseGrantBuilder.product(product);
+            }
+        }
+
+        if (bindingResult.hasErrors()) {
+            throw new LicenseGrantException(bindingResult);
+        }
+
+        licenseGrantBuilder.owner(dto.isOwner());
+
+        return licenseGrantRepository.save(licenseGrantBuilder.build()).getId();
+    }
+
+    @Transactional
+    public <T> Optional<T> updateOwner(Long id, boolean owner, Class<T> projection) {
+        return licenseGrantRepository.findById(id)
+                .map(licenseGrant -> {
+                    licenseGrant.setOwner(owner);
+                    return licenseGrantRepository.findByIdFetchInstitutionAndProduct(id, projection).get();
+                });
+    }
+
+    @Transactional
+    public boolean delete(Long id) {
+        return licenseGrantRepository.findById(id)
+                .map(licenseGrant -> {
+                    licenseGrantRepository.delete(licenseGrant);
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    @Transactional
+    public boolean delete(Long productId, String institutionSlug) throws LicenseGrantException {
+        val licenseGrant = licenseGrantRepository.findByProductIdAndInstitutionSlug(productId, institutionSlug)
+                .orElse(null);
+
+        if (licenseGrant == null) {
+            return false;
+        }
+
+        if (licenseGrant.isOwner()) {
+            BindingResult bindingResult = new MapBindingResult(Map.of(), "delete");
+            bindingResult.reject(CANNOT_DELETE_OWNER_CODE);
+            throw new LicenseGrantException(bindingResult);
+        }
+
+        licenseGrantRepository.delete(licenseGrant);
+        return true;
+    }
+
+    public <T> Optional<T> findByIdFetchInstitutionAndProduct(Long id, Class<T> projection) {
+        return licenseGrantRepository.findByIdFetchInstitutionAndProduct(id, projection);
+    }
+
+    public <T> List<T> findAllFetchInstitutionAndProduct(Class<T> projection) {
+        return licenseGrantRepository.findAllFetchInstitutionAndProduct(projection);
+    }
+
+    @Transactional(readOnly = true)
+    public <T> Optional<List<T>> findAllByProductIdFetchInstitutionAndProduct(Long productId, Class<T> projection) {
+        if (!productRepository.existsById(productId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                licenseGrantRepository.findAllByProductIdFetchInstitutionAndProduct(productId, projection)
+        );
+    }
+
+    public <T> Optional<List<T>> findAllByInstitutionSlugFetchInstitutionAndProduct(String institutionSlug, Class<T> projection) {
+        if (!institutionRepository.existsBySlug(institutionSlug)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+                licenseGrantRepository.findAllByInstitutionSlugFetchInstitutionAndProduct(institutionSlug, projection)
+        );
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/LicenseGrant.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/LicenseGrant.java
@@ -23,4 +23,6 @@ public class LicenseGrant extends CreationAndModificationAudited {
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     private Product product;
+
+    private boolean owner;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private static String[] prefix(String... paths) {
         return Arrays.stream(paths)
                 .map(path -> API_PREFIX_V1 + path)
-                .toArray(n -> new String[n]);
+                .toArray(String[]::new);
     }
 
     @Override
@@ -104,6 +104,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .access("hasRole('ADMIN') || @ish.isAdmin(#institution)")
                 .mvcMatchers(GET, prefix("/institutions")).authenticated()
                 .mvcMatchers(prefix("/institutions")).hasRole("ADMIN")
+
+                .mvcMatchers(GET, prefix("/license-grants/institution/{institutionSlug}"))
+                    .access("hasRole('ADMIN') || @ish.isMember(#institutionSlug)")
+                .mvcMatchers(prefix(
+                        "/license-grants/product/{productId}",
+                        "/license-grants/product/{productId}/**"
+                )).access("@licensePermissionEvaluator.allowProductWrite(#productId, principal)")
 
                 .mvcMatchers(prefix("/user-role")).hasRole("ADMIN")
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/LicenseGrantController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/LicenseGrantController.java
@@ -1,0 +1,106 @@
+package pl.cyfronet.s4e.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pl.cyfronet.s4e.admin.license.LicenseGrantService;
+import pl.cyfronet.s4e.controller.response.LicenseGrantResponse;
+import pl.cyfronet.s4e.ex.LicenseGrantException;
+import pl.cyfronet.s4e.ex.NotFoundException;
+
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+
+@RestController
+@RequestMapping(path = API_PREFIX_V1 + "/license-grants", produces = APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Tag(name = "license-grant", description = "The LicenseGrant API")
+public class LicenseGrantController {
+    private final LicenseGrantService licenseGrantService;
+
+    @Operation(summary = "List grants for Institution")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Institution not found (admin only)", content = @Content)
+    })
+    @GetMapping("/institution/{institutionSlug}")
+    public List<LicenseGrantResponse> getLicenseGrantsForInstitution(
+            @PathVariable String institutionSlug
+    ) throws NotFoundException {
+        return licenseGrantService.findAllByInstitutionSlugFetchInstitutionAndProduct(
+                institutionSlug,
+                LicenseGrantResponse.class
+        ).orElseThrow(() -> new NotFoundException("Institution with slug '" + institutionSlug + "' not found"));
+    }
+
+    @Operation(summary = "List grants for Product")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @GetMapping("/product/{productId}")
+    public List<LicenseGrantResponse> getLicenseGrantsForProduct(
+            @PathVariable Long productId
+    ) throws NotFoundException {
+        return licenseGrantService.findAllByProductIdFetchInstitutionAndProduct(
+                productId,
+                LicenseGrantResponse.class
+        ).orElseThrow(() -> new NotFoundException("Product with id '" + productId + "' not found"));
+    }
+
+    @Operation(summary = "Grant Product access")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Access granted"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @PostMapping("/product/{productId}/institution/{institutionSlug}")
+    public LicenseGrantResponse grantAccessToProductToInstitution(
+            @PathVariable Long productId,
+            @PathVariable String institutionSlug
+    ) throws LicenseGrantException {
+        val newId = licenseGrantService.create(LicenseGrantService.CreateDTO.builder()
+                .productId(productId)
+                .institutionSlug(institutionSlug)
+                .owner(false)
+                .build());
+
+        return licenseGrantService.findByIdFetchInstitutionAndProduct(newId, LicenseGrantResponse.class).get();
+    }
+
+    @Operation(summary = "Deny Product access")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Access denied"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content),
+            @ApiResponse(responseCode = "404", description = "No LicenseGrant exists for given Institution", content = @Content)
+    })
+    @DeleteMapping("/product/{productId}/institution/{institutionSlug}")
+    public ResponseEntity<?> denyAccessToProductToInstitution(
+            @PathVariable Long productId,
+            @PathVariable String institutionSlug
+    ) throws NotFoundException, LicenseGrantException {
+        if (!licenseGrantService.delete(productId, institutionSlug)) {
+            throw new NotFoundException(
+                    "LicenseGrant with" +
+                    " productId '" + productId + "'" +
+                    " and institutionSlug '" + institutionSlug + "'" +
+                    " not found"
+            );
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/LicenseGrantResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/LicenseGrantResponse.java
@@ -1,0 +1,13 @@
+package pl.cyfronet.s4e.controller.response;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public interface LicenseGrantResponse {
+    @Value("#{target.institution.slug}")
+    String getInstitutionSlug();
+
+    @Value("#{target.product.id}")
+    Long getProductId();
+
+    Boolean getOwner();
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/InstitutionRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/InstitutionRepository.java
@@ -15,6 +15,8 @@ import java.util.Set;
 public interface InstitutionRepository extends CrudRepository<Institution, Long> {
     <T> Optional<T> findById(Long id, Class<T> projection);
 
+    boolean existsBySlug(String institutionSlug);
+
     <T> List<T> findAllBy(Class<T> projection);
 
     Optional<Institution> findBySlug(String slug);
@@ -22,8 +24,6 @@ public interface InstitutionRepository extends CrudRepository<Institution, Long>
     <T> Optional<T> findBySlug(String slug, Class<T> projection);
 
     Set<Institution> findAllByParentId(Long ParentId);
-
-    <T> Set<T> findAllByParentId(Long ParentId, Class<T> projection);
 
     @Query(value = "SELECT i.* " +
             "FROM Institution i " +

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/LicenseGrantRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/LicenseGrantRepository.java
@@ -1,9 +1,33 @@
 package pl.cyfronet.s4e.data.repository;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 import pl.cyfronet.s4e.bean.LicenseGrant;
 
+import java.util.List;
+import java.util.Optional;
+
 @Transactional(readOnly = true)
-public interface LicenseGrantRepository extends CrudRepository<LicenseGrant, Long> {
+public interface LicenseGrantRepository extends JpaRepository<LicenseGrant, Long> {
+    @Query("SELECT lg FROM LicenseGrant lg WHERE lg.id = :id")
+    @EntityGraph(attributePaths = { "institution", "product" })
+    <T> Optional<T> findByIdFetchInstitutionAndProduct(Long id, Class<T> projection);
+
+    Optional<LicenseGrant> findByProductIdAndInstitutionSlug(Long productId, String institutionSlug);
+
+    boolean existsByProductIdAndInstitutionSlug(Long productId, String institutionSlug);
+
+    @Query("SELECT lg FROM LicenseGrant lg")
+    @EntityGraph(attributePaths = { "institution", "product" })
+    <T> List<T> findAllFetchInstitutionAndProduct(Class<T> projection);
+
+    @Query("SELECT lg FROM LicenseGrant lg WHERE lg.product.id = :productId")
+    @EntityGraph(attributePaths = { "institution", "product" })
+    <T> List<T> findAllByProductIdFetchInstitutionAndProduct(Long productId, Class<T> projection);
+
+    @Query("SELECT lg FROM LicenseGrant lg WHERE lg.institution.slug = :institutionSlug")
+    @EntityGraph(attributePaths = { "institution", "product" })
+    <T> List<T> findAllByInstitutionSlugFetchInstitutionAndProduct(String institutionSlug, Class<T> projection);
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/BindingResultException.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/BindingResultException.java
@@ -1,0 +1,7 @@
+package pl.cyfronet.s4e.ex;
+
+import org.springframework.validation.BindingResult;
+
+public interface BindingResultException {
+    BindingResult getBindingResult();
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandler.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandler.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -107,6 +106,11 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorHandlerHelper.toResponseMap(e));
     }
 
+    @ExceptionHandler(LicenseGrantException.class)
+    public ResponseEntity<?> handle(LicenseGrantException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorHandlerHelper.toResponseMap(e));
+    }
+
     @ExceptionHandler(InvitationCreationException.class)
     public ResponseEntity<?> handle(InvitationCreationException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorHandlerHelper.toResponseMap(e));
@@ -119,11 +123,6 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
-        BindingResult bindingResult = e.getBindingResult();
-        if (bindingResult == null) {
-            // no BindingResult, just return an error code 400 without further info
-            return ResponseEntity.badRequest().build();
-        }
         return ResponseEntity.badRequest().body(errorHandlerHelper.toResponseMap(e));
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandlerHelper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/ErrorHandlerHelper.java
@@ -2,6 +2,7 @@ package pl.cyfronet.s4e.ex;
 
 import com.github.mkopylec.recaptcha.validation.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -12,75 +13,63 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import pl.cyfronet.s4e.ex.product.ProductValidationException;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ErrorHandlerHelper {
     private final Environment env;
     private final MessageSource messageSource;
 
     public Map<String, Object> toResponseMap(Exception e) {
-        String message = e.getMessage();
         val map = new LinkedHashMap<String, Object>();
-        map.put("__general__", message);
+        map.put("__general__", e.getMessage());
+        if (e instanceof BindingResultException) {
+            addBindingResultInformation(map, ((BindingResultException) e).getBindingResult());
+        }
         optionallyAddDevelopmentInformation(map, e);
         return map;
     }
 
     public Map<String, Object> toResponseMap(MethodArgumentNotValidException e) {
-        val out = getStringObjectMap(e.getBindingResult());
-        optionallyAddDevelopmentInformation(out, e);
-        return out;
-    }
-
-    public Map<String, Object> toResponseMap(QueryException e) {
-        val out = getStringObjectMap(e.getBindingResult());
-        optionallyAddDevelopmentInformation(out, e);
-        return out;
-    }
-
-    public Map<String, Object> toResponseMap(ProductValidationException e) {
-        val out = getStringObjectMap(e.getBindingResult());
-        optionallyAddDevelopmentInformation(out, e);
-        return out;
+        val map = new LinkedHashMap<String, Object>();
+        addBindingResultInformation(map, e.getBindingResult());
+        optionallyAddDevelopmentInformation(map, e);
+        return map;
     }
 
     public Map<String, Object> toResponseMap(RecaptchaException e) {
-        val errorCodes = e.getErrorCodes();
         val map = new LinkedHashMap<String, Object>();
 
-        map.put("recaptcha", errorCodes.stream()
+        map.put("recaptcha", e.getErrorCodes().stream()
                 .map(ErrorCode::getText)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toUnmodifiableList()));
 
         optionallyAddDevelopmentInformation(map, e);
         return map;
     }
 
-    private LinkedHashMap<String, Object> getStringObjectMap(BindingResult bindingResult) {
-        val map = new LinkedHashMap<String, Object>();
-
+    private void addBindingResultInformation(Map<String, Object> map, BindingResult bindingResult) {
         // populate general errors
         if (bindingResult.hasGlobalErrors()) {
             map.put("__general__", bindingResult.getGlobalErrors().stream()
-                    .map(objectError -> getMessage(objectError))
+                    .map(this::getMessage)
                     .collect(Collectors.toUnmodifiableList()));
         }
 
         // populate field errors
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
             map.putIfAbsent(fieldError.getField(), new ArrayList<>());
-            ((List) map.get(fieldError.getField())).add(
-                    getMessage(fieldError));
+            ((List) map.get(fieldError.getField())).add(getMessage(fieldError));
         }
-
-        return map;
     }
 
     private String getMessage(DefaultMessageSourceResolvable error) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/LicenseGrantException.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/LicenseGrantException.java
@@ -1,0 +1,33 @@
+package pl.cyfronet.s4e.ex;
+
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
+public class LicenseGrantException extends Exception implements BindingResultException {
+    @Getter
+    private final BindingResult bindingResult;
+
+    public LicenseGrantException(BindingResult bindingResult) {
+        this.bindingResult = bindingResult;
+    }
+
+    public LicenseGrantException(String message, BindingResult bindingResult) {
+        super(message);
+        this.bindingResult = bindingResult;
+    }
+
+    public LicenseGrantException(String message, Throwable cause, BindingResult bindingResult) {
+        super(message, cause);
+        this.bindingResult = bindingResult;
+    }
+
+    public LicenseGrantException(Throwable cause, BindingResult bindingResult) {
+        super(cause);
+        this.bindingResult = bindingResult;
+    }
+
+    public LicenseGrantException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, BindingResult bindingResult) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.bindingResult = bindingResult;
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/QueryException.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/QueryException.java
@@ -3,7 +3,7 @@ package pl.cyfronet.s4e.ex;
 import lombok.Getter;
 import org.springframework.validation.BindingResult;
 
-public class QueryException extends Exception {
+public class QueryException extends Exception implements BindingResultException {
     @Getter
     private final BindingResult bindingResult;
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/product/ProductValidationException.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/ex/product/ProductValidationException.java
@@ -2,8 +2,9 @@ package pl.cyfronet.s4e.ex.product;
 
 import lombok.Getter;
 import org.springframework.validation.BindingResult;
+import pl.cyfronet.s4e.ex.BindingResultException;
 
-public class ProductValidationException extends ProductException {
+public class ProductValidationException extends ProductException implements BindingResultException {
     @Getter
     private final BindingResult bindingResult;
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/license/types/PrivateLicense.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/license/types/PrivateLicense.java
@@ -6,19 +6,34 @@ import pl.cyfronet.s4e.security.AppUserDetails;
 
 import static pl.cyfronet.s4e.security.AppUserDetailsUtil.isAdmin;
 import static pl.cyfronet.s4e.security.SecurityConstants.LICENSE_READ_AUTHORITY_PREFIX;
+import static pl.cyfronet.s4e.security.SecurityConstants.LICENSE_WRITE_AUTHORITY_PREFIX;
 
-public class PrivateLicense implements ProductGranularLicense {
+public class PrivateLicense implements WritableLicense {
+    @Override
+    public boolean canWrite(Product product, AppUserDetails userDetails) {
+        if (isAdmin(userDetails)) {
+            return true;
+        }
+
+        return hasWriteLicense(userDetails, product);
+    }
+
     @Override
     public boolean canRead(Product product, AppUserDetails userDetails) {
         if (isAdmin(userDetails)) {
             return true;
         }
 
-        return hasLicense(userDetails, product);
+        return hasReadLicense(userDetails, product);
     }
 
-    private boolean hasLicense(AppUserDetails userDetails, Product product) {
+    private boolean hasReadLicense(AppUserDetails userDetails, Product product) {
         return userDetails != null && userDetails.getAuthorities()
                 .contains(new SimpleGrantedAuthority(LICENSE_READ_AUTHORITY_PREFIX + product.getId().toString()));
+    }
+
+    private boolean hasWriteLicense(AppUserDetails userDetails, Product product) {
+        return userDetails != null && userDetails.getAuthorities()
+                .contains(new SimpleGrantedAuthority(LICENSE_WRITE_AUTHORITY_PREFIX + product.getId().toString()));
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/license/types/WritableLicense.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/license/types/WritableLicense.java
@@ -1,0 +1,17 @@
+package pl.cyfronet.s4e.license.types;
+
+import pl.cyfronet.s4e.bean.Product;
+import pl.cyfronet.s4e.security.AppUserDetails;
+
+public interface WritableLicense extends ProductGranularLicense {
+    /**
+     * Decide whether to allow writing product grants by user.
+     * <p>
+     * No further information fetching should occur in implementations.
+     *
+     * @param product
+     * @param userDetails
+     * @return
+     */
+    boolean canWrite(Product product, AppUserDetails userDetails);
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/security/AppUserDetailsService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/security/AppUserDetailsService.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static pl.cyfronet.s4e.security.SecurityConstants.LICENSE_READ_AUTHORITY_PREFIX;
+import static pl.cyfronet.s4e.security.SecurityConstants.LICENSE_WRITE_AUTHORITY_PREFIX;
 
 @Service("userDetailsService")
 @RequiredArgsConstructor
@@ -61,6 +62,18 @@ public class AppUserDetailsService implements UserDetailsService {
                 .mapToLong(Product::getId)
                 .distinct()
                 .mapToObj(id -> LICENSE_READ_AUTHORITY_PREFIX + id)
+                .forEach(sourceAuthorities::add);
+
+        appUser.getRoles().stream()
+                .filter(userRole -> userRole.getRole() == AppRole.INST_ADMIN)
+                .map(UserRole::getInstitution)
+                .map(Institution::getLicenseGrants)
+                .flatMap(Collection::stream)
+                .filter(LicenseGrant::isOwner)
+                .map(LicenseGrant::getProduct)
+                .mapToLong(Product::getId)
+                .distinct()
+                .mapToObj(id -> LICENSE_WRITE_AUTHORITY_PREFIX + id)
                 .forEach(sourceAuthorities::add);
 
         boolean grantEumetsatLicense = appUser.isEumetsatLicense() || appUser.getRoles().stream()

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/security/SecurityConstants.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/security/SecurityConstants.java
@@ -9,4 +9,5 @@ public class SecurityConstants {
     public static final String JWT_PRIORITY_ACCESS_CLAIM = "priority_access";
 
     public static final String LICENSE_READ_AUTHORITY_PREFIX = "LICENSE_READ_";
+    public static final String LICENSE_WRITE_AUTHORITY_PREFIX = "LICENSE_WRITE_";
 }

--- a/s4e-backend/src/main/resources/db/migration/V59__add_owner_to_license_grant_table.sql
+++ b/s4e-backend/src/main/resources/db/migration/V59__add_owner_to_license_grant_table.sql
@@ -1,0 +1,7 @@
+ALTER TABLE license_grant
+    ADD COLUMN owner BOOLEAN;
+
+UPDATE license_grant SET owner = FALSE;
+
+ALTER TABLE license_grant
+    ALTER COLUMN owner SET NOT NULL;

--- a/s4e-backend/src/main/resources/messages_pl_PL.properties
+++ b/s4e-backend/src/main/resources/messages_pl_PL.properties
@@ -16,6 +16,12 @@ pl.cyfronet.s4e.service.ProductService.granuleArtifactRule.missing-default=Braku
 pl.cyfronet.s4e.service.ProductService.schema.doesnt-exist=Schema z podaną nazwą nie istnieje
 pl.cyfronet.s4e.service.ProductService.schema.incorrect-type=Niepoprawny typ Schemy
 
+pl.cyfronet.s4e.admin.license.LicenseGrantService.institution-not-found=Instytucja nie istnieje
+pl.cyfronet.s4e.admin.license.LicenseGrantService.product-not-found=Produkt nie istnieje
+pl.cyfronet.s4e.admin.license.LicenseGrantService.product-not-private=Produkt musi mieć accessType PRIVATE
+pl.cyfronet.s4e.admin.license.LicenseGrantService.already-exists=LicenseGrant dla produktu i instytucji już istnieje
+pl.cyfronet.s4e.admin.license.LicenseGrantService.cannot-delete-owner=Nie możesz usunąć jeśli owner=true
+
 email.confirm-email.subject=Potwierdzenie adresu email
 email.duplicate-registration.subject=Ponowna rejestracja na twój adres email
 email.account-activated.subject=Konto aktywowane

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantControllerTest.java
@@ -1,0 +1,362 @@
+package pl.cyfronet.s4e.admin.license;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.Constants;
+import pl.cyfronet.s4e.SceneTestHelper;
+import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.bean.Institution;
+import pl.cyfronet.s4e.bean.LicenseGrant;
+import pl.cyfronet.s4e.bean.Product;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+import pl.cyfronet.s4e.data.repository.InstitutionRepository;
+import pl.cyfronet.s4e.data.repository.LicenseGrantRepository;
+import pl.cyfronet.s4e.data.repository.ProductRepository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
+
+@BasicTest
+@AutoConfigureMockMvc
+public class AdminLicenseGrantControllerTest {
+    private static final String URL_PREFIX = Constants.ADMIN_PREFIX + "/license-grants";
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private InstitutionRepository institutionRepository;
+
+    @Autowired
+    private LicenseGrantRepository licenseGrantRepository;
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private AppUser admin;
+
+    private AppUser user;
+    private Product product;
+    private Institution institution;
+
+    @BeforeEach
+    public void beforeEach() {
+        testDbHelper.clean();
+
+        admin = appUserRepository.save(AppUser.builder()
+                .email("admin@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .admin(true)
+                .build());
+
+        user = appUserRepository.save(AppUser.builder()
+                .email("user@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .build());
+
+        product = productRepository.save(SceneTestHelper.productBuilder()
+                .accessType(Product.AccessType.PRIVATE)
+                .build());
+
+        institution = institutionRepository.save(Institution.builder()
+                .name("A")
+                .slug("A")
+                .build());
+    }
+
+    @Nested
+    class Create {
+        private AdminCreateLicenseGrantRequest.AdminCreateLicenseGrantRequestBuilder requestBuilder;
+
+        @BeforeEach
+        public void beforeEach() {
+            requestBuilder = AdminCreateLicenseGrantRequest.builder()
+                .institutionSlug(institution.getSlug())
+                .productId(product.getId());
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = { true, false })
+        public void shouldWork(boolean owner) throws Exception {
+            val createRequest = requestBuilder
+                    .owner(owner)
+                    .build();
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+
+            mockMvc.perform(post(URL_PREFIX)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(admin, objectMapper))
+                    .content(objectMapper.writeValueAsBytes(createRequest)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").isNumber())
+                    .andExpect(jsonPath("$.productId", is(equalTo(product.getId().intValue()))))
+                    .andExpect(jsonPath("$.institutionSlug", is(equalTo(institution.getSlug()))))
+                    .andExpect(jsonPath("$.owner", is(owner)));
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            transactionTemplate.executeWithoutResult((transactionStatus) -> {
+                val newLicenseGrant = licenseGrantRepository.findAll().get(0);
+                assertThat(newLicenseGrant, allOf(
+                        hasProperty("id", notNullValue()),
+                        hasProperty("product", equalTo(product)),
+                        hasProperty("institution", equalTo(institution)),
+                        hasProperty("owner", equalTo(owner))
+                ));
+            });
+        }
+
+        @Test
+        public void shouldBeSecured() throws Exception {
+            val createRequest = requestBuilder.build();
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+
+            mockMvc.perform(post(URL_PREFIX)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(user, objectMapper))
+                    .content(objectMapper.writeValueAsBytes(createRequest)))
+                    .andExpect(status().isForbidden());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+        }
+
+        @Test
+        public void shouldVerifyProductExists() throws Exception {
+            val createRequest = requestBuilder
+                    .productId(product.getId() + 1)
+                    .build();
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+
+            mockMvc.perform(post(URL_PREFIX)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(admin, objectMapper))
+                    .content(objectMapper.writeValueAsBytes(createRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.productId", hasSize(1)));
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "OPEN", "EUMETSAT" })
+        public void shouldVerifyProductHasPrivateAccessType(String accessType) throws Exception {
+            product.setAccessType(Product.AccessType.valueOf(accessType));
+            product = productRepository.save(product);
+
+            val createRequest = requestBuilder.build();
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+
+            mockMvc.perform(post(URL_PREFIX)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(admin, objectMapper))
+                    .content(objectMapper.writeValueAsBytes(createRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.productId[0]", containsString("PRIVATE")));
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+        }
+
+        @Test
+        public void shouldVerifyInstitutionExists() throws Exception {
+            val createRequest = requestBuilder
+                    .institutionSlug("B")
+                    .build();
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+
+            mockMvc.perform(post(URL_PREFIX)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(admin, objectMapper))
+                    .content(objectMapper.writeValueAsBytes(createRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.institutionSlug", hasSize(1)));
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+        }
+    }
+
+    @Nested
+    class ReadAndList {
+        private LicenseGrant licenseGrant;
+
+        @BeforeEach
+        public void beforeEach() {
+            licenseGrant = licenseGrantRepository.save(LicenseGrant.builder()
+                    .product(product)
+                    .institution(institution)
+                    .build());
+        }
+
+        @Test
+        public void shouldList() throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(get(URL_PREFIX)
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(1)));
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+
+        @Test
+        public void shouldRead() throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(get(URL_PREFIX + "/{id}", licenseGrant.getId())
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").isNumber())
+                    .andExpect(jsonPath("$.productId", is(equalTo(product.getId().intValue()))))
+                    .andExpect(jsonPath("$.institutionSlug", is(equalTo(institution.getSlug()))))
+                    .andExpect(jsonPath("$.owner", is(equalTo(false))));
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+
+        @Test
+        public void shouldHandleNotFound() throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(get(URL_PREFIX + "/{id}", licenseGrant.getId() + 1)
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isNotFound());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+    }
+
+    @Nested
+    class Update {
+        private AdminUpdateLicenseGrantRequest.AdminUpdateLicenseGrantRequestBuilder requestBuilder;
+        private LicenseGrant licenseGrant;
+
+        @BeforeEach
+        public void beforeEach() {
+            licenseGrant = licenseGrantRepository.save(LicenseGrant.builder()
+                    .product(product)
+                    .institution(institution)
+                    .build());
+
+            requestBuilder = AdminUpdateLicenseGrantRequest.builder();
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = { true, false })
+        public void shouldWork(boolean owner) throws Exception {
+            val updateRequest = requestBuilder.owner(owner).build();
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(patch(URL_PREFIX + "/{id}", licenseGrant.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(admin, objectMapper))
+                    .content(objectMapper.writeValueAsBytes(updateRequest)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").isNumber())
+                    .andExpect(jsonPath("$.productId", is(equalTo(product.getId().intValue()))))
+                    .andExpect(jsonPath("$.institutionSlug", is(equalTo(institution.getSlug()))))
+                    .andExpect(jsonPath("$.owner", is(owner)));
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            transactionTemplate.executeWithoutResult((transactionStatus) -> {
+                val updatedLicenseGrant = licenseGrantRepository.findAll().get(0);
+                assertThat(updatedLicenseGrant, allOf(
+                        hasProperty("id", notNullValue()),
+                        hasProperty("product", equalTo(product)),
+                        hasProperty("institution", equalTo(institution)),
+                        hasProperty("owner", equalTo(owner))
+                ));
+            });
+        }
+
+        @Test
+        public void shouldBeSecured() throws Exception {
+            val updateRequest = requestBuilder.build();
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(patch(URL_PREFIX + "/{id}", licenseGrant.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(user, objectMapper))
+                    .content(objectMapper.writeValueAsBytes(updateRequest)))
+                    .andExpect(status().isForbidden());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+    }
+
+    @Nested
+    class Delete {
+        private LicenseGrant licenseGrant;
+
+        @BeforeEach
+        public void beforeEach() {
+            licenseGrant = licenseGrantRepository.save(LicenseGrant.builder()
+                    .product(product)
+                    .institution(institution)
+                    .build());
+        }
+
+        @Test
+        public void shouldWork() throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(delete(URL_PREFIX + "/{id}", licenseGrant.getId())
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isNoContent());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(0L)));
+        }
+
+        @Test
+        public void shouldHandleNotFound() throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(delete(URL_PREFIX + "/{id}", licenseGrant.getId() + 1)
+                    .with(jwtBearerToken(admin, objectMapper)))
+                    .andExpect(status().isNotFound());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/LicenseGrantControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/LicenseGrantControllerTest.java
@@ -1,0 +1,440 @@
+package pl.cyfronet.s4e.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.Constants;
+import pl.cyfronet.s4e.SceneTestHelper;
+import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.bean.*;
+import pl.cyfronet.s4e.data.repository.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.ResultMatcher.matchAll;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
+
+@BasicTest
+@AutoConfigureMockMvc
+public class LicenseGrantControllerTest {
+    private static final String URL_PREFIX = Constants.API_PREFIX_V1 + "/license-grants";
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private InstitutionRepository institutionRepository;
+
+    @Autowired
+    private UserRoleRepository userRoleRepository;
+
+    @Autowired
+    private LicenseGrantRepository licenseGrantRepository;
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private Product product1;
+    private Institution instA;
+    private Institution instB;
+
+    @BeforeEach
+    public void beforeEach() {
+        testDbHelper.clean();
+
+        product1 = productRepository.save(SceneTestHelper.productBuilder()
+                .accessType(Product.AccessType.PRIVATE)
+                .build());
+
+        instA = institutionRepository.save(Institution.builder()
+                .name("A")
+                .slug("A")
+                .build());
+
+        instB = institutionRepository.save(Institution.builder()
+                .name("B")
+                .slug("B")
+                .build());
+
+        licenseGrantRepository.save(LicenseGrant.builder()
+                .product(product1)
+                .institution(instA)
+                .owner(true)
+                .build());
+
+        val instAdmin = appUserRepository.save(AppUser.builder()
+                .email("instAdmin@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .build());
+
+        userRoleRepository.save(UserRole.builder()
+                .role(AppRole.INST_MEMBER)
+                .user(instAdmin)
+                .institution(instA)
+                .build());
+        userRoleRepository.save(UserRole.builder()
+                .role(AppRole.INST_ADMIN)
+                .user(instAdmin)
+                .institution(instA)
+                .build());
+
+        val instMember = appUserRepository.save(AppUser.builder()
+                .email("instMember@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .build());
+
+        userRoleRepository.save(UserRole.builder()
+                .role(AppRole.INST_MEMBER)
+                .user(instMember)
+                .institution(instA)
+                .build());
+
+        appUserRepository.save(AppUser.builder()
+                .email("user@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .build());
+
+        appUserRepository.save(AppUser.builder()
+                .email("admin@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .admin(true)
+                .build());
+    }
+
+    private AppUser user(String name) {
+        return appUserRepository.findByEmail(name + "@mail.pl").get();
+    }
+
+    @Nested
+    class ListByInstitution {
+        private static final String URL_TEMPLATE = URL_PREFIX + "/institution/{institutionSlug}";
+        private Product product2;
+
+        @BeforeEach
+        public void beforeEach() {
+            product2 = productRepository.save(SceneTestHelper.productBuilder()
+                    .accessType(Product.AccessType.PRIVATE)
+                    .build());
+
+            licenseGrantRepository.save(LicenseGrant.builder()
+                    .institution(instA)
+                    .product(product2)
+                    .build());
+
+            // This LicenseGrant is meant not to be included in the responses.
+            licenseGrantRepository.save(LicenseGrant.builder()
+                    .institution(instB)
+                    .product(product2)
+                    .build());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "instAdmin", "instMember" })
+        public void shouldAllowForInstA(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "A")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(matchAll(
+                            status().isOk(),
+                            jsonPath("$", hasSize(2)),
+                            jsonPath("$[0].institutionSlug", is(equalTo("A"))),
+                            jsonPath("$[0].productId", is(equalTo(product1.getId().intValue()))),
+                            jsonPath("$[0].owner", is(equalTo(true))),
+                            jsonPath("$[1].institutionSlug", is(equalTo("A"))),
+                            jsonPath("$[1].productId", is(equalTo(product2.getId().intValue()))),
+                            jsonPath("$[1].owner", is(equalTo(false)))
+                    ));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "user" })
+        public void shouldForbidForInstA(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "A")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "instAdmin", "instMember", "user" })
+        public void shouldForbidForInstB(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "B")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "instAdmin", "instMember", "user" })
+        public void shouldReturn403ForNonExistentInstitution(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "doesnt_exist")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin" })
+        public void shouldReturn404ForNonExistentInstitution(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "doesnt_exist")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    class ListByProduct {
+        private static final String URL_TEMPLATE = URL_PREFIX + "/product/{productId}";
+        private Product product2;
+
+        @BeforeEach
+        public void beforeEach() {
+            product2 = productRepository.save(SceneTestHelper.productBuilder()
+                    .accessType(Product.AccessType.PRIVATE)
+                    .build());
+
+            licenseGrantRepository.save(LicenseGrant.builder()
+                    .institution(instB)
+                    .product(product1)
+                    .build());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "instAdmin" })
+        public void shouldAllowForProduct1(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, product1.getId())
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(matchAll(
+                            status().isOk(),
+                            jsonPath("$", hasSize(2)),
+                            jsonPath("$[0].institutionSlug", is(equalTo("A"))),
+                            jsonPath("$[0].productId", is(equalTo(product1.getId().intValue()))),
+                            jsonPath("$[0].owner", is(equalTo(true))),
+                            jsonPath("$[1].institutionSlug", is(equalTo("B"))),
+                            jsonPath("$[1].productId", is(equalTo(product1.getId().intValue()))),
+                            jsonPath("$[1].owner", is(equalTo(false)))
+                    ));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "instMember", "user" })
+        public void shouldForbidForProduct1(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, product1.getId())
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin" })
+        public void shouldAllowForProduct2(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, product2.getId())
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(matchAll(
+                            status().isOk(),
+                            jsonPath("$", hasSize(0))
+                    ));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "instAdmin", "instMember", "user" })
+        public void shouldForbidForProduct2(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, product2.getId())
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "instAdmin", "instMember", "user" })
+        public void shouldReturn403ForNonExistentProduct(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, product2.getId() + 1)
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    class GrantAccess {
+        private static final String URL_TEMPLATE = URL_PREFIX + "/product/{productId}/institution/{institutionSlug}";
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "instAdmin" })
+        public void shouldAllow(String userName) throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(post(URL_TEMPLATE, product1.getId(), "B")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(matchAll(
+                            status().isOk(),
+                            jsonPath("$.institutionSlug", is(equalTo("B"))),
+                            jsonPath("$.productId", is(equalTo(product1.getId().intValue()))),
+                            jsonPath("$.owner", is(equalTo(false)))
+                    ));
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(2L)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "instMember", "user" })
+        public void shouldForbid(String userName) throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(post(URL_TEMPLATE, product1.getId(), "B")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "instAdmin" })
+        public void shouldRequireValidInstitutionSlug(String userName) throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(post(URL_TEMPLATE, product1.getId(), "C")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isBadRequest());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+
+        @Nested
+        class WithPreexistingGrant {
+            @BeforeEach
+            public void beforeEach() {
+                licenseGrantRepository.save(LicenseGrant.builder()
+                        .institution(instB)
+                        .product(product1)
+                        .build());
+            }
+
+            @ParameterizedTest
+            @CsvSource({
+                    "admin,A",
+                    "admin,B",
+                    "instAdmin,A",
+                    "instAdmin,B"
+            })
+            public void shouldRequireNoPreexistingGrant(String userName, String institutionSlug) throws Exception {
+                assertThat(licenseGrantRepository.count(), is(equalTo(2L)));
+
+                mockMvc.perform(post(URL_TEMPLATE, product1.getId(), institutionSlug)
+                        .with(jwtBearerToken(user(userName), objectMapper)))
+                        .andExpect(status().isBadRequest());
+
+                assertThat(licenseGrantRepository.count(), is(equalTo(2L)));
+            }
+        }
+    }
+
+    @Nested
+    class DenyAccess {
+        private static final String URL_TEMPLATE = URL_PREFIX + "/product/{productId}/institution/{institutionSlug}";
+        private Product product2;
+
+        @BeforeEach
+        public void beforeEach() {
+            product2 = productRepository.save(SceneTestHelper.productBuilder()
+                    .accessType(Product.AccessType.PRIVATE)
+                    .build());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "instAdmin" })
+        public void shouldForbidToDeleteOwnerGrant(String userName) throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(delete(URL_TEMPLATE, product1.getId(), "A")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isBadRequest());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "instMember", "user" })
+        public void shouldForbidForProduct1(String userName) throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(delete(URL_TEMPLATE, product1.getId(), "A")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "instAdmin", "instMember", "user" })
+        public void shouldForbidForProduct2(String userName) throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(delete(URL_TEMPLATE, product2.getId(), "A")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "instAdmin" })
+        public void shouldRequireExistingInstitutionSlug(String userName) throws Exception {
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+
+            mockMvc.perform(delete(URL_TEMPLATE, product1.getId(), "B")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isNotFound());
+
+            assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+        }
+
+        @Nested
+        class WithPreexistingGrant {
+            @BeforeEach
+            public void beforeEach() {
+                licenseGrantRepository.save(LicenseGrant.builder()
+                        .institution(instB)
+                        .product(product1)
+                        .build());
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = { "admin", "instAdmin" })
+            public void shouldAllowForProduct1(String userName) throws Exception {
+                assertThat(licenseGrantRepository.count(), is(equalTo(2L)));
+
+                mockMvc.perform(delete(URL_TEMPLATE, product1.getId(), "B")
+                        .with(jwtBearerToken(user(userName), objectMapper)))
+                        .andExpect(status().isNoContent());
+
+                assertThat(licenseGrantRepository.count(), is(equalTo(1L)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add endpoints for management of LicenseGrants, so that admin can manage
the grants from admin API and institution admin can manage read access
only.

Improve handling of BindingResult errors - introduce a single interface
which differentiates exceptions with such information.

Add WritableLicense interface, which is meant to be implemented by
licenses which can be managed using grants.

Closes: #773.