### PR TITLE
[#1034] Homogenize lat/long order

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/admin/scene/AdminSceneMapper.java
@@ -25,12 +25,12 @@ public abstract class AdminSceneMapper {
 
         val footprintPart = new AdminSceneResponse.FootprintPart();
 
-        footprintPart.setEpsg3857(geometry3857.toText());
+        footprintPart.setEpsg3857(geometryUtil.toWkt(geometry3857));
         try {
             Geometry geometry4326 = geometryUtil.transform(geometry3857, "EPSG:3857", "EPSG:4326");
-            footprintPart.setEpsg4326(geometry4326.toText());
+            footprintPart.setEpsg4326(geometryUtil.toWkt(geometry4326));
         } catch (FactoryException | TransformException e) {
-            log.warn("Cannot transform geometry to EPSG:4326: '" + geometry3857.toText() + "'", e);
+            log.warn("Cannot transform geometry to EPSG:4326: '" + geometryUtil.toWkt(geometry3857) + "'", e);
         }
 
         return footprintPart;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/api/SearchApiParams.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/api/SearchApiParams.java
@@ -29,7 +29,7 @@ public class SearchApiParams {
 
     public static final String CLOUD_COVER_PERCENTAGE = "cloudcoveragepercentage";
 
-    public static final String getQueryParam(String param) {
+    public static String getQueryParam(String param) {
         switch (param) {
             case SENSING_START:
             case SENSING_END:

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/mapper/SceneMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/mapper/SceneMapper.java
@@ -50,7 +50,8 @@ public abstract class SceneMapper {
 
     protected String mapTo4326Wkt(Geometry footprint) {
         try {
-            return geometryUtil.transform(footprint, "EPSG:3857", "EPSG:4326").toText();
+            Geometry geometry4326 = geometryUtil.transform(footprint, "EPSG:3857", "EPSG:4326");
+            return geometryUtil.toWkt(geometry4326);
         } catch (FactoryException | TransformException e) {
             log.warn("Cannot transform geometry to EPSG:4326: '" + footprint + "'", e);
             return null;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderImpl.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderImpl.java
@@ -15,7 +15,7 @@ public class QueryBuilderImpl implements QueryBuilder {
         columns.add(Scene.COLUMN_ID);
         columns.add(Scene.COLUMN_PRODUCT_ID);
         columns.add(Scene.COLUMN_SCENE_KEY);
-        columns.add("ST_AsText(ST_Transform(" + Scene.COLUMN_FOOTPRINT + ",4326)) AS footprint");
+        columns.add("ST_AsText(ST_Transform(" + Scene.COLUMN_FOOTPRINT + ",4326),5) AS footprint");
         columns.add(Scene.COLUMN_METADATA);
         columns.add(Scene.COLUMN_CONTENT);
         columns.add(Scene.COLUMN_TIMESTAMP);

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/TestGeometryHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/TestGeometryHelper.java
@@ -21,9 +21,9 @@ public class TestGeometryHelper {
         WKTReader reader = new WKTReader(factory);
         Geometry polygon = null;
         try {
-            // 108m
-            // lat/long
-            polygon = reader.read("POLYGON((18.981890089820652 -36.95919177442794,74.10811836891402 -36.95919177442794,74.10811836891402 57.037586807964416,18.981890089820652 57.037586807964416,18.981890089820652 -36.95919177442794))");
+            // Here we specifically use long/lat, as the JTS expects the EPSG:4326 coords to be in that order,
+            // and it swaps the coords when transforming to EPSG:3857.
+            polygon = reader.read("POLYGON((55 12.6,55.25 19,55 26,47.55 24.93,47.67 19,47.5 14,55 12.6))");
             polygon = transform(polygon, "EPSG:4326", "EPSG:3857");
         } catch (ParseException | FactoryException | TransformException e) {
             log.warn("Unexpected", e);

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/api/OSearchControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/api/OSearchControllerTest.java
@@ -161,37 +161,37 @@ public class OSearchControllerTest {
         @Test
         public void shouldReturnScenesDhusQueryByTime() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(beginposition:[2019-11-09T00:00:00.000000+00:00 TO 2019-11-12T00:00:00.000000+00:00])")
+                    .param("q", "beginposition:[2019-11-09T00:00:00.000000+00:00 TO 2019-11-12T00:00:00.000000+00:00]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(3))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(endposition:[2019-11-09T00:00:00.000000+00:00 TO 2019-11-12T00:00:00.000000+00:00])")
+                    .param("q", "endposition:[2019-11-09T00:00:00.000000+00:00 TO 2019-11-12T00:00:00.000000+00:00]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(3))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(ingestiondate:[2019-11-09T00:00:00.000Z TO 2019-11-12T00:00:00.000Z])")
+                    .param("q", "ingestiondate:[2019-11-09T00:00:00.000Z TO 2019-11-12T00:00:00.000Z]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(3))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(endposition:[NOW-24MONTHS TO NOW])")
+                    .param("q", "endposition:[NOW-24MONTHS TO NOW]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(20))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(endposition:[NOW-1DAY TO NOW-1HOUR])")
+                    .param("q", "endposition:[NOW-1DAY TO NOW-1HOUR]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(0))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(endposition:[NOW-5HOURS TO NOW-20MINUTES])")
+                    .param("q", "endposition:[NOW-5HOURS TO NOW-20MINUTES]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(0))));
@@ -200,17 +200,17 @@ public class OSearchControllerTest {
         @Test
         public void shouldntReturnScenesDhusQueryByTime() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(beginposition:[2019-11-09T00:00:00.000000+00:00])")
+                    .param("q", "beginposition:[2019-11-09T00:00:00.000000+00:00]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isBadRequest());
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(beginposition:[2019-11-09T00:00:00.000000+00:00 TO])")
+                    .param("q", "beginposition:[2019-11-09T00:00:00.000000+00:00 TO]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isBadRequest());
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "(beginposition:[ TO 2019-11-12T00:00:00.000000+00:00])")
+                    .param("q", "beginposition:[ TO 2019-11-12T00:00:00.000000+00:00]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isBadRequest());
         }
@@ -233,13 +233,13 @@ public class OSearchControllerTest {
         @Test
         public void shouldReturnScenesDhusQueryFootprintPolygon() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "footprint:\"Intersects(POLYGON((155.90 19.60,156.60 15.70,157.40 16.10,157.34 20.05,155.90 19.60)))\"")
+                    .param("q", "footprint:Intersects(POLYGON((155.90 19.60,156.60 15.70,157.40 16.10,157.34 20.05,155.90 19.60)))")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(0))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "footprint:\"Intersects(POLYGON((55.90 19.60,56.60 15.70,57.40 16.10,57.34 20.05,55.90 19.60)))\"")
+                    .param("q", "footprint:Intersects(POLYGON((12.6 55,19 55.25,26 55,24.93 47.55,19 47.67,14 47.5,12.6 55)))")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(20))));
@@ -248,13 +248,13 @@ public class OSearchControllerTest {
         @Test
         public void shouldReturnScenesDhusQueryFootprintPoint() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "footprint:\"Intersects(55.8000 19.5000)\"")
+                    .param("q", "footprint:Intersects(15 51)")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(20))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "footprint:\"Intersects(76.8000,17.0000)\"")
+                    .param("q", "footprint:Intersects(12 55)")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(0))));
@@ -534,37 +534,37 @@ public class OSearchControllerTest {
         @Test
         public void shouldReturnScenesDhusQueryByTime() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "(beginposition:[2019-11-09T00:00:00.000000+00:00 TO 2019-11-12T00:00:00.000000+00:00])")
+                    .param("q", "beginposition:[2019-11-09T00:00:00.000000+00:00 TO 2019-11-12T00:00:00.000000+00:00]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(3))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "(endposition:[2019-11-09T00:00:00.000000+00:00 TO 2019-11-12T00:00:00.000000+00:00])")
+                    .param("q", "endposition:[2019-11-09T00:00:00.000000+00:00 TO 2019-11-12T00:00:00.000000+00:00]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(3))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "(ingestiondate:[2019-11-09T00:00:00.000Z TO 2019-11-12T00:00:00.000Z])")
+                    .param("q", "ingestiondate:[2019-11-09T00:00:00.000Z TO 2019-11-12T00:00:00.000Z]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(3))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "(endposition:[NOW-24MONTHS TO NOW])")
+                    .param("q", "endposition:[NOW-24MONTHS TO NOW]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(30))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "(endposition:[NOW-1DAY TO NOW-1HOUR])")
+                    .param("q", "endposition:[NOW-1DAY TO NOW-1HOUR]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(0))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "(endposition:[NOW-5HOURS TO NOW-20MINUTES])")
+                    .param("q", "endposition:[NOW-5HOURS TO NOW-20MINUTES]")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(0))));
@@ -588,13 +588,13 @@ public class OSearchControllerTest {
         @Test
         public void shouldReturnScenesDhusQueryFootprintPolygon() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "footprint:\"Intersects(POLYGON((155.90 19.60,156.60 15.70,157.40 16.10,157.34 20.05,155.90 19.60)))\"")
+                    .param("q", "footprint:Intersects(POLYGON((155.90 19.60,156.60 15.70,157.40 16.10,157.34 20.05,155.90 19.60)))")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(0))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "footprint:\"Intersects(POLYGON((55.90 19.60,56.60 15.70,57.40 16.10,57.34 20.05,55.90 19.60)))\"")
+                    .param("q", "footprint:Intersects(POLYGON((12.6 55,19 55.25,26 55,24.93 47.55,19 47.67,14 47.5,12.6 55)))")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(30))));
@@ -603,13 +603,13 @@ public class OSearchControllerTest {
         @Test
         public void shouldReturnScenesDhusQueryFootprintPoint() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "footprint:\"Intersects(55.8000 19.5000)\"")
+                    .param("q", "footprint:Intersects(15 51)")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(30))));
 
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "footprint:\"Intersects(76.8000,17.0000)\"")
+                    .param("q", "footprint:Intersects(12 55)")
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(0))));

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SceneControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SceneControllerTest.java
@@ -113,7 +113,7 @@ public class SceneControllerTest {
                 .param("date", "2019-10-11"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()", is(equalTo(1))))
-                .andExpect(jsonPath("$[0].footprint", is(equalTo("POLYGON ((18.98189008982064 -36.95919177442794, 74.10811836891402 -36.95919177442794, 74.10811836891402 57.037586807964416, 18.98189008982064 57.037586807964416, 18.98189008982064 -36.95919177442794))"))));
+                .andExpect(jsonPath("$[0].footprint", is(equalTo("POLYGON((12.60000 55.00000,19.00000 55.25000,26.00000 55.00000,24.93000 47.55000,19.00000 47.67000,14.00000 47.50000,12.60000 55.00000))"))));
     }
 
     @Test

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderTest.java
@@ -45,7 +45,7 @@ public class QueryBuilderTest {
         params.put("ingestionTo", "2019-11-12T00:00:00.000000+00:00");
         StringBuilder resultQuery = new StringBuilder();
         StringBuilder query = new StringBuilder();
-        query.append("SELECT id,product_id,scene_key,ST_AsText(ST_Transform(footprint,4326)) AS footprint,");
+        query.append("SELECT id,product_id,scene_key,ST_AsText(ST_Transform(footprint,4326),5) AS footprint,");
         query.append("metadata_content,scene_content,timestamp ");
         query.append("FROM Scene WHERE true  ");
         query.append("AND to_timestamp(metadata_content->>'sensing_time', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') >= ?  ");
@@ -68,7 +68,7 @@ public class QueryBuilderTest {
         StringBuilder resultQuery = new StringBuilder();
         StringBuilder query = new StringBuilder();
         query.append("SELECT id,product_id,scene_key,");
-        query.append("ST_AsText(ST_Transform(footprint,4326)) AS footprint,");
+        query.append("ST_AsText(ST_Transform(footprint,4326),5) AS footprint,");
         query.append("metadata_content,scene_content,timestamp ");
         query.append("FROM Scene ");
         query.append("WHERE true  ORDER BY id DESC LIMIT ?  OFFSET ? ;");

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorIntegrationTest.java
@@ -2,11 +2,16 @@ package pl.cyfronet.s4e.sync;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.operation.TransformException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 import pl.cyfronet.s4e.IntegrationTest;
 import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.bean.Scene;
 import pl.cyfronet.s4e.data.repository.SceneRepository;
+import pl.cyfronet.s4e.util.GeometryUtil;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,13 +35,16 @@ class SceneAcceptorIntegrationTest {
     @Autowired
     private TestDbHelper testDbHelper;
 
+    @Autowired
+    private GeometryUtil geometryUtil;
+
     @BeforeEach
     public void beforeEach() {
         testDbHelper.clean();
     }
 
     @Test
-    public void test() {
+    public void test() throws FactoryException, TransformException {
         Long productId = sceneAcceptorTestHelper.setUpProduct();
 
         assertThat(sceneRepository.count(), is(equalTo(0L)));
@@ -44,5 +52,11 @@ class SceneAcceptorIntegrationTest {
         sceneAcceptor.accept(SCENE_KEY);
 
         await().until(() -> sceneRepository.findAllByProductId(productId), hasSize(greaterThan(0)));
+
+        Scene scene = sceneRepository.findBySceneKey(SCENE_KEY).get();
+        Geometry footprint3857 = scene.getFootprint();
+        assertThat(footprint3857.toText(), is(equalTo("POLYGON ((2621616.6435465664 7481577.552185162, 2163180.3826032346 7564446.906756013, 2209931.229151686 7867684.010797335, 2686569.228715135 7780420.14854482, 2621616.6435465664 7481577.552185162))")));
+        Geometry footprint4326 = geometryUtil.transform(footprint3857, "EPSG:3857", "EPSG:4326");
+        assertThat(footprint4326.toText(), is(equalTo("POLYGON ((55.612087 23.550383, 56.030285000000006 19.43218, 57.522560000000006 19.85215, 57.099194 24.133862, 55.612087 23.550383))")));
     }
 }

--- a/s4e-web/src/app/views/apihowto/apihowto.component.html
+++ b/s4e-web/src/app/views/apihowto/apihowto.component.html
@@ -93,10 +93,10 @@
     <li>sensoroperationalmode → np. sensoroperationalmode:IW</li>
     <li>orbitnumber / lastorbitnumber → np. orbitnumber:22 czy lastorbitnumber:22</li>
     <li>relativeorbitnumber / lastrelativeorbitnumber  → np. relativeorbitnumber:22 czy lastrelativeorbitnumber:22</li>
-    <li>footprint
+    <li>footprint (koordynaty są zawsze w kolejności: długość i szerokość geograficzna)
       <ul>
-        <li>POINT → np. footprint:"Intersects(55.8000 19.5000)"</li>
-        <li>POLYGON → np. footprint:"Intersects(POLYGON((55.90 19.60,56.60 15.70,57.40 16.10,57.34 20.05,55.90 19.60)))"</li>
+        <li>POINT → np. footprint:"Intersects(19.5000 55.8000)"</li>
+        <li>POLYGON → np. footprint:"Intersects(POLYGON((19.60 55.90,15.70 56.60,16.10 57.40,20.05 57.34,19.60 55.90)))"</li>
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
In endpoints always return and require coordinates in EPSG:4326 lat/long
order.
Update apihowto to include this.

Internally, leave long/lat in some cases (metadata for example).

Always return coordinates with 5 significant digits: it corresponds to
around 1m of precision, which is more than necessary in our case.

Improve parsing of geometry params in OSearch API.

Fixes: #1034.