### PR TITLE
[#964] Fix forget-me endpoint

### DIFF
--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AppUserControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AppUserControllerTest.java
@@ -634,6 +634,38 @@ public class AppUserControllerTest {
     @Nested
     class ForgetMe {
         @Test
+        public void shouldForgetZkAdmin() throws Exception {
+            val zkAdmin = appUserRepository.save(AppUser.builder()
+                    .email("zkAdmin@mail.com")
+                    .name("Get")
+                    .surname("Profile")
+                    .password("{noop}password")
+                    .enabled(true)
+                    .build());
+            userRoleRepository.save(UserRole.builder().
+                    role(AppRole.INST_MEMBER)
+                    .user(zkAdmin)
+                    .institution(institution)
+                    .build());
+            userRoleRepository.save(UserRole.builder().
+                    role(AppRole.INST_ADMIN)
+                    .user(zkAdmin)
+                    .institution(institution)
+                    .build());
+            String email = "zkAdmin@mail.com";
+            String password = "password";
+            ForgetUserRequest request = ForgetUserRequest.builder().email(email).password(password).build();
+
+            mockMvc.perform(post(API_PREFIX_V1 + "/users/forget-me")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request))
+                    .with(jwtBearerToken(zkAdmin, objectMapper)))
+                    .andExpect(status().isOk());
+
+            assertThat(appUserRepository.findByEmail(email), isEmpty());
+        }
+
+        @Test
         public void shouldBeSecured() throws Exception {
             ForgetUserRequest request = ForgetUserRequest.builder()
                     .email(securityAppUser.getEmail())


### PR DESCRIPTION
rewrite removeRoles. dont use service, just delete every userrole directly.

user with multiple roles should be forgotten.

closes #964 