### PR TITLE
[#1006] Set domain for authorization cookie

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/JwtProperties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/JwtProperties.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
 import java.time.Duration;
 
 @ConfigurationProperties("jwt")
@@ -29,10 +30,20 @@ public class JwtProperties {
     @NestedConfigurationProperty
     private Token token = new Token();
 
+    @NestedConfigurationProperty
+    private Cookie cookie = new Cookie();
+
     @Getter
     @Setter
     public static class Token {
         /// Half a day. In case of an 8h shift require a login every day.
         private Duration expirationTime = Duration.ofHours(12);
+    }
+
+    @Getter
+    @Setter
+    public static class Cookie {
+        @Pattern(regexp = "[^/:]+")
+        private String domain;
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AuthControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/AuthControllerTest.java
@@ -3,12 +3,15 @@ package pl.cyfronet.s4e.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
 import pl.cyfronet.s4e.BasicTest;
 import pl.cyfronet.s4e.TestDbHelper;
 import pl.cyfronet.s4e.bean.AppUser;
@@ -17,6 +20,7 @@ import pl.cyfronet.s4e.data.repository.AppUserRepository;
 import pl.cyfronet.s4e.security.SecurityConstants;
 
 import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.ResultMatcher.matchAll;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
@@ -26,6 +30,9 @@ import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 class AuthControllerTest {
     /// Constant in all our tokens.
     private static final String JWT_ALG_PREFIX = "eyJhbGciOiJSUzI1NiJ9";
+    private static final String TOKEN_COOKIE = SecurityConstants.COOKIE_NAME;
+    private static final String TEST_HOST = "test-host:1234";
+    private static final String TEST_HOST_DOMAIN = "test-host";
 
     @Autowired
     private AppUserRepository appUserRepository;
@@ -116,18 +123,32 @@ class AuthControllerTest {
                 .password("password")
                 .build();
 
-        String cookieName = SecurityConstants.COOKIE_NAME;
-
         mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .header("Host", TEST_HOST)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(loginRequest)))
                 .andExpect(status().isOk())
-                .andExpect(cookie().value(cookieName, startsWith(JWT_ALG_PREFIX)))
-                .andExpect(cookie().httpOnly(cookieName, true))
-                .andExpect(cookie().path(cookieName, "/"))
-                .andExpect(cookie().secure(cookieName, true))
-                .andExpect(cookie().maxAge(cookieName, greaterThan(0)))
-                .andExpect(content().string(is(emptyOrNullString())));
+                .andExpect(content().string(is(emptyOrNullString())))
+                .andExpect(setsCookie(TEST_HOST_DOMAIN));
+    }
+
+    @Test
+    public void loginShouldSetCookieWithXForwardedHost() throws Exception {
+        val appUser = appUserRepository.save(appUser(true));
+
+        val loginRequest = LoginRequest.builder()
+                .email(appUser.getEmail())
+                .password("password")
+                .build();
+
+        mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .header("Host", TEST_HOST)
+                .header("X-Forwarded-Host", "original-host")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is(emptyOrNullString())))
+                .andExpect(setsCookie("original-host"));
     }
 
     @Test
@@ -140,6 +161,7 @@ class AuthControllerTest {
                 .build();
 
         mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .header("Host", TEST_HOST)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(loginRequest)))
                 .andExpect(status().isForbidden());
@@ -155,6 +177,7 @@ class AuthControllerTest {
                 .build();
 
         mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .header("Host", TEST_HOST)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(loginRequest)))
                 .andExpect(status().isUnauthorized());
@@ -168,6 +191,7 @@ class AuthControllerTest {
                 .build();
 
         mockMvc.perform(post(API_PREFIX_V1+"/login")
+                .header("Host", TEST_HOST)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(loginRequest)))
                 .andExpect(status().isUnauthorized());
@@ -175,17 +199,84 @@ class AuthControllerTest {
 
     @Test
     public void logoutShouldResetCookie() throws Exception {
-        String cookieName = SecurityConstants.COOKIE_NAME;
-
         mockMvc.perform(post(API_PREFIX_V1+"/logout")
+                .header("Host", TEST_HOST)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(cookie().value(cookieName, is(emptyOrNullString())))
-                .andExpect(cookie().httpOnly(cookieName, true))
-                .andExpect(cookie().path(cookieName, "/"))
-                .andExpect(cookie().secure(cookieName, true))
-                .andExpect(cookie().maxAge(cookieName, 0)) // resets cookie
-                .andExpect(content().string(is(emptyOrNullString())));
+                .andExpect(content().string(is(emptyOrNullString())))
+                .andExpect(unsetsCookie(TEST_HOST_DOMAIN));
+    }
+
+    @Test
+    public void logoutShouldResetCookieWithXForwardedHost() throws Exception {
+        mockMvc.perform(post(API_PREFIX_V1+"/logout")
+                .header("Host", TEST_HOST)
+                .header("X-Forwarded-Host", "original-host")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(is(emptyOrNullString())))
+                .andExpect(unsetsCookie("original-host"));
+    }
+
+    @Nested
+    @TestPropertySource(properties = {
+            "jwt.cookie.domain=other-domain"
+    })
+    class WithCookieDomainProperty {
+        // For some reason, the set property isn't propagated to the mockMvc from an enclosing class,
+        // but works when it's moved here.
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        public void loginShouldSetCookie() throws Exception {
+            val appUser = appUserRepository.save(appUser(true));
+
+            val loginRequest = LoginRequest.builder()
+                    .email(appUser.getEmail())
+                    .password("password")
+                    .build();
+
+            mockMvc.perform(post(API_PREFIX_V1+"/login")
+                    .header("Host", TEST_HOST)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(loginRequest)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(is(emptyOrNullString())))
+                    .andExpect(setsCookie("other-domain"));
+        }
+
+        @Test
+        public void logoutShouldResetCookie() throws Exception {
+            mockMvc.perform(post(API_PREFIX_V1+"/logout")
+                    .header("Host", TEST_HOST)
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(is(emptyOrNullString())))
+                    .andExpect(unsetsCookie("other-domain"));
+        }
+    }
+
+    private ResultMatcher setsCookie(String expectedDomain) {
+        return matchAll(
+                cookie().value(TOKEN_COOKIE, startsWith(JWT_ALG_PREFIX)),
+                cookie().httpOnly(TOKEN_COOKIE, true),
+                cookie().path(TOKEN_COOKIE, "/"),
+                cookie().secure(TOKEN_COOKIE, true),
+                cookie().maxAge(TOKEN_COOKIE, greaterThan(0)),
+                cookie().domain(TOKEN_COOKIE, expectedDomain)
+        );
+    }
+
+    private ResultMatcher unsetsCookie(String expectedDomain) {
+        return matchAll(
+                cookie().value(TOKEN_COOKIE, is(emptyOrNullString())),
+                cookie().httpOnly(TOKEN_COOKIE, true),
+                cookie().path(TOKEN_COOKIE, "/"),
+                cookie().secure(TOKEN_COOKIE, true),
+                cookie().maxAge(TOKEN_COOKIE, 0), // resets cookie
+                cookie().domain(TOKEN_COOKIE, expectedDomain)
+        );
     }
 
     private AppUser appUser(boolean enabled) {

--- a/s4e-web/nginx-e2e.conf
+++ b/s4e-web/nginx-e2e.conf
@@ -25,6 +25,7 @@ http {
 
         location /api/v1 {
             proxy_pass http://s4e-backend-e2e:4201/api/v1;
+            proxy_set_header X-Forwarded-Host $host:443;
         }
 
         location /static {

--- a/s4e-web/nginx.conf
+++ b/s4e-web/nginx.conf
@@ -25,6 +25,7 @@ http {
 
         location /api/v1 {
             proxy_pass http://s4e-backend:4201/api/v1;
+            proxy_set_header X-Forwarded-Host $host:443;
         }
 
         location /static {


### PR DESCRIPTION
Depending on the property jwt.cookie.domain the cookie's domain is
either fetched from header Host (in case the property is null or blank)
and set to the value from the property otherwise.

Closes: #1006.