### PR TITLE
[#1017] Set From outgoing mail header

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/MailService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/MailService.java
@@ -1,23 +1,30 @@
 package pl.cyfronet.s4e.service;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
+import java.util.Optional;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class MailService {
     public interface Modifier {
         void modify(MimeMessageHelper helper) throws MessagingException;
     }
 
+    public MailService(JavaMailSender javaMailSender, Optional<MailProperties> mailProperties) {
+        this.javaMailSender = javaMailSender;
+        this.from = mailProperties.map(MailProperties::getUsername).orElse(null);
+    }
+
     private final JavaMailSender javaMailSender;
+
+    private final String from;
 
     public void sendEmail(String to, String subject, String plainText, String htmlText) {
         sendEmail(helper -> {
@@ -31,6 +38,7 @@ public class MailService {
         try {
             MimeMessage message = javaMailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
+            helper.setFrom(from);
             modifier.modify(helper);
             javaMailSender.send(message);
         } catch (MessagingException e) {


### PR DESCRIPTION
Populate the header's value based on Spring MailProperties, so it is
consistent with auto-configuration of the JavaMailSender.

Leaving the field empty causes some SMTP servers to reject such requests.

Fixes: #1017.