### PR TITLE
Expose OpenAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,9 @@ openssl pkcs12 -export -inkey $NAME.pem -in $NAME.crt -out $NAME.p12
 #### API docs
 
 We use Swagger to create API documentation.
-When you run the backend Swagger-UI is exposed under `http://localhost:4201/swagger-ui.html`.
+When you run the backend Swagger-UI is exposed under `http://localhost:4201/api/v1/docs.html`.
+
+In profile `production` only package `pl.cyfronet.s4e.controller` is scanned and exposed.
 
 
 #### <a id="backend-static"></a> Static images S3 storage

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
@@ -160,6 +160,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
                 .mvcMatchers(GET, prefix("/places")).permitAll()
 
+                .mvcMatchers(GET, prefix(
+                        "/docs",
+                        "/docs.yaml",
+                        "/docs.html",
+                        "/docs/swagger-config",
+                        "/swagger-ui/**"
+                )).permitAll()
+
                 .mvcMatchers(ADMIN_PREFIX + "/**").hasRole("ADMIN")
 
                 .anyRequest().denyAll();

--- a/s4e-backend/src/main/resources/application-production.properties
+++ b/s4e-backend/src/main/resources/application-production.properties
@@ -46,6 +46,8 @@ spring.flyway.clean-disabled=true
 spring.cache.cache-names=auth-bucket
 spring.cache.caffeine.spec=maximumSize=500000,expireAfterAccess=600s
 
+springdoc.packages-to-scan=pl.cyfronet.s4e.controller
+
 bucket4j.enabled=true
 bucket4j.filters[0].cache-name=auth-bucket
 bucket4j.filters[0].url=/api/v1/login.*

--- a/s4e-backend/src/main/resources/application.properties
+++ b/s4e-backend/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.port=4201
 server.tomcat.relaxed-query-chars=[,]
+server.forward-headers-strategy=framework
 
 spring.datasource.platform=postgres
 
@@ -15,6 +16,8 @@ spring.web.locale-resolver=fixed
 
 spring.thymeleaf.enabled=false
 
+springdoc.api-docs.path=/api/v1/docs
+springdoc.swagger-ui.path=/api/v1/docs.html
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.tagsSorter=alpha
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SwaggerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SwaggerTest.java
@@ -7,6 +7,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 
 @BasicTest
 @AutoConfigureMockMvc
@@ -16,7 +17,7 @@ public class SwaggerTest {
 
     @Test
     public void test() throws Exception {
-        mockMvc.perform(get("/v3/api-docs"))
+        mockMvc.perform(get(API_PREFIX_V1 + "/docs"))
             .andExpect(status().isOk());
     }
 }

--- a/s4e-web/src/app/views/apihowto/apihowto.component.html
+++ b/s4e-web/src/app/views/apihowto/apihowto.component.html
@@ -152,9 +152,20 @@
     <i>wymaga dodania tokenu autoryzacyjnego</i>
   </p>
 
+  <h2>API SOK</h2>
+  <p>
+    API SOK wystawione pod prefixem <code>{{API_BASE}}</code>
+    opisane jest w standardzie <a href="http://spec.openapis.org/oas/v3.0.1" target="_blank">OpenAPIv3</a>
+    w formacie <a href="{{API_BASE}}/docs" target="_blank">JSON</a> oraz
+    <a href="{{API_BASE}}/docs.yaml" target="_blank">YAML</a>.
+  </p>
+  <p>
+    Udostępniona jest również <a href="{{API_BASE}}/docs.html" target="_blank">graficzna przeglądarka Swagger-UI</a>.
+  </p>
+
   <h2>API Web Map Service (WMS)</h2>
-  <p>Aby pobrać  warstwy udostępniane w serwisie Sat4Envi należy skorzystać z metody GetCapabilities serwera WMS.</p>
+  <p>Aby pobrać warstwy udostępniane w serwisie Sat4Envi należy skorzystać z metody GetCapabilities serwera WMS.</p>
   <p>API jest zgodne ze standardem WMS (v. 1.3.0), a opis pozostałych metod opisany w dokumentacji standardu pod adresem <a href="https://www.ogc.org/standards/wms" target="_blank">https://www.ogc.org/standards/wms</a></p>
-  <p>API WMS jest dostępne pod adresem {{API_WMS}}</p>
+  <p>API WMS jest dostępne pod adresem {{API_WMS}}.</p>
   <p>Każdy produkt wystawiony jest jako warstwa WMS z możliwością czasowego zawężenia wyników przez użycie parametru TIME.</p>
 </main>

--- a/s4e-web/src/app/views/apihowto/apihowto.component.scss
+++ b/s4e-web/src/app/views/apihowto/apihowto.component.scss
@@ -5,10 +5,6 @@ main {
   margin: 40px auto;
 }
 
-a {
-  display: block;
-}
-
 h1,h2,h3 {
   font-family: $font-secondary;
 }


### PR DESCRIPTION
The docs are accessible either by
- /api/v1/docs: OpenAPIv3 json,
- /api/v1/docs.yaml: OpenAPIv3 yaml,
- /api/v1/docs.html: swagger-ui.

Update API how-to description.

Closes: #943.