### PR TITLE
Return actual authorities in /users/me and don't force re-seed users by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Several profiles can be specified in a comma separated list, e.g. `production,ru
 - Mailer properties must be configured.
 
 `run-seed-users`: Runs `SeedUsers`.
+By default doesn't force re-seed, but it can be told to do so by setting `seed.users.force=true`.
 
 `run-seed-places`: Runs `SeedPlaces`.
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedUsers.java
@@ -2,6 +2,7 @@ package pl.cyfronet.s4e.db.seed;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
@@ -30,6 +31,8 @@ import java.util.Locale;
 @RequiredArgsConstructor
 @Slf4j
 public class SeedUsers implements ApplicationRunner {
+    private static final String FORCE_PROPERTY = "seed.users.force";
+
     private final AppUserRepository appUserRepository;
     private final InstitutionRepository institutionRepository;
     private final InstitutionService institutionService;
@@ -39,9 +42,17 @@ public class SeedUsers implements ApplicationRunner {
 
     private final PasswordEncoder passwordEncoder;
 
+    @Value("${" + FORCE_PROPERTY + ":false}")
+    private boolean force;
+
     @Async
     @Override
     public void run(ApplicationArguments args) {
+        if (appUserRepository.count() > 0 && !force) {
+            log.info("Users already seeded, skipping. Set " + FORCE_PROPERTY + "=true to seed anyway");
+            return;
+        }
+
         emailVerificationRepository.deleteAll();
         institutionRepository.deleteAll();
         appUserRepository.deleteAll();

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/AppUserMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/AppUserMapper.java
@@ -41,11 +41,15 @@ public abstract class AppUserMapper {
     @Mapping(target = "surname", source = "projection.surname")
     @Mapping(target = "admin", source = "userDetails", qualifiedByName = "admin")
     @Mapping(target = "memberZK", source = "userDetails", qualifiedByName = "memberZK")
-    @Mapping(target = "authorities", source = "projection.authorities")
+    @Mapping(target = "authorities", source = "userDetails.authorities")
     public abstract UserMeResponse projectionToMeResponse(
             AppUserController.UserMeProjection projection,
             AppUserDetails userDetails
     );
+
+    protected String sgaToString(SimpleGrantedAuthority simpleGrantedAuthority) {
+        return simpleGrantedAuthority.getAuthority();
+    }
 
     @Named("admin")
     protected boolean admin(AppUserDetails userDetails) {

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AppUserControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AppUserControllerTest.java
@@ -293,7 +293,7 @@ public class AppUserControllerTest {
         verifyNoMoreInteractions(testListener);
 
         // Email sending handler is executed in @Async method so allow it to run
-        await().atMost(Durations.ONE_SECOND)
+        await().atMost(Durations.TWO_SECONDS)
                 .until(() -> inbox.getMessageCount() == 1);
 
         // The message should contain a link with the token.
@@ -399,7 +399,7 @@ public class AppUserControllerTest {
         verifyNoMoreInteractions(testListener);
 
         // Email sending handler is executed in @Async method so allow it to run
-        await().atMost(Durations.ONE_SECOND)
+        await().atMost(Durations.TWO_SECONDS)
                 .until(() -> inbox.getMessageCount() == 1);
 
         // The message should contain a link with the token.
@@ -442,7 +442,7 @@ public class AppUserControllerTest {
         verifyNoMoreInteractions(testListener);
 
         // Email sending handler is executed in @Async method so allow it to run.
-        await().atMost(Durations.ONE_SECOND)
+        await().atMost(Durations.TWO_SECONDS)
                 .until(() -> inbox.getMessageCount() == 1);
 
         // EmailVerification is only removed in the EmailConfirmationListener, so it is verified after
@@ -518,7 +518,7 @@ public class AppUserControllerTest {
         verifyNoMoreInteractions(testListener);
 
         // Email sending handler is executed in @Async method so allow it to run.
-        await().atMost(Durations.ONE_SECOND)
+        await().atMost(Durations.TWO_SECONDS)
                 .until(() -> inbox.getMessageCount() == 1);
 
         // The message should contain a link with the token.
@@ -577,7 +577,7 @@ public class AppUserControllerTest {
         verifyNoMoreInteractions(testListener);
 
         // Email sending handler is executed in @Async method so allow it to run.
-        await().atMost(Durations.ONE_SECOND)
+        await().atMost(Durations.TWO_SECONDS)
                 .until(() -> inbox.getMessageCount() == 1);
 
         // The message should contain a link with the token.

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ExpertHelpControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ExpertHelpControllerTest.java
@@ -121,7 +121,7 @@ public class ExpertHelpControllerTest {
                     .content(objectMapper.writeValueAsBytes(request)))
                     .andExpect(status().isOk());
 
-            await().atMost(Durations.ONE_SECOND)
+            await().atMost(Durations.TWO_SECONDS)
                     .until(() -> zkInbox.getMessageCount() == 1 && expertInbox.getMessageCount() == 1);
 
             {

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ShareLinkControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ShareLinkControllerTest.java
@@ -124,7 +124,7 @@ public class ShareLinkControllerTest {
                 .andExpect(status().isOk());
 
         // Email sending handler is executed in @Async method so allow it to run
-        await().atMost(Durations.ONE_SECOND)
+        await().atMost(Durations.TWO_SECONDS)
                 .until(() -> inbox1.getMessageCount() == 1 && inbox2.getMessageCount() == 1);
 
         MimeMessageParser parser1 = getParserForFirstMail(inbox1);


### PR DESCRIPTION
### Return authorities from userDetails in users/me

It makes it easier to access products managed by a user for example.
It could also replace the output of users/me.roles, but needs more
parsing.

### Don't force reseed users by default

Add a property seed.users.force, which, if set to true, will force
regardless of any user existence in the DB.