### PR TITLE
[#1025] Disable GS-Gateway X-Forwarded headers handling

### DIFF
--- a/gs-gateway/src/main/resources/application.properties
+++ b/gs-gateway/src/main/resources/application.properties
@@ -1,4 +1,7 @@
 gateway.allowed-params=SERVICE,VERSION,REQUEST,LAYERS,BBOX,WIDTH,HEIGHT,CRS,SRS,FORMAT,TIME,TRANSPARENT,TILED
 
+# GS-Gateway is to be deployed behind an other proxy server, so it should leave the X-Forwarded headers the same.
+spring.cloud.gateway.x-forwarded.enabled=false
+
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoints.jmx.exposure.include=

--- a/s4e-web/nginx-e2e.conf
+++ b/s4e-web/nginx-e2e.conf
@@ -26,6 +26,7 @@ http {
         location /api/v1 {
             proxy_pass http://s4e-backend-e2e:4201/api/v1;
             proxy_set_header X-Forwarded-Host $host:443;
+            proxy_set_header X-Forwarded-Proto https;
         }
 
         location /static {
@@ -34,6 +35,8 @@ http {
 
         location /wms {
             proxy_pass http://gs-gateway-test:8090/geoserver/wms;
+            proxy_set_header X-Forwarded-Host $host:443;
+            proxy_set_header X-Forwarded-Proto https;
         }
     }
 }

--- a/s4e-web/nginx.conf
+++ b/s4e-web/nginx.conf
@@ -26,6 +26,7 @@ http {
         location /api/v1 {
             proxy_pass http://s4e-backend:4201/api/v1;
             proxy_set_header X-Forwarded-Host $host:443;
+            proxy_set_header X-Forwarded-Proto https;
         }
 
         location /static {
@@ -38,6 +39,8 @@ http {
 
         location /wms {
             proxy_pass http://gs-gateway:8090/geoserver/wms;
+            proxy_set_header X-Forwarded-Host $host:443;
+            proxy_set_header X-Forwarded-Proto https;
         }
     }
 }


### PR DESCRIPTION
The spring-cloud-gateway by default appends the domains on the path, but
GeoServer doesn't handle multi-valued headers, leading to bad domain,
e.g. `<outside-domain>:443,gs-gateway:8090` instead of just
`<outside-domain>:443`.

Closes: #1025.