### PR TITLE
[#1030] Allow resending password reset token

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/PasswordResetRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/PasswordResetRepository.java
@@ -10,6 +10,4 @@ import java.util.Optional;
 public interface PasswordResetRepository extends CrudRepository<PasswordReset, Long> {
     Optional<PasswordReset> findByToken(String token);
     Optional<PasswordReset> findByAppUserEmail(String email);
-    @Transactional
-    void deleteByAppUserEmail(String email);
 }


### PR DESCRIPTION
Don't remove a ResetPassword if it exists on re-request.

Fixes: #1030.