### PR TITLE
[#919] Add authority allowing to delete managed Institutions

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/AppUser.java
@@ -9,11 +9,13 @@ import javax.validation.constraints.NotEmpty;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * If you delete user, you will also delete password_reset and email_verification entries
  */
 @Entity
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -55,9 +57,24 @@ public class AppUser extends CreationAndModificationAudited {
 
     private boolean enabled;
 
-    private boolean admin;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Column(name = "authority")
+    @Singular
+    private Set<String> authorities;
 
-    private boolean eumetsatLicense;
+    public boolean addAuthority(String authority) {
+        val mutableAuthorities = new HashSet<>(authorities);
+        val out = mutableAuthorities.add(authority);
+        authorities = mutableAuthorities.stream().collect(Collectors.toUnmodifiableSet());
+        return out;
+    }
+
+    public boolean removeAuthority(String authority) {
+        val mutableAuthorities = new HashSet<>(authorities);
+        val out = mutableAuthorities.remove(authority);
+        authorities = mutableAuthorities.stream().collect(Collectors.toUnmodifiableSet());
+        return out;
+    }
 
     @Enumerated(EnumType.STRING)
     private ScientificDomain domain;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
@@ -66,6 +66,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 )).permitAll()
 
                 .mvcMatchers(GET, prefix("/users/me")).authenticated()
+                .mvcMatchers(prefix("/users/authority/{authority}"))
+                    .access("hasRole('ADMIN') || hasAuthority('OP_GRANT_' + #authority)")
+
                 .mvcMatchers(POST, prefix(
                         "/register",
                         "/resend-registration-token-by-email",
@@ -99,7 +102,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .mvcMatchers(GET, prefix("/institutions/{institution}"))
                     .access("hasRole('ADMIN') || @ish.isMember(#institution)")
                 .mvcMatchers(DELETE, prefix("/institutions/{institution}"))
-                    .access("hasRole('ADMIN')")
+                    .access("hasRole('ADMIN') || (hasAuthority('OP_INSTITUTION_DELETE') && @ish.isAdmin(#institution))")
                 .mvcMatchers(prefix("/institutions/{institution}", "/institutions/{institution}/**"))
                     .access("hasRole('ADMIN') || @ish.isAdmin(#institution)")
                 .mvcMatchers(GET, prefix("/institutions")).authenticated()

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/AppUserController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/AppUserController.java
@@ -18,7 +18,6 @@ import lombok.val;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.web.bind.annotation.*;
-import pl.cyfronet.s4e.bean.AppUser;
 import pl.cyfronet.s4e.controller.request.RegisterRequest;
 import pl.cyfronet.s4e.controller.response.UserMeResponse;
 import pl.cyfronet.s4e.controller.response.UserRoleResponse;
@@ -135,6 +134,8 @@ public class AppUserController {
     }
 
     public interface UserMeProjection {
+        Long getId();
+
         String getEmail();
 
         String getName();
@@ -142,6 +143,8 @@ public class AppUserController {
         boolean getAdmin();
 
         String getSurname();
+
+        List<String> getAuthorities();
 
         Set<UserRoleResponse> getRoles();
 
@@ -164,7 +167,7 @@ public class AppUserController {
         AppUserDetails appUserDetails = AppUserDetailsSupplier.get();
         val projection = appUserService.findByEmailWithRolesAndGroupsAndInstitution(appUserDetails.getUsername(), UserMeProjection.class)
                 .orElseThrow(() -> new NotFoundException("User not found for email: '" + appUserDetails.getUsername() + "'"));
-        return appUserMapper.projectionToMeResponse(projection);
+        return appUserMapper.projectionToMeResponse(projection, appUserDetails);
     }
 
     private void validateRecaptcha(HttpServletRequest request) throws RecaptchaException {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/UserAuthorityController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/UserAuthorityController.java
@@ -1,0 +1,77 @@
+package pl.cyfronet.s4e.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+import pl.cyfronet.s4e.controller.request.UserAuthorityRequest;
+import pl.cyfronet.s4e.controller.response.UserAuthorityResponse;
+import pl.cyfronet.s4e.ex.NotFoundException;
+import pl.cyfronet.s4e.service.UserAuthorityService;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+
+@Slf4j
+@RestController
+@RequestMapping(path = API_PREFIX_V1, produces = APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Tag(name = "user-authority", description = "The UserAuthority API")
+public class UserAuthorityController {
+    private final UserAuthorityService userAuthorityService;
+
+    @Operation(summary = "Get users with authority")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Returns user with authority"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated"),
+            @ApiResponse(responseCode = "403", description = "Forbidden")
+    })
+    @GetMapping("/users/authority/{authority}")
+    public List<UserAuthorityResponse> getUsersWithAuthority(@PathVariable String authority) {
+        return userAuthorityService.findAllUsersByAuthority(authority, UserAuthorityResponse.class);
+    }
+
+    @Operation(summary = "Add authority to user")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Added authority to user"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "User doesn't exist")
+    })
+    @Transactional(rollbackFor = NotFoundException.class)
+    @PutMapping("/users/authority/{authority}")
+    @Consumes(APPLICATION_JSON_VALUE)
+    public void addAuthority(
+            @PathVariable String authority,
+            @RequestBody @Valid UserAuthorityRequest request
+    ) throws NotFoundException {
+        userAuthorityService.addAuthority(request.getEmail(), authority)
+                .orElseThrow(NotFoundException::new);
+    }
+
+    @Operation(summary = "Remove authority from user")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Removed authority from user"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "User doesn't exist")
+    })
+    @Transactional(rollbackFor = NotFoundException.class)
+    @DeleteMapping("/users/authority/{authority}")
+    @Consumes(APPLICATION_JSON_VALUE)
+    public void removeAuthority(
+            @PathVariable String authority,
+            @RequestBody @Valid UserAuthorityRequest request
+    ) throws NotFoundException {
+        userAuthorityService.removeAuthority(request.getEmail(), authority)
+                .orElseThrow(NotFoundException::new);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/UserAuthorityRequest.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/request/UserAuthorityRequest.java
@@ -1,0 +1,17 @@
+package pl.cyfronet.s4e.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAuthorityRequest {
+    @NotEmpty
+    @Email
+    private String email;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/UserAuthorityResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/UserAuthorityResponse.java
@@ -1,0 +1,5 @@
+package pl.cyfronet.s4e.controller.response;
+
+public interface UserAuthorityResponse {
+    String getEmail();
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/UserMeResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/UserMeResponse.java
@@ -8,12 +8,14 @@ import java.util.Set;
 @Getter
 @Setter
 public class UserMeResponse {
+    Long id;
     String email;
     String name;
     String surname;
 
     boolean admin;
     boolean memberZK;
+    Set<String> authorities;
 
     Set<UserRoleResponse> roles;
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/AppUserRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/AppUserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.transaction.annotation.Transactional;
 import pl.cyfronet.s4e.bean.AppUser;
 
+import java.util.List;
 import java.util.Optional;
 
 @Transactional(readOnly = true)
@@ -33,6 +34,12 @@ public interface AppUserRepository extends CrudRepository<AppUser, Long> {
             "LEFT JOIN FETCH r.institution i " +
             "WHERE u.email = :email")
     <T> Optional<T> findByEmailWithRolesAndInstitution(String email, Class<T> projection);
+
+    @Query("SELECT u " +
+            "FROM AppUser u " +
+            "LEFT JOIN u.authorities ua " +
+            "WHERE ua = :authority")
+    <T> List<T> findAllByAuthority(String authority, Class<T> projection);
 
     boolean existsByEmail(String email);
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
@@ -121,7 +121,7 @@ public class SeedUsers implements ApplicationRunner {
                         .surname("Surname7")
                         .password(passwordEncoder.encode("adminPass20"))
                         .enabled(true)
-                        .admin(true)
+                        .authority("ROLE_ADMIN")
                         .domain(nextDomain())
                         .usage(nextUsage())
                         .country(nextCountry())

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/security/AppUserDetailsService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/security/AppUserDetailsService.java
@@ -48,7 +48,7 @@ public class AppUserDetailsService implements UserDetailsService {
     }
 
     private Set<SimpleGrantedAuthority> getAuthorities(AppUser appUser) {
-        val sourceAuthorities = new HashSet<String>();
+        val sourceAuthorities = new HashSet<>(appUser.getAuthorities());
 
         appUser.getRoles().stream()
                 .map(this::toRole)
@@ -76,16 +76,12 @@ public class AppUserDetailsService implements UserDetailsService {
                 .mapToObj(id -> LICENSE_WRITE_AUTHORITY_PREFIX + id)
                 .forEach(sourceAuthorities::add);
 
-        boolean grantEumetsatLicense = appUser.isEumetsatLicense() || appUser.getRoles().stream()
-                        .map(UserRole::getInstitution)
-                        .anyMatch(Institution::isEumetsatLicense);
+        boolean grantEumetsatLicense = appUser.getRoles().stream()
+                .map(UserRole::getInstitution)
+                .anyMatch(Institution::isEumetsatLicense);
 
         if (grantEumetsatLicense) {
             sourceAuthorities.add("LICENSE_EUMETSAT");
-        }
-
-        if (appUser.isAdmin()) {
-            sourceAuthorities.add("ROLE_ADMIN");
         }
 
         if (appUser.getRoles().stream().map(UserRole::getInstitution).anyMatch(Institution::isZk)) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/UserAuthorityService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/UserAuthorityService.java
@@ -1,0 +1,33 @@
+package pl.cyfronet.s4e.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserAuthorityService {
+    private final AppUserRepository appUserRepository;
+
+    public <T> List<T> findAllUsersByAuthority(String authority, Class<T> projection) {
+        return appUserRepository.findAllByAuthority(authority, projection);
+    }
+
+    @Transactional
+    public Optional<Boolean> addAuthority(String email, String authority) {
+        return appUserRepository.findByEmail(email)
+                .map(appUser -> appUser.addAuthority(authority));
+    }
+
+    @Transactional
+    public Optional<Boolean> removeAuthority(String email, String authority) {
+        return appUserRepository.findByEmail(email)
+                .map(appUser -> appUser.removeAuthority(authority));
+    }
+}

--- a/s4e-backend/src/main/resources/db/migration/V61__add_authorities_to_app_user_table.sql
+++ b/s4e-backend/src/main/resources/db/migration/V61__add_authorities_to_app_user_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE app_user_authorities (
+    app_user_id BIGINT NOT NULL,
+    authority VARCHAR NOT NULL,
+    UNIQUE(app_user_id, authority)
+);
+
+INSERT INTO app_user_authorities (app_user_id, authority)
+    SELECT au.id as app_user_id, 'ROLE_ADMIN' as authority
+        FROM app_user au
+        WHERE admin;
+
+INSERT INTO app_user_authorities (app_user_id, authority)
+    SELECT au.id as app_user_id, 'LICENSE_EUMETSAT' as authority
+        FROM app_user au
+        WHERE eumetsat_license;
+
+ALTER TABLE app_user
+    DROP COLUMN admin,
+    DROP COLUMN eumetsat_license;
+

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/InvitationHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/InvitationHelper.java
@@ -35,7 +35,6 @@ public class InvitationHelper {
                 .name(name)
                 .surname(name)
                 .password(password)
-                .admin(false)
                 .enabled(true);
     }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SecurityTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SecurityTest.java
@@ -91,7 +91,7 @@ public class SecurityTest {
     // 404
     @Test
     public void shouldReturn404ForAuthenticatedAndAuthorizedUserNoResource() throws Exception {
-        securityAppUser.setAdmin(true);
+        securityAppUser.addAuthority("ROLE_ADMIN");
         appUserRepository.save(securityAppUser);
         DeleteUserRoleRequest userRoleRequest = DeleteUserRoleRequest.builder()
                 .email("profile@email")

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/TestJwtUtil.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/TestJwtUtil.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.jackson.io.JacksonSerializer;
-import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -17,7 +16,6 @@ import pl.cyfronet.s4e.security.SecurityConstants;
 import javax.servlet.http.Cookie;
 import java.security.KeyPair;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.stream.Collectors;
 
 import static pl.cyfronet.s4e.security.SecurityConstants.JWT_AUTHORITIES_CLAIM;
@@ -64,15 +62,13 @@ public class TestJwtUtil {
     }
 
     private static AppUserDetails createAppUserDetails(AppUser user) {
-        val authorities = new HashSet<SimpleGrantedAuthority>();
-        if (user.isAdmin()) {
-            authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
-        }
         return new AppUserDetails(
                 user.getEmail(),
                 user.getName(),
                 user.getSurname(),
-                authorities,
+                user.getAuthorities().stream()
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
                 user.getPassword(),
                 user.isEnabled());
     }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/category/AdminProductCategoryControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/category/AdminProductCategoryControllerTest.java
@@ -55,7 +55,7 @@ public class AdminProductCategoryControllerTest {
                 .surname("Smith")
                 .password("{noop}password")
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
 
         user = appUserRepository.save(AppUser.builder()

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/geoserver/AdminGeoserverControllerIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/geoserver/AdminGeoserverControllerIntegrationTest.java
@@ -29,7 +29,7 @@ import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
 @IntegrationTest
 @AutoConfigureMockMvc
 class AdminGeoserverControllerIntegrationTest {
-    private Faker faker = new Faker();
+    private final Faker faker = new Faker();
 
     @Autowired
     private GeoServerOperations geoServerOperations;
@@ -76,7 +76,7 @@ class AdminGeoserverControllerIntegrationTest {
                 .surname(faker.name().lastName())
                 .password("{noop}" + faker.internet().password())
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
 
         for (String workspace : geoServerOperations.listWorkspaces()) {

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/institution/AdminInstitutionControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/institution/AdminInstitutionControllerTest.java
@@ -68,7 +68,7 @@ class AdminInstitutionControllerTest {
                     .surname("Smith")
                     .password("{noop}password")
                     .enabled(true)
-                    .admin(true)
+                    .authority("ROLE_ADMIN")
                     .build());
 
             user = appUserRepository.save(AppUser.builder()

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/license/AdminLicenseGrantControllerTest.java
@@ -77,7 +77,7 @@ public class AdminLicenseGrantControllerTest {
                 .surname("Smith")
                 .password("{noop}password")
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
 
         user = appUserRepository.save(AppUser.builder()

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/product/AdminProductControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/product/AdminProductControllerTest.java
@@ -69,7 +69,7 @@ public class AdminProductControllerTest {
                 .surname("Smith")
                 .password("{noop}password")
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
 
         user = appUserRepository.save(AppUser.builder()

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/property/AdminPropertyControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/property/AdminPropertyControllerTest.java
@@ -59,7 +59,7 @@ class AdminPropertyControllerTest {
                 .surname("Smith")
                 .password("{noop}password")
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
 
         user = appUserRepository.save(AppUser.builder()
@@ -72,7 +72,7 @@ class AdminPropertyControllerTest {
     }
 
     @Nested
-    public class Put {
+    public class PutEndpoint {
         private final String URL = Constants.ADMIN_PREFIX + "/properties/{name}";
 
         @Test
@@ -132,7 +132,7 @@ class AdminPropertyControllerTest {
     }
 
     @Nested
-    class List {
+    class ListEndpoint {
         private final String URL = Constants.ADMIN_PREFIX + "/properties";
 
         @BeforeEach
@@ -170,7 +170,7 @@ class AdminPropertyControllerTest {
     }
 
     @Nested
-    class Delete {
+    class DeleteEndpoint {
         private static final String URL = Constants.ADMIN_PREFIX + "/properties/{name}";
 
         @BeforeEach

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/scene/AdminSceneControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/scene/AdminSceneControllerTest.java
@@ -75,7 +75,7 @@ public class AdminSceneControllerTest {
                 .surname("Smith")
                 .password("{noop}password")
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
 
         SchemaTestHelper.SCENE_AND_METADATA_SCHEMA_NAMES.stream()

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/schema/AdminSchemaControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/schema/AdminSchemaControllerTest.java
@@ -35,7 +35,7 @@ public class AdminSchemaControllerTest {
     private static final String S1_SCENE_SCHEMA_PATH = "classpath:schema/Sentinel-1.scene.v1.json";
     private static final String S2_SCENE_SCHEMA_PATH = "classpath:schema/Sentinel-2.scene.v1.json";
 
-    private Faker faker = new Faker();
+    private final Faker faker = new Faker();
 
     @Autowired
     private AppUserRepository appUserRepository;
@@ -73,7 +73,7 @@ public class AdminSchemaControllerTest {
                 .surname(faker.name().lastName())
                 .password("{noop}" + faker.internet().password())
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
     }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/api/AdminSyncJobControllerIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/admin/sync/api/AdminSyncJobControllerIntegrationTest.java
@@ -35,7 +35,7 @@ import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
 })
 @Slf4j
 public class AdminSyncJobControllerIntegrationTest {
-    private Faker faker = new Faker();
+    private final Faker faker = new Faker();
 
     @Autowired
     private AppUserRepository appUserRepository;
@@ -73,7 +73,7 @@ public class AdminSyncJobControllerIntegrationTest {
                 .surname(faker.name().lastName())
                 .password("{noop}" + faker.internet().password())
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
     }
 
@@ -128,7 +128,7 @@ public class AdminSyncJobControllerIntegrationTest {
     @Order(5)
     public void showJob() throws Exception {
         SyncJob syncJob = syncJobStore.find("test-1").get();
-        await().until(() -> syncJob.getState(), is(equalTo(SyncJob.State.FINISHED)));
+        await().until(syncJob::getState, is(equalTo(SyncJob.State.FINISHED)));
 
         mockMvc.perform(get(ADMIN_PREFIX + "/sync-jobs/{name}", "test-1")
                 .with(jwtBearerToken(admin, objectMapper)))

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/InstitutionControllerIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/InstitutionControllerIntegrationTest.java
@@ -24,7 +24,6 @@ import pl.cyfronet.s4e.data.repository.InstitutionRepository;
 import pl.cyfronet.s4e.data.repository.UserRoleRepository;
 import pl.cyfronet.s4e.properties.FileStorageProperties;
 import pl.cyfronet.s4e.service.SlugService;
-import pl.cyfronet.s4e.service.UserRoleService;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -55,9 +54,6 @@ public class InstitutionControllerIntegrationTest {
     private UserRoleRepository userRoleRepository;
 
     @Autowired
-    private UserRoleService userRoleService;
-
-    @Autowired
     private ObjectMapper objectMapper;
 
     @Autowired
@@ -80,7 +76,7 @@ public class InstitutionControllerIntegrationTest {
 
     private AppUser appUser;
     private String parentSlug;
-    private String testInstitution = "Test Institution - ZKPL";
+    private final String testInstitution = "Test Institution - ZKPL";
 
     @BeforeEach
     public void beforeEach() {
@@ -91,7 +87,7 @@ public class InstitutionControllerIntegrationTest {
                 .name("Get")
                 .surname("Profile")
                 .password("{noop}password")
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .enabled(true)
                 .build());
         //1st lvl institution

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/LicenseGrantControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/LicenseGrantControllerTest.java
@@ -129,7 +129,7 @@ public class LicenseGrantControllerTest {
                 .surname("Smith")
                 .password("{noop}password")
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
     }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/OverlayControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/OverlayControllerTest.java
@@ -72,7 +72,7 @@ public class OverlayControllerTest {
     public void beforeEach() {
         testDbHelper.clean();
 
-        superAdmin = appUserRepository.save(InvitationHelper.userBuilder().admin(true).build());
+        superAdmin = appUserRepository.save(InvitationHelper.userBuilder().authority("ROLE_ADMIN").build());
 
         institution = institutionRepository.save(InvitationHelper.institutionBuilder().build());
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ProductControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ProductControllerTest.java
@@ -206,7 +206,7 @@ public class ProductControllerTest {
         class ByAdmin {
             @BeforeEach
             public void beforeEach() {
-                appUser.setAdmin(true);
+                appUser.addAuthority("ROLE_ADMIN");
                 appUserRepository.save(appUser);
             }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SceneControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SceneControllerTest.java
@@ -336,7 +336,7 @@ public class SceneControllerTest {
                         .surname("Profile")
                         .password("{noop}password")
                         .enabled(true)
-                        .eumetsatLicense(true)
+                        .authority("LICENSE_EUMETSAT")
                         .build());
 
                 product1.setAccessType(Product.AccessType.EUMETSAT);

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/UserAuthorityControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/UserAuthorityControllerTest.java
@@ -1,0 +1,246 @@
+package pl.cyfronet.s4e.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.controller.request.UserAuthorityRequest;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.ResultMatcher.matchAll;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
+
+@BasicTest
+@AutoConfigureMockMvc
+class UserAuthorityControllerTest {
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    @BeforeEach
+    public void beforeEach() {
+        testDbHelper.clean();
+
+        appUserRepository.save(AppUser.builder()
+                .email("admin@mail.pl")
+                .name("Name")
+                .surname("Surname")
+                .password("{noop}password")
+                .enabled(true)
+                .authority("ROLE_ADMIN")
+                .build());
+
+        appUserRepository.save(AppUser.builder()
+                .email("granter_A@mail.pl")
+                .name("Name")
+                .surname("Surname")
+                .password("{noop}password")
+                .enabled(true)
+                .authority("OP_GRANT_A")
+                .build());
+
+        appUserRepository.save(AppUser.builder()
+                .email("granter_B@mail.pl")
+                .name("Name")
+                .surname("Surname")
+                .password("{noop}password")
+                .enabled(true)
+                .authority("OP_GRANT_B")
+                .build());
+
+        appUserRepository.save(AppUser.builder()
+                .email("authority_A@mail.pl")
+                .name("Name")
+                .surname("Surname")
+                .password("{noop}password")
+                .enabled(true)
+                .authority("A")
+                .build());
+
+        appUserRepository.save(AppUser.builder()
+                .email("authority_B@mail.pl")
+                .name("Name")
+                .surname("Surname")
+                .password("{noop}password")
+                .enabled(true)
+                .authority("B")
+                .build());
+
+        appUserRepository.save(AppUser.builder()
+                .email("user@mail.pl")
+                .name("Name")
+                .surname("Surname")
+                .password("{noop}password")
+                .enabled(true)
+                .build());
+    }
+
+    private AppUser user(String name) {
+        return appUserRepository.findByEmail(name + "@mail.pl").get();
+    }
+
+    @Nested
+    class ListEndpoint {
+        private static final String URL_TEMPLATE = API_PREFIX_V1 + "/users/authority/{authority}";
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "granter_A" })
+        public void shouldAllowForAuthA(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "A")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(matchAll(
+                            status().isOk(),
+                            jsonPath("$", hasSize(1)),
+                            jsonPath("$[0].email", is(equalTo("authority_A@mail.pl")))
+                    ));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "granter_B", "authority_A", "authority_B", "user" })
+        public void shouldForbidForAuthA(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "A")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin" })
+        public void shouldAllowForAuthOther(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "OTHER")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(matchAll(
+                            status().isOk(),
+                            jsonPath("$", hasSize(0))
+                    ));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "granter_A", "granter_B", "authority_A", "authority_B", "user" })
+        public void shouldForbidForAuthOther(String userName) throws Exception {
+            mockMvc.perform(get(URL_TEMPLATE, "OTHER")
+                    .with(jwtBearerToken(user(userName), objectMapper)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    class AddEndpoint {
+        private static final String URL_TEMPLATE = API_PREFIX_V1 + "/users/authority/{authority}";
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "granter_A" })
+        public void shouldAllowForAuthA(String userName) throws Exception {
+            UserAuthorityRequest request = new UserAuthorityRequest("authority_B@mail.pl");
+
+            assertThat(user("authority_B").getAuthorities(), containsInAnyOrder("B"));
+
+            mockMvc.perform(put(URL_TEMPLATE, "A")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(user(userName), objectMapper))
+                    .content(objectMapper.writeValueAsBytes(request)))
+                    .andExpect(status().isOk());
+
+            assertThat(user("authority_B").getAuthorities(), containsInAnyOrder("A", "B"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "granter_B", "authority_A", "authority_B", "user" })
+        public void shouldForbidForAuthA(String userName) throws Exception {
+            UserAuthorityRequest request = new UserAuthorityRequest("authority_B@mail.pl");
+
+            assertThat(user("authority_B").getAuthorities(), containsInAnyOrder("B"));
+
+            mockMvc.perform(put(URL_TEMPLATE, "A")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(user(userName), objectMapper))
+                    .content(objectMapper.writeValueAsBytes(request)))
+                    .andExpect(status().isForbidden());
+
+            assertThat(user("authority_B").getAuthorities(), containsInAnyOrder("B"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "granter_A" })
+        public void shouldReturn404ForNonExistingUser(String userName) throws Exception {
+            UserAuthorityRequest request = new UserAuthorityRequest("doesntExist@mail.pl");
+
+            mockMvc.perform(put(URL_TEMPLATE, "A")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(user(userName), objectMapper))
+                    .content(objectMapper.writeValueAsBytes(request)))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    class RemoveEndpoint {
+        private static final String URL_TEMPLATE = API_PREFIX_V1 + "/users/authority/{authority}";
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "granter_A" })
+        public void shouldAllowForAuthA(String userName) throws Exception {
+            UserAuthorityRequest request = new UserAuthorityRequest("authority_A@mail.pl");
+
+            assertThat(user("authority_A").getAuthorities(), containsInAnyOrder("A"));
+
+            mockMvc.perform(delete(URL_TEMPLATE, "A")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(user(userName), objectMapper))
+                    .content(objectMapper.writeValueAsBytes(request)))
+                    .andExpect(status().isOk());
+
+            assertThat(user("authority_A").getAuthorities(), hasSize(0));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "granter_B", "authority_A", "authority_B", "user" })
+        public void shouldForbidForAuthA(String userName) throws Exception {
+            UserAuthorityRequest request = new UserAuthorityRequest("authority_A@mail.pl");
+
+            assertThat(user("authority_A").getAuthorities(), containsInAnyOrder("A"));
+
+            mockMvc.perform(delete(URL_TEMPLATE, "A")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(user(userName), objectMapper))
+                    .content(objectMapper.writeValueAsBytes(request)))
+                    .andExpect(status().isForbidden());
+
+            assertThat(user("authority_A").getAuthorities(), containsInAnyOrder("A"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "admin", "granter_A" })
+        public void shouldReturn404ForNonExistingUser(String userName) throws Exception {
+            UserAuthorityRequest request = new UserAuthorityRequest("doesntExist@mail.pl");
+
+            mockMvc.perform(delete(URL_TEMPLATE, "A")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(jwtBearerToken(user(userName), objectMapper))
+                    .content(objectMapper.writeValueAsBytes(request)))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/UserRoleControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/UserRoleControllerTest.java
@@ -18,7 +18,6 @@ import pl.cyfronet.s4e.controller.request.CreateUserRoleRequest;
 import pl.cyfronet.s4e.controller.request.DeleteUserRoleRequest;
 import pl.cyfronet.s4e.data.repository.AppUserRepository;
 import pl.cyfronet.s4e.data.repository.InstitutionRepository;
-import pl.cyfronet.s4e.data.repository.UserRoleRepository;
 import pl.cyfronet.s4e.service.SlugService;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -37,9 +36,6 @@ public class UserRoleControllerTest {
 
     @Autowired
     private AppUserRepository appUserRepository;
-
-    @Autowired
-    private UserRoleRepository userRoleRepository;
 
     @Autowired
     private InstitutionRepository institutionRepository;
@@ -67,12 +63,12 @@ public class UserRoleControllerTest {
                 .surname("Profile")
                 .password("{noop}password")
                 .enabled(true)
-                .admin(true)
+                .authority("ROLE_ADMIN")
                 .build());
 
         String test_institution = "Test Institution";
         slugInstitution = slugService.slugify(test_institution);
-        Institution institution = institutionRepository.save(Institution.builder()
+        institutionRepository.save(Institution.builder()
                 .name(test_institution)
                 .slug(slugInstitution)
                 .build());


### PR DESCRIPTION
Add endpoints to grant authorities.

Move authorities such as admin or eumetsat_license to
AppUser.authorities, so that they are settable dynamically.

Closes: #919.