### PR TITLE
[#931] Artifact download and image thumbnails to sentinel results

### DIFF
--- a/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.html
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.html
@@ -1,29 +1,39 @@
 <button [disabled]="isFirst$ | async" (click)="previousResult()" class="modal__prev"><i class="fa fa-chevron-left"></i></button>
 <button [disabled]="isLast$ | async" (click)="nextResult()" class="modal__next"><i class="fa fa-chevron-right"></i></button>
-<s4e-generic-modal [buttonX]="true" [modalId]="registeredId">
+<s4e-generic-modal [buttonX]="true" [modalId]="registeredId" [xclicked]="xclicked">
   <div class="s4e-modal-header">
     {{(searchResult$ | async)?.sceneKeyShort}}
   </div>
   <div class="s4e-modal-body report">
-    <aside>
-      <strong i18n>Footprint</strong>
-      <div class="report-template">
-        <img src="assets/images/gfx_temp_footprint.png" width="180"/>
-      </div>
+    <aside *ngIf="(searchResult$ | async)?.image as imageSrc">
       <strong i18n>Quicklook</strong>
       <div class="report-template">
-        <img src="assets/images/gfx_temp_quicklook.png" width="180"/>
+        <img [attr.src]="imageSrc" width="180"/>
       </div>
 
     </aside>
     <div class="form">
-      <h3>Summary</h3>
+      <h3 i18n>Summary</h3>
       <table class="modal__table">
         <tr *ngFor="let entry of ((searchResult$ | async)?.metadataContent | keyvalue)">
           <td>{{entry.key}}</td>
           <td>{{entry.value}}</td>
         </tr>
       </table>
+
+      <ng-container *ngIf="(searchResult$ | async)?.artifactsWithLinks?.length">
+        <h3 i18n>Artifacts</h3>
+        <table class="modal__table modal__table__artifacts">
+          <tr *ngFor="let entry of (searchResult$ | async)?.artifactsWithLinks">
+            <td>{{entry.artifact}}</td>
+            <td><a [attr.href]="entry.url"
+                   (click)="interceptDownload($event, false)"
+                   target="_blank" title="Pobierz Artefakt" i18n-title>
+              <i class="fa fa-download"></i>
+            </a></td>
+          </tr>
+        </table>
+      </ng-container>
     </div>
   </div>
   <div class="s4e-modal-footer">

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.scss
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.scss
@@ -5,3 +5,9 @@
 h3 {
   margin-top: 0;
 }
+
+.modal__table__artifacts {
+  td:first-child {
+    width: 100%;
+  }
+}

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.ts
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-result-modal/search-result-modal.component.ts
@@ -17,6 +17,7 @@ export class SearchResultModalComponent extends ModalComponent implements OnInit
   searchResult$: Observable<SentinelSearchResult>;
   isFirst$: Observable<boolean>;
   isLast$: Observable<boolean>;
+  xclicked = () => this.dismiss();
 
   constructor(
     modalService: ModalService,
@@ -44,11 +45,19 @@ export class SearchResultModalComponent extends ModalComponent implements OnInit
   ngOnDestroy(): void {
   }
 
-  interceptDownload($event: MouseEvent) {
-    this.dismiss();
+  interceptDownload($event: MouseEvent, dismiss: boolean = true) {
+    if (dismiss) {
+      this.dismiss();
+    }
+
     if (!this._sessionQuery.isLoggedIn()) {
       $event.preventDefault();
       this._sentinelSearchService.redirectToLoginPage();
     }
+  }
+
+  dismiss(returnValue?: void) {
+    this._sentinelSearchService.openModalForResult(null);
+    super.dismiss(returnValue);
   }
 }

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.html
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.html
@@ -29,9 +29,10 @@
           <strong class="package-name">{{result.sceneKeyShort}}</strong>
         </div>
         <section class="search-result__content">
-          <div class="search-result__quicklook" (click)="showDetails.emit(result)">
-            <img *ngIf="result.image" [attr.src]="result.image">
-            <strong>Brak podglądu</strong>
+          <div class="search-result__quicklook"
+               [ngStyle]="{'background': result.image ? ('url(' + result.image + ')') : ''}"
+               (click)="showDetails.emit(result)">
+            <strong *ngIf="!result.image">Brak podglądu</strong>
           </div>
           <div class="search-result__details">
             <span class="search-result__timestamp">{{result.timestamp}}</span>

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.scss
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.scss
@@ -90,6 +90,7 @@
     width: 80px;
     height: 50px;
     background: $color-grey-secondary;
+    background-size: cover;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.spec.ts
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.spec.ts
@@ -52,6 +52,19 @@ describe('SearchResultsComponent', () => {
       expect(de.queryAll(By.css('[data-test="search-result-entry"]')).length).toBe(1);
     });
 
+    it('should have thumbnail', () => {
+      expect(de.query(By.css('.search-result__quicklook')).styles)
+        .toEqual({background: `url(api/v1/scenes/${result.id}/download/thumbnail)`})
+    });
+
+    it('should have empty thumbnail', () => {
+      result.image = null;
+      component.searchResults = [result];
+      fixture.detectChanges()
+      expect(de.query(By.css('.search-result__quicklook')).styles)
+        .toEqual({background: ''})
+    });
+
     it('should emit showDetails when details button is clicked', async () => {
       const showDetailsEmitted = component.showDetails.pipe(take(1)).toPromise();
       de.query(By.css('[data-test="search-result-entry"]:first-child [data-test="show-details-button"]')).nativeElement.click();

--- a/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.factory.spec.ts
+++ b/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.factory.spec.ts
@@ -92,7 +92,7 @@ class _SentinelSearchFactory extends Factory.Factory<SentinelSearchResultRespons
       productId: Factory.each(i => i),
       timestamp: '2020-06-25T22:45:26.576Z',
       footprint: 'POLYGON((20.602945 46.652897,17.222746 47.056656,17.563738 48.554222,21.041603 48.14983,20.602945 46.652897))',
-      artifacts: ['metadata', 'manifest', 'checksum', 'RGBs_8b', 'RGB_16b', 'quicklook', 'product_archive'],
+      artifacts: ['thumbnail', 'metadata', 'manifest', 'checksum', 'RGBs_8b', 'RGB_16b', 'quicklook', 'product_archive'],
       sceneKey: 'Sentinel-1/SLC_/2020-02-01/S1A_IW_SLC__1SDV_20200201T042809_20200201T042837_031054_039147_B63E.scene',
       metadataContent: {
         format: 'GeoTiff',

--- a/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.model.ts
+++ b/s4e-web/src/app/views/map-view/state/sentinel-search/sentinel-search.model.ts
@@ -4,8 +4,10 @@ import {SentinelSearchMetadata} from './sentinel-search.metadata.model';
 
 export const SENTINEL_VISIBLE_QUERY_KEY = 'visible_sent';
 export const SENTINEL_SELECTED_QUERY_KEY = 'selected_sent';
+export const SENTINEL_THUMBNAIL_ARTIFACT_NAME = 'thumbnail';
 export const SENTINEL_SHOW_RESULTS_QUERY_KEY = 'showSearchResults';
 export const SENTINEL_SEARCH_PARAMS_QUERY_KEY = 'searchParams';
+export const SENTINEL_SEARCH_ACTIVE_ID = 'search_active_id';
 
 export interface SentinelSearchResultMetadata {
   format: string;
@@ -37,26 +39,38 @@ export interface SentinelSearchResultResponse {
 }
 
 export interface SentinelSearchResult extends SentinelSearchResultResponse {
+  thumbnailStyle: string;
   sceneKeyShort: string;
   image: string;
   mission: string;
   instrument: string;
   timestamp: string;
+  artifactsWithLinks: {artifact: string, url: string}[];
   // this should be calculated from the response
   url: string;
 }
+
+export function artifactDownloadLink(id: string, artifact: string): string {
+  return `${environment.apiPrefixV1}/scenes/${id}/download/${artifact}`;
+}
+
 
 /**
  * A factory function that creates SentinelSearchResult
  */
 export function createSentinelSearchResult(params: SentinelSearchResultResponse) {
+  const image = params.artifacts.includes(SENTINEL_THUMBNAIL_ARTIFACT_NAME)
+    ? artifactDownloadLink(params.id, SENTINEL_THUMBNAIL_ARTIFACT_NAME)
+    : null;
+
   return {
-    image: null,
+    image: image,
     sceneKeyShort: params.sceneKey.match(/([^/]+)\.scene$/)[1],
     url: `${environment.apiPrefixV1}/dhus/odata/v1/Products('${params.id}')/$value`,
     metadataContent: {},
     artifacts: [],
     footprint: '',
+    artifactsWithLinks: (params.artifacts || []).map(artifact => ({artifact, url: artifactDownloadLink(params.id, artifact)})),
     ...params
   } as SentinelSearchResult;
 }


### PR DESCRIPTION
## Overview

* Add thumbnails to sentinel search results & to details metadata
* Add artifacts table with download buttons to details modal

## How does it look?

<img width="1392" alt="Screen Shot 2020-11-25 at 21 39 48" src="https://user-images.githubusercontent.com/13235269/100279655-41fa6d00-2f67-11eb-94f8-e84911348d82.png">

<img width="1392" alt="Screen Shot 2020-11-25 at 21 39 54" src="https://user-images.githubusercontent.com/13235269/100279672-4b83d500-2f67-11eb-8df6-2db058e56c0e.png">

<img width="1392" alt="Screen Shot 2020-11-25 at 21 39 59" src="https://user-images.githubusercontent.com/13235269/100279685-50488900-2f67-11eb-9dd6-95ca32fa00b0.png">


## Warning

Currently the artifact download api requires authorized user. So searching when anonymous will show blank images, but there is an issue #945 and after it is resolved that part of the feature should naturally work.
<img width="1392" alt="Screen Shot 2020-11-25 at 21 39 48" src="https://user-images.githubusercontent.com/13235269/100279655-41fa6d00-2f67-11eb-94f8-e84911348d82.png">


Closes: #931