### PR TITLE
[#945] Whitelist selected artifact download

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/SceneArtifactsProperties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/SceneArtifactsProperties.java
@@ -1,0 +1,18 @@
+package pl.cyfronet.s4e.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+@ConfigurationProperties("scene.artifacts")
+@Validated
+@Setter
+@Getter
+public class SceneArtifactsProperties {
+    @NotNull
+    private Set<String> internalDownloadWhitelist;
+}

--- a/s4e-backend/src/main/resources/application.properties
+++ b/s4e-backend/src/main/resources/application.properties
@@ -23,3 +23,5 @@ springdoc.swagger-ui.tagsSorter=alpha
 
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoints.jmx.exposure.include=
+
+scene.artifacts.internal-download-whitelist=thumbnail


### PR DESCRIPTION
Add property `scene.artifacts.internal-download-whitelist` with a set of
Scene artifact names which will be open for unauthenticated users to
download (doesn't apply to private Products).

Closes: #945.