### PR TITLE
[#1005] Make OSM url configurable

### DIFF
--- a/backend-e2e.env
+++ b/backend-e2e.env
@@ -9,6 +9,7 @@ SPRING_RABBITMQ_PASSWORD=rabbittest123
 GEOSERVER_PASSWORD=admintest123
 GEOSERVER_BASEURL=http://geoserver-test:8080/geoserver/rest
 GEOSERVER_OUTSIDEBASEURL=/wms
+OSM_URL=/osm/{z}/{x}/{y}.png
 S3_FILESTORAGE_BUCKET=static
 S3_FILESTORAGE_KEYPREFIX=thumbnails/
 S3_ACCESSKEY=miniotest

--- a/backend-production.env.template
+++ b/backend-production.env.template
@@ -9,6 +9,7 @@ SPRING_RABBITMQ_PASSWORD=rabbit123
 GEOSERVER_PASSWORD=admin123
 GEOSERVER_BASEURL=http://geoserver:8080/geoserver/rest
 GEOSERVER_OUTSIDEBASEURL=/wms
+OSM_URL=https://osm.imgw.pl/hot/{z}/{x}/{y}.png
 SPRING_MAIL_HOST=<smtp server host>
 SPRING_MAIL_PORT=<smtp server port>
 SPRING_MAIL_USERNAME=<login user to smtp server>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import pl.cyfronet.s4e.controller.response.ConfigResponse;
 import pl.cyfronet.s4e.properties.GeoServerProperties;
+import pl.cyfronet.s4e.properties.OsmProperties;
 import pl.cyfronet.s4e.search.SentinelSearchConfig;
 import pl.cyfronet.s4e.search.SentinelSearchConfigSupplier;
 
@@ -23,6 +24,7 @@ import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 @Tag(name = "config", description = "The Config API")
 public class ConfigController {
     private final GeoServerProperties geoServerProperties;
+    private final OsmProperties osmProperties;
     private final SentinelSearchConfigSupplier sentinelSearchConfigSupplier;
 
     @Value("${recaptcha.validation.siteKey}")
@@ -35,6 +37,7 @@ public class ConfigController {
     @GetMapping("/config")
     public ConfigResponse config() {
         return ConfigResponse.builder()
+                .osmUrl(osmProperties.getUrl())
                 .geoserverUrl(geoServerProperties.getOutsideBaseUrl())
                 .geoserverWorkspace(geoServerProperties.getWorkspace())
                 .recaptchaSiteKey(recaptchaSiteKey)

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
@@ -7,6 +7,8 @@ import lombok.Value;
 @Value
 @Builder
 public class ConfigResponse {
+    @Schema(example = "/osm/{z}/{x}/{y}.png")
+    String osmUrl;
     @Schema(example = "/wms")
     String geoserverUrl;
     @Schema(example = "development")

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/OsmProperties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/OsmProperties.java
@@ -1,0 +1,20 @@
+package pl.cyfronet.s4e.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@ConfigurationProperties("osm")
+@Setter
+@Getter
+@Validated
+public class OsmProperties {
+    /// Url from which OSM tiles will be fetched by front-end
+    @NotBlank
+    @Pattern(regexp = ".*/\\{z}/\\{x}/\\{y}.*")
+    private String url;
+}

--- a/s4e-backend/src/main/resources/application-development.properties
+++ b/s4e-backend/src/main/resources/application-development.properties
@@ -15,6 +15,8 @@ geoserver.base-url=http://localhost:8080/geoserver/rest
 geoserver.outside-base-url=/wms
 geoserver.workspace=development
 
+osm.url=/osm/{z}/{x}/{y}.png
+
 s3.access-key=minio
 s3.secret-key=minio123
 s3.endpoint=http://localhost:9001/

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ConfigControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/ConfigControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.test.web.servlet.MockMvc;
 import pl.cyfronet.s4e.BasicTest;
 import pl.cyfronet.s4e.properties.GeoServerProperties;
+import pl.cyfronet.s4e.properties.OsmProperties;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -19,6 +20,9 @@ public class ConfigControllerTest {
     @Autowired
     private GeoServerProperties geoServerProperties;
 
+    @Autowired
+    private OsmProperties osmProperties;
+
     @Value("${recaptcha.validation.siteKey}")
     private String recaptchaSiteKey;
 
@@ -29,6 +33,7 @@ public class ConfigControllerTest {
     public void shouldReturnConfiguration() throws Exception {
         mockMvc.perform(get(API_PREFIX_V1 + "/config"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.osmUrl").value(osmProperties.getUrl()))
                 .andExpect(jsonPath("$.geoserverUrl").value(geoServerProperties.getOutsideBaseUrl()))
                 .andExpect(jsonPath("$.recaptchaSiteKey").value(recaptchaSiteKey));
     }

--- a/s4e-backend/src/test/resources/application-test.properties
+++ b/s4e-backend/src/test/resources/application-test.properties
@@ -15,6 +15,8 @@ geoserver.base-url=http://localhost:8081/geoserver/rest
 geoserver.outside-base-url=/wms
 geoserver.workspace=test
 
+osm.url=/osm/{z}/{x}/{y}.png
+
 s3.access-key=miniotest
 s3.secret-key=miniotest123
 s3.endpoint=http://localhost:9002/

--- a/s4e-web/src/app/app.configuration.spec.ts
+++ b/s4e-web/src/app/app.configuration.spec.ts
@@ -7,6 +7,7 @@ import {LocalStorage} from './app.providers';
 import {HashMap} from '@datorama/akita';
 
 export const RemoteConfigurationFactory = Factory.makeFactory<IRemoteConfiguration>({
+  osmUrl: '/osm/{z}/{x}/{y}.png',
   geoserverUrl: 'http://localhost:8080/geoserver/wms',
   geoserverWorkspace: 'testing',
   recaptchaSiteKey: 'abc123',
@@ -46,11 +47,11 @@ class LocalStorageMock {
 export const LocalStorageTestingProvider: Provider = {
   provide: LocalStorage,
   useValue: new LocalStorageMock()
-}
+};
 
 export function makeLocalStorageTestingProvider(initState: HashMap<string>): Provider {
   return {
     provide: LocalStorage,
     useValue: new LocalStorageMock(initState)
-  }
+  };
 }

--- a/s4e-web/src/app/app.configuration.ts
+++ b/s4e-web/src/app/app.configuration.ts
@@ -1,4 +1,5 @@
 export interface IRemoteConfiguration {
+  osmUrl: string;
   geoserverUrl: string;
   geoserverWorkspace: string;
   recaptchaSiteKey: string;

--- a/s4e-web/src/app/views/map-view/map/map.component.spec.ts
+++ b/s4e-web/src/app/views/map-view/map/map.component.spec.ts
@@ -3,8 +3,9 @@ import {MapComponent} from './map.component';
 import {ShareModule} from '../../../common/share.module';
 import {ReplaySubject} from 'rxjs';
 import {take} from 'rxjs/operators';
-import {Tile} from 'ol/layer';
 import {RouterTestingModule} from '@angular/router/testing';
+import {RemoteConfigurationTestingProvider} from '../../../app.configuration.spec';
+
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -12,6 +13,7 @@ describe('MapComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      providers: [RemoteConfigurationTestingProvider],
       imports: [
         ShareModule,
         RouterTestingModule
@@ -41,7 +43,7 @@ describe('MapComponent', () => {
     });
 
     component.getMapData().pipe(take(1)).subscribe(data => {
-      expect(data).toEqual({height: 150, width: 300, image: 'data:image/png;base64,00', "pointResolution": 152.87405656527181});
+      expect(data).toEqual({height: 150, width: 300, image: 'data:image/png;base64,00', 'pointResolution': 152.87405656527181});
       done();
     });
     expect(spy).toHaveBeenCalled();

--- a/s4e-web/src/app/views/map-view/map/map.component.ts
+++ b/s4e-web/src/app/views/map-view/map/map.component.ts
@@ -19,7 +19,7 @@ import moment from 'moment';
 import {NgxUiLoaderService} from 'ngx-ui-loader';
 import VectorSource from 'ol/source/Vector';
 import VectorLayer from 'ol/layer/Vector';
-import {Draw, Modify, Snap} from 'ol/interaction';
+import {Draw} from 'ol/interaction';
 import GeometryType from 'ol/geom/GeometryType';
 import {WKT} from 'ol/format';
 import {SentinelSearchService} from '../state/sentinel-search/sentinel-search.service';
@@ -124,7 +124,10 @@ export class MapComponent implements OnInit, OnDestroy {
       )
     );
 
-    const source = new OSM({url: '/osm/{z}/{x}/{y}.png', crossOrigin: 'Anonymous'});
+    const source = new OSM({
+      url: this._remoteConfiguration.get().osmUrl,
+      crossOrigin: 'Anonymous'
+    });
     this.baseLayer = new Tile({source});
 
     this.map.getLayers().push(this.baseLayer);
@@ -218,7 +221,7 @@ export class MapComponent implements OnInit, OnDestroy {
       centerCoordinates: view.getCenter(),
       zoomLevel: view.getZoom()
     });
-  };
+  }
 
   public getMapData(): Observable<MapData | null> {
     if (!this.map) {
@@ -343,7 +346,7 @@ export class MapComponent implements OnInit, OnDestroy {
           }),
         });
         this.map.addLayer(this._polygonDrawing.polygon);
-        this.map.removeInteraction(this._polygonDrawing.drawing)
+        this.map.removeInteraction(this._polygonDrawing.drawing);
       });
   }
 


### PR DESCRIPTION
Add property osm.url, that configures the OSM url used by front-end to
fetch tiles.

This allows fetching tiles from other domain or several domains, for
example if `osm.url={a-c}.osm/...` then a.osm, b.osm, c.osm domains
will be used.

Closes: #1005.