### PR TITLE
[#1043] Use current connection when executing scene search requests

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRowMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SceneRowMapper.java
@@ -9,7 +9,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 @RequiredArgsConstructor
-public class SceneRowMapper implements RowMapper {
+public class SceneRowMapper implements RowMapper<MappedScene> {
     @Override
     public MappedScene mapRow(ResultSet rs, int i) throws SQLException {
         return MappedScene.builder()

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/PreparedStatementBuilder.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/PreparedStatementBuilder.java
@@ -16,6 +16,10 @@ import java.util.Map;
 @Slf4j
 @RequiredArgsConstructor
 public class PreparedStatementBuilder {
+    public interface PrepareStatement {
+        PreparedStatement prepare(Connection connection, Map<String, Object> params) throws SQLException, QueryException;
+    }
+
     private final QueryBuilder queryBuilder;
 
     public PreparedStatement preparedStatement(Connection connection,


### PR DESCRIPTION
A checked exception cannot be thrown from a PreparedStatementBuilder, so
I wrap a QueryException in IAE, and unwrap it later on.

Fixes: #1043.