### PR TITLE
[#1022] Add polygon to SceneResponse

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneMapper.java
@@ -30,7 +30,7 @@ public abstract class AdminSceneMapper {
             Geometry geometry4326 = geometryUtil.transform(geometry3857, "EPSG:3857", "EPSG:4326");
             footprintPart.setEpsg4326(geometry4326.toText());
         } catch (FactoryException | TransformException e) {
-            log.info("Cannot transform geometry to EPSG:4326: '" + geometry3857.toText() + "'", e);
+            log.warn("Cannot transform geometry to EPSG:4326: '" + geometry3857.toText() + "'", e);
         }
 
         return footprintPart;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SceneController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SceneController.java
@@ -14,6 +14,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import pl.cyfronet.s4e.controller.mapper.SceneMapper;
 import pl.cyfronet.s4e.controller.request.ZoneParameter;
 import pl.cyfronet.s4e.controller.response.MostRecentSceneResponse;
 import pl.cyfronet.s4e.controller.response.SceneResponse;
@@ -29,7 +30,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.*;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -43,6 +43,7 @@ public class SceneController {
     private final SceneService sceneService;
     private final SceneStorage sceneStorage;
     private final TimeHelper timeHelper;
+    private final SceneMapper sceneMapper;
 
     @Operation(summary = "View a list of scenes")
     @ApiResponses({
@@ -60,11 +61,9 @@ public class SceneController {
         ZonedDateTime zdtStart = ZonedDateTime.of(date, LocalTime.MIDNIGHT, timeZone.getZoneId());
         LocalDateTime start = timeHelper.getLocalDateTimeInBaseZone(zdtStart);
         LocalDateTime end = timeHelper.getLocalDateTimeInBaseZone(zdtStart.plusDays(1));
-        Function<LocalDateTime, ZonedDateTime> timeConverter = (timestamp) ->
-                timeHelper.getZonedDateTime(timestamp, timeZone.getZoneId());
 
         return sceneService.list(productId, start, end, userDetails, SceneResponse.Projection.class).stream()
-                .map(s -> SceneResponse.of(productId, s, timeConverter))
+                .map(s -> sceneMapper.toResponse(s, timeZone.getZoneId()))
                 .collect(Collectors.toList());
     }
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/mapper/SceneMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/mapper/SceneMapper.java
@@ -1,0 +1,68 @@
+package pl.cyfronet.s4e.controller.mapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Geometry;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.operation.TransformException;
+import org.springframework.beans.factory.annotation.Autowired;
+import pl.cyfronet.s4e.config.MapStructCentralConfig;
+import pl.cyfronet.s4e.controller.response.SceneResponse;
+import pl.cyfronet.s4e.util.GeometryUtil;
+import pl.cyfronet.s4e.util.TimeHelper;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static pl.cyfronet.s4e.bean.Schema.SCENE_SCHEMA_ARTIFACTS_KEY;
+
+@Mapper(config = MapStructCentralConfig.class)
+@Slf4j
+public abstract class SceneMapper {
+    @Autowired
+    private TimeHelper timeHelper;
+
+    @Autowired
+    private GeometryUtil geometryUtil;
+
+    @Mapping(source = "scene", target = "productId", qualifiedByName = "productId")
+    @Mapping(source = "sceneContent", target = "artifacts")
+    public abstract SceneResponse toResponse(SceneResponse.Projection scene, @Context ZoneId zoneId);
+
+    @Named("productId")
+    protected Long getProductId(SceneResponse.Projection scene) {
+        return scene.getProduct().getId();
+    }
+
+    protected ZonedDateTime mapToZonedDateTime(LocalDateTime timestamp, @Context ZoneId zoneId) {
+        return timeHelper.getZonedDateTime(timestamp, zoneId);
+    }
+
+    protected String mapTo4326Wkt(Geometry footprint) {
+        try {
+            return geometryUtil.transform(footprint, "EPSG:3857", "EPSG:4326").toText();
+        } catch (FactoryException | TransformException e) {
+            log.warn("Cannot transform geometry to EPSG:4326: '" + footprint + "'", e);
+            return null;
+        }
+    }
+
+    protected Set<String> mapToArtifactNames(JsonNode sceneContent) {
+        ObjectNode artifacts = (ObjectNode) sceneContent.get(SCENE_SCHEMA_ARTIFACTS_KEY);
+        Iterator<String> artifactNamesIterator = artifacts.fieldNames();
+        return Stream.generate(() -> null)
+                .takeWhile(ignored -> artifactNamesIterator.hasNext())
+                .map(ignored -> artifactNamesIterator.next())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/SceneResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/SceneResponse.java
@@ -1,28 +1,24 @@
 package pl.cyfronet.s4e.controller.response;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Builder;
 import lombok.Data;
+import org.locationtech.jts.geom.Geometry;
 import pl.cyfronet.s4e.bean.Legend;
 import pl.cyfronet.s4e.data.repository.projection.ProjectionWithId;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
-import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static pl.cyfronet.s4e.bean.Schema.SCENE_SCHEMA_ARTIFACTS_KEY;
 
 @Data
 @Builder
 public class SceneResponse {
     public interface Projection extends ProjectionWithId {
+        ProjectionWithId getProduct();
         String getSceneKey();
         LocalDateTime getTimestamp();
+        Geometry getFootprint();
         Legend getLegend();
         JsonNode getSceneContent();
         JsonNode getMetadataContent();
@@ -31,29 +27,9 @@ public class SceneResponse {
     private Long id;
     private Long productId;
     private String sceneKey;
+    private ZonedDateTime timestamp;
+    private String footprint;
     private Legend legend;
     private Set<String> artifacts;
     private JsonNode metadataContent;
-    private ZonedDateTime timestamp;
-
-    public static SceneResponse of(Long productId, Projection scene, Function<LocalDateTime, ZonedDateTime> timestampConverter) {
-        return SceneResponse.builder()
-                .id(scene.getId())
-                .productId(productId)
-                .sceneKey(scene.getSceneKey())
-                .timestamp(timestampConverter.apply(scene.getTimestamp()))
-                .legend(scene.getLegend())
-                .artifacts(getArtifactNames(scene))
-                .metadataContent(scene.getMetadataContent())
-                .build();
-    }
-
-    private static Set<String> getArtifactNames(Projection scene) {
-        ObjectNode artifacts = (ObjectNode) scene.getSceneContent().get(SCENE_SCHEMA_ARTIFACTS_KEY);
-        Iterator<String> artifactNamesIterator = artifacts.fieldNames();
-        return Stream.generate(() -> null)
-                .takeWhile(ignored -> artifactNamesIterator.hasNext())
-                .map(ignored -> artifactNamesIterator.next())
-                .collect(Collectors.toUnmodifiableSet());
-    }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SceneControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SceneControllerTest.java
@@ -105,6 +105,18 @@ public class SceneControllerTest {
     }
 
     @Test
+    public void shouldReturnScenesWithFootprint() throws Exception {
+        val product = productRepository.save(productBuilder().build());
+        sceneRepository.save(sceneBuilder(product, LocalDateTime.of(2019, 10, 11, 12, 13)).build());
+
+        mockMvc.perform(get(API_PREFIX_V1 + "/products/" + product.getId() + "/scenes")
+                .param("date", "2019-10-11"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", is(equalTo(1))))
+                .andExpect(jsonPath("$[0].footprint", is(equalTo("POLYGON ((18.98189008982064 -36.95919177442794, 74.10811836891402 -36.95919177442794, 74.10811836891402 57.037586807964416, 18.98189008982064 57.037586807964416, 18.98189008982064 -36.95919177442794))"))));
+    }
+
+    @Test
     public void shouldReturnFilteredScenes() throws Exception {
         val product = productRepository.save(productBuilder().build());
 


### PR DESCRIPTION
Move mapping operations to a separate mapper.
Add polygon to SceneResponse, its mapping and a test for correct
operation.

Promote a footprint mapping exception to WARN log call in
AdminSceneMapper, as it's an erroneous behaviour which should be caught.
Use the same log level in new SceneMapper footprint mapping.

Correct the field order in SceneResponse to match with the Scene bean.

Closes: #1022.