### PR TITLE
[#1009] Stringify SyncJob ErrorsResponse cause

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/ErrorsResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/ErrorsResponse.java
@@ -16,7 +16,7 @@ public class ErrorsResponse {
     public static class ErrorResponse {
         private String sceneKey;
         private String code;
-        private Exception cause;
+        private String cause;
         private Map<String, Object> parameters;
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/RunningDetailsMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/sync/api/RunningDetailsMapper.java
@@ -1,10 +1,26 @@
 package pl.cyfronet.s4e.admin.sync.api;
 
+import lombok.val;
 import org.mapstruct.Mapper;
 import pl.cyfronet.s4e.admin.sync.task.SyncJob;
 import pl.cyfronet.s4e.config.MapStructCentralConfig;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 @Mapper(config = MapStructCentralConfig.class)
 public abstract class RunningDetailsMapper {
     public abstract ErrorsResponse toErrorsResponse(SyncJob.RunningDetails runningDetails);
+
+    protected String toString(Exception cause) {
+        if (cause == null) {
+            return null;
+        }
+
+        val sw = new StringWriter();
+        val pw = new PrintWriter(sw);
+        cause.printStackTrace(pw);
+        pw.close();
+        return sw.toString();
+    }
 }


### PR DESCRIPTION
Serializing an Exception for each Error causes the produced response to
be unwieldy in certain cases.

Fixes: #1009.