### PR TITLE
[#928] Handle anonymous user trying to download files

### DIFF
--- a/s4e-web/src/app/utils/error-interceptor/error.interceptor.ts
+++ b/s4e-web/src/app/utils/error-interceptor/error.interceptor.ts
@@ -14,6 +14,7 @@ import {
 } from '../../errors/errors.model';
 import {HttpErrorHelper} from './error.helper';
 import {NotificationService} from 'notifications';
+import {BACK_LINK_QUERY_PARAM} from '../../state/session/session.service';
 
 
 @Injectable({
@@ -64,7 +65,7 @@ export class ErrorInterceptor implements HttpInterceptor {
           type: 'error',
           content: 'Wystąpił błąd: Nie jesteś zalogowany lub twoja sesja się przedawniła'
         });
-        this._router.navigate(['login'], {queryParams: {back_link: this._backLink}});
+        this._router.navigate(['login'], {queryParams: {[BACK_LINK_QUERY_PARAM]: this._backLink}});
         break;
       case HTTP_101_TIMEOUT:
       case HTTP_404_BAD_REQUEST:
@@ -78,7 +79,7 @@ export class ErrorInterceptor implements HttpInterceptor {
         break;
       case HTTP_502_BAD_GATEWAY:
       case HTTP_500_INTERNAL_SERVER_ERROR:
-        this._router.navigate(['errors', error.status], {queryParams: {back_link: this._backLink}});
+        this._router.navigate(['errors', error.status], {queryParams: {[BACK_LINK_QUERY_PARAM]: this._backLink}});
         break;
       default:
         this._notificationService.addGeneral({

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.html
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.html
@@ -28,7 +28,7 @@
   </div>
   <div class="s4e-modal-footer">
     <button class="button button--cancel button--small" type="button" (click)="dismiss()" i18n>Zamknij</button>
-    <a [attr.href]="(searchResult$ | async)?.url" target="_blank" (click)="dismiss()"
+    <a [attr.href]="(searchResult$ | async)?.url" target="_blank" (click)="interceptDownload($event)"
        class="button button--secondary button--small" type="button" i18n>Pobierz Plik</a>
   </div>
 </s4e-generic-modal>

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.ts
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.ts
@@ -6,8 +6,7 @@ import {Observable} from 'rxjs';
 import {SentinelSearchResult} from '../../state/sentinel-search/sentinel-search.model';
 import {SentinelSearchQuery} from '../../state/sentinel-search/sentinel-search.query';
 import {SentinelSearchService} from '../../state/sentinel-search/sentinel-search.service';
-import { SentinelSearchStore } from '../../state/sentinel-search/sentinel-search.store';
-import { ActivatedQueue } from 'src/app/utils/search/activated-queue.utils';
+import {SessionQuery} from '../../../../state/session/session.query';
 
 @Component({
   selector: 's4e-search-result-modal',
@@ -22,7 +21,8 @@ export class SearchResultModalComponent extends ModalComponent implements OnInit
   constructor(
     modalService: ModalService,
     private _sentinelSearchService: SentinelSearchService,
-    private _sentinelSearchQuery: SentinelSearchQuery
+    private _sentinelSearchQuery: SentinelSearchQuery,
+    private _sessionQuery: SessionQuery
   ) {
     super(modalService, SENTINEL_SEARCH_RESULT_MODAL_ID);
   }
@@ -33,10 +33,6 @@ export class SearchResultModalComponent extends ModalComponent implements OnInit
     this.isLast$ = this._sentinelSearchQuery.selectIsActiveLast();
   }
 
-  download() {
-
-  }
-
   previousResult() {
     this._sentinelSearchService.previousActive();
   }
@@ -45,5 +41,14 @@ export class SearchResultModalComponent extends ModalComponent implements OnInit
     this._sentinelSearchService.nextActive();
   }
 
-  ngOnDestroy(): void {}
+  ngOnDestroy(): void {
+  }
+
+  interceptDownload($event: MouseEvent) {
+    this.dismiss();
+    if (!this._sessionQuery.isLoggedIn()) {
+      $event.preventDefault();
+      this._sentinelSearchService.redirectToLoginPage();
+    }
+  }
 }

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.html
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.html
@@ -43,7 +43,7 @@
           </div>
           <div class="search-result__actions">
             <button data-test="show-details-button" class="show-details" (click)="showDetails.emit(result)"></button>
-            <a [attr.href]="result.url" target="_blank" class="download-link download"></a>
+            <a [attr.href]="result.url" (click)="isUserLoggedIn || interceptDownload($event)" target="_blank" class="download-link download"></a>
           </div>
         </section>
       </li>
@@ -51,7 +51,9 @@
     </ul>
     </ng-container>
     <ng-template #errorRef>
-      <div class="error" data-test="error-container" i18n>Wystąpił błąd podczas pobierania wyników, <a href="javascript:void" data-test="reload" (click)="reload.emit()">kliknij by ponówić próbę</a></div>
+      <div class="error" data-test="error-container" i18n>Wystąpił błąd podczas pobierania wyników,
+        <a href="javascript:undefined" data-test="reload" (click)="reload.emit()">kliknij by ponówić próbę</a>
+      </div>
     </ng-template>
   </section>
 

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.ts
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {SentinelSearchResult} from '../../state/sentinel-search/sentinel-search.model';
 
 @Component({
@@ -9,8 +9,16 @@ import {SentinelSearchResult} from '../../state/sentinel-search/sentinel-search.
 export class SearchResultsComponent {
   @Input() searchResults: SentinelSearchResult[] = [];
   @Input() isLoading: boolean = false;
-  @Input() error: any|null = null;
+  @Input() error: any | null = null;
+  @Input() isUserLoggedIn: boolean = false;
   @Output() close = new EventEmitter<void>();
   @Output() showDetails = new EventEmitter<SentinelSearchResult>();
   @Output() reload = new EventEmitter<void>();
+  @Output() forbiddenAction = new EventEmitter<void>();
+
+
+  interceptDownload($event: MouseEvent) {
+    this.forbiddenAction.emit();
+    $event.preventDefault();
+  }
 }

--- a/s4e-web/src/app/views/map-view/sentinel-search/sentinel-search.component.html
+++ b/s4e-web/src/app/views/map-view/sentinel-search/sentinel-search.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="!(loadingMetadata$ | async); else metadataLoadingRef">
   <form [formGroup]="form" class="form form--sentinel">
-    <div class="infobox infobox--poligon" i18>
+    <div class="infobox infobox--poligon" i18n>
       Możesz zawęzić obszar w którym chcesz szukać danych Sentinel. Wyznacz punkty klikając prawym przyciskiem myszy.
     </div>
     <ul>
@@ -24,9 +24,11 @@
 
 <s4e-search-results class="search-results"
                     *ngIf="showSearchResults$ | async"
+                    [isUserLoggedIn]="isLoggedIn$ | async"
                     [isLoading]="loading$ | async"
                     [error]="error$ | async"
                     (reload)="search()"
                     (close)="clearResults()"
+                    (forbiddenAction)="redirectToLoginPage()"
                     (showDetails)="openSearchResultModal($event)"
                     [searchResults]="searchResults$ | async"></s4e-search-results>

--- a/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.model.ts
+++ b/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.model.ts
@@ -1,12 +1,13 @@
-import { environment } from './../../../../../environments/environment';
-import {ActiveState, EntityState, HashMap} from '@datorama/akita';
+import {environment} from '../../../../../environments/environment';
+import {ActiveState, EntityState} from '@datorama/akita';
 import {SentinelSearchMetadata} from './sentinel-search.metadata.model';
 
 export const SENTINEL_VISIBLE_QUERY_KEY = 'visible_sent';
 export const SENTINEL_SELECTED_QUERY_KEY = 'selected_sent';
+export const SENTINEL_SHOW_RESULTS_QUERY_KEY = 'showSearchResults';
+export const SENTINEL_SEARCH_PARAMS_QUERY_KEY = 'searchParams';
 
 export interface SentinelSearchResultMetadata {
-  [key: string]: string;
   format: string;
   ingestion_time: string;
   polarisation: string;
@@ -18,6 +19,8 @@ export interface SentinelSearchResultMetadata {
   sensing_time: string;
   sensor_mode: string;
   spacecraft: string;
+
+  [key: string]: string;
 }
 
 /**
@@ -63,5 +66,4 @@ export interface SentinelSearchState extends EntityState<SentinelSearchResult>, 
   metadataLoading: boolean;
   metadataLoaded: boolean;
   loaded: boolean;
-  showSearchResults: boolean;
 }

--- a/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.query.spec.ts
+++ b/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.query.spec.ts
@@ -7,15 +7,15 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {RouterQuery} from '@datorama/akita-ng-router-store';
 import {createSentinelSearchResult, SENTINEL_SELECTED_QUERY_KEY, SENTINEL_VISIBLE_QUERY_KEY} from './sentinel-search.model';
 import {ReplaySubject, Subject} from 'rxjs';
-import {take} from 'rxjs/operators';
+import {take, toArray} from 'rxjs/operators';
 import {SentinelSearchFactory, SentinelSearchMetadataFactory} from './sentinel-search.factory.spec';
-import environment from 'src/environments/environment';
 
 describe('SentinelSearchResultQuery', () => {
   let query: SentinelSearchQuery;
   let store: SentinelSearchStore;
   let routerQuery: RouterQuery;
   let queryParams$: Subject<string>;
+  let selectQueryParamsSpy;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -26,7 +26,7 @@ describe('SentinelSearchResultQuery', () => {
     store = TestBed.get(SentinelSearchStore);
     routerQuery = TestBed.get(RouterQuery);
     queryParams$ = new ReplaySubject<string>(1);
-    spyOn(routerQuery, 'selectQueryParams').and.returnValue(queryParams$);
+    selectQueryParamsSpy = spyOn(routerQuery, 'selectQueryParams').and.returnValue(queryParams$);
   });
 
   it('should create an instance', () => {
@@ -146,5 +146,14 @@ describe('SentinelSearchResultQuery', () => {
     expect(await query.selectIsActiveLast().pipe(take(1)).toPromise()).toBeFalsy();
     store.setActive(results[2].id);
     expect(await query.selectIsActiveLast().pipe(take(1)).toPromise()).toBeTruthy();
+  });
+
+  it('selectShowSearchResults', async () => {
+    const params$ = new ReplaySubject(2);
+    const promise = query.selectShowSearchResults().pipe(take(2), toArray()).toPromise()
+    queryParams$.next(undefined);
+    queryParams$.next('1');
+    expect(await promise).toEqual([false, true]);
+    expect(selectQueryParamsSpy).toHaveBeenCalledWith('showSearchResults');
   });
 });

--- a/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.query.ts
+++ b/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.query.ts
@@ -89,6 +89,6 @@ export class SentinelSearchQuery extends QueryEntity<SentinelSearchState, Sentin
   }
 
   selectShowSearchResults() {
-    return this.select('showSearchResults');
+    return this._routerQuery.selectQueryParams('showSearchResults').pipe(map(showSearchResults => showSearchResults === '1'))
   }
 }

--- a/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.service.ts
+++ b/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.service.ts
@@ -1,16 +1,16 @@
 import {handleHttpRequest$} from 'src/app/common/store.util';
-import {environment} from './../../../../../environments/environment';
+import {environment} from '../../../../../environments/environment';
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {SentinelSearchStore} from './sentinel-search.store';
 import {
-  createSentinelSearchResult,
-  SENTINEL_SELECTED_QUERY_KEY,
+  createSentinelSearchResult, SENTINEL_SEARCH_PARAMS_QUERY_KEY,
+  SENTINEL_SELECTED_QUERY_KEY, SENTINEL_SHOW_RESULTS_QUERY_KEY,
   SENTINEL_VISIBLE_QUERY_KEY,
   SentinelSearchResultResponse,
 } from './sentinel-search.model';
 import {SentinelSearchQuery} from './sentinel-search.query';
-import {delay, map, shareReplay, tap} from 'rxjs/operators';
+import {catchError, delay, map, switchMap, take, tap} from 'rxjs/operators';
 import {SentinelSearchMetadata} from './sentinel-search.metadata.model';
 import {Router} from '@angular/router';
 import {HashMap} from '@datorama/akita';
@@ -18,7 +18,12 @@ import {NotificationService} from 'notifications';
 import {ModalService} from '../../../../modal/state/modal.service';
 import {SENTINEL_SEARCH_RESULT_MODAL_ID} from '../../sentinel-search/search-result-modal/search-result-modal.model';
 import {ActivatedQueue} from 'src/app/utils/search/activated-queue.utils';
-import {logIt} from '../../../../utils/rxjs/observable';
+import {Observable, of, throwError} from 'rxjs';
+import {fromPromise} from 'rxjs/internal-compatibility';
+import {FormGroup} from '@angular/forms';
+import {RouterQuery} from '@datorama/akita-ng-router-store';
+import {filterTrue} from '../../../../utils/rxjs/observable';
+import {BACK_LINK_QUERY_PARAM} from '../../../../state/session/session.service';
 
 @Injectable({providedIn: 'root'})
 export class SentinelSearchService {
@@ -30,7 +35,8 @@ export class SentinelSearchService {
     private http: HttpClient,
     private router: Router,
     private notificationService: NotificationService,
-    private modalService: ModalService
+    private modalService: ModalService,
+    private routerQuery: RouterQuery
   ) {
     this._activatedQueue = new ActivatedQueue(this.query, this.store);
   }
@@ -49,57 +55,56 @@ export class SentinelSearchService {
     this.setSentinelVisibility(sentinelId, !this.query.isSentinelVisible(sentinelId));
   }
 
-  search(params: HashMap<string>) {
+  search(form: FormGroup): Observable<SentinelSearchResultResponse[]> {
+    const params: HashMap<any> = Object.values(form.value).reduce((prev, current) => Object.assign(prev, current), {});
+
     this.store.set([]);
-    this.store.update({showSearchResults: true});
+    this.store.update({loaded: false, loading: true, error: null});
     const url = `${environment.apiPrefixV1}/search`;
-    const get$ = this.http.get<SentinelSearchResultResponse[]>(url, {params})
+    return fromPromise(this.router.navigate([], {
+      queryParams: {[SENTINEL_SEARCH_PARAMS_QUERY_KEY]: JSON.stringify(form.value), [SENTINEL_SHOW_RESULTS_QUERY_KEY]: '1'},
+      queryParamsHandling: 'merge'
+    }))
       .pipe(
+        switchMap(() => this.http.get<SentinelSearchResultResponse[]>(url, {params})),
         handleHttpRequest$(this.store),
         delay(250),
         map(data => data.map(product => createSentinelSearchResult(product))),
-        shareReplay(1)
-      );
-    get$
-      .subscribe(
-        (data) => {
+        tap(data => {
           this.store.set(data);
           this.store.setLoaded(true);
-        },
-        error => this.notificationService.addGeneral({
-          type: 'error',
-          content: 'Wystąpił błąd podczas wyszukiwaniania'
+        }),
+        catchError(error => {
+          this.notificationService.addGeneral({
+            type: 'error',
+            content: 'Wystąpił błąd podczas wyszukiwaniania'
+          });
+          return throwError(error);
         })
       );
-    return get$;
   }
 
-  getSentinels() {
+  getSentinels$(): Observable<SentinelSearchMetadata> {
     if (this.query.isMetadataLoaded()) {
-      return;
+      return of(this.query.getValue().metadata);
     }
 
     this.store.setError(null);
     this.store.setMetadataLoading();
     const url = `${environment.apiPrefixV1}/config/sentinel-search`;
-    const get$ = this.http.get<SentinelSearchMetadata>(url)
+    return this.http.get<SentinelSearchMetadata>(url)
       .pipe(
         tap(() => this.store.setMetadataLoading(false)),
-        tap(data => this.store.update({metadata: data, metadataLoaded: true}))
+        tap(data => this.store.update({metadata: data, metadataLoaded: true})),
+        catchError(error => {
+          this.store.setError(error);
+          this.notificationService.addGeneral({
+            type: 'error',
+            content: 'Wystąpił błąd podczas pobierania metadanych'
+          });
+          return throwError(error);
+        })
       );
-    get$.subscribe(
-      () => {
-      },
-      error => {
-        this.store.setError(error);
-        this.notificationService.addGeneral({
-          type: 'error',
-          content: 'Wystąpił błąd podczas pobierania metadanych'
-        });
-      }
-    );
-
-    return get$;
   }
 
   setLoaded(loaded: boolean) {
@@ -121,6 +126,32 @@ export class SentinelSearchService {
 
   clearResults() {
     this.store.set([]);
-    this.store.update({showSearchResults: false});
+    this._clearSentinelSearchFromQuery();
+  }
+
+  connectQueryToForm(form: FormGroup): Observable<any> {
+    return this.routerQuery.selectQueryParams(SENTINEL_SEARCH_PARAMS_QUERY_KEY).pipe(
+      take(1),
+      map((params: string) => {
+        try {
+          return JSON.parse(params);
+        } catch (e) {
+          return {};
+        }
+      }),
+      tap(params => Object.keys(form.controls).forEach(key => form.get(key).patchValue(params[key] || {}))),
+      switchMap(() => this.query.selectShowSearchResults().pipe(take(1))),
+      filterTrue(),
+      switchMap(() => this.search(form))
+    );
+  }
+
+  private _clearSentinelSearchFromQuery(): Promise<any> {
+    return this.router.navigate([], {queryParamsHandling: 'merge', queryParams: {[SENTINEL_SHOW_RESULTS_QUERY_KEY]: undefined}});
+  }
+
+  redirectToLoginPage() {
+    this.notificationService.addGeneral({type: 'warning', duration: 10000, content: 'Zaloguj się by uzyskać dostęp do zasobu'})
+    this.router.navigate(['/login'], {queryParams: {[BACK_LINK_QUERY_PARAM]: this.routerQuery.getValue().state.url}})
   }
 }

--- a/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.store.ts
+++ b/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.store.ts
@@ -11,7 +11,6 @@ export class SentinelSearchStore extends EntityStore<SentinelSearchState, Sentin
       loaded: false,
       metadataLoading: false,
       metadataLoaded: false,
-      showSearchResults: false,
       metadata: {
         common: {
           params: []


### PR DESCRIPTION
## What is in this PR?

* Handle anonymous user handling of search result download
* Preserve sentinel search params between page reloads and link pasting

## How does it look like

![Screen Shot 2020-11-24 at 21 34 51](https://user-images.githubusercontent.com/13235269/100148531-2d51a280-2e9d-11eb-8d5f-fad28b5f9fd9.png)

![Screen Shot 2020-11-24 at 21 34 56](https://user-images.githubusercontent.com/13235269/100148548-32aeed00-2e9d-11eb-8faa-53b6a1d0001c.png)

![Screen Shot 2020-11-24 at 21 35 01](https://user-images.githubusercontent.com/13235269/100148557-35a9dd80-2e9d-11eb-84b5-96f520b408ef.png)

## Test steps

1. As an anonymous user search for sentinel scenes and click download button
2. you should be redirected to login page with notification informing you about the fact that those resources are only for authorized users
3. Refresh page (this will ensure that this feature does not depend on JS in memory page state)
3. log in
4. you should be redirected back to map with search drawer open
5. click download, the file should download

Repeat those steps for download button in the search result metadata modal.

Closes: #928