### PR TITLE
[#716] Remove sentry.properties and correct log timestamp pattern

### DIFF
--- a/gs-gateway/src/main/resources/logback.xml
+++ b/gs-gateway/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
     <!-- Configure the Console appender -->
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/gs-gateway/src/main/resources/sentry.properties
+++ b/gs-gateway/src/main/resources/sentry.properties
@@ -1,1 +1,0 @@
-dsn=<link with token>

--- a/s4e-backend/src/main/resources/logback.xml
+++ b/s4e-backend/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
     <!-- Configure the Console appender -->
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/s4e-backend/src/main/resources/sentry.properties
+++ b/s4e-backend/src/main/resources/sentry.properties
@@ -1,1 +1,0 @@
-dsn=<link with token>


### PR DESCRIPTION
The sentry.properties files are not necessary, and only generate
stacktraces in runtime. If removed, Sentry issues a log entry at WARN
level anyway.

Set a logback timestamp pattern which complies with ISO8601, see e.g. SO
https://stackoverflow.com/a/23096247/1778478 for more info (beware
though, as there's an error in this SO answer - the fraction of a
second should be dot (.) and not comma (,) delimited).

Fixes: #716.