### PR TITLE
[#1039] Search based on Product.name instead of metadata.product_type

### DIFF
--- a/s4e-backend/seed-configs/seed-1/products.json
+++ b/s4e-backend/seed-configs/seed-1/products.json
@@ -16,7 +16,6 @@
   {
     "name": "Sentinel-1-GRDM",
     "displayName": "Sentinel 1 GRDM",
-
     "description": "Dane z przyrządu SAR satelitów Sentinel-1, w trybie skanowania EW (Extra Wide),typu GRD (Ground Range Detected).",
     "accessType": "OPEN",
     "layerName": "sentinel_1_grdm",

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/QueryConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/QueryConfig.java
@@ -17,10 +17,14 @@
 
 package pl.cyfronet.s4e.config;
 
+import lombok.val;
 import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import pl.cyfronet.s4e.data.repository.query.*;
+
+import java.util.List;
+import java.util.function.Function;
 
 @Configuration
 public class QueryConfig {
@@ -37,14 +41,22 @@ public class QueryConfig {
 
     @Bean
     public QueryBuilder queryBuilder() {
+        QueryBuilder queryBuilder = new QueryBuilderImpl();
+        List<Function<QueryBuilder, QueryBuilder>> constructors = List.of(
+                QueryProductType::new,
+                QueryTime::new,
+                QueryGeometry::new,
+                QueryText::new,
+                QueryNumber::new
+        );
+        for (val constructor : constructors) {
+            queryBuilder = constructor.apply(queryBuilder);
+        }
         return new QueryEnding(
-                new QueryNumber(
-                        new QueryText(
-                                new QueryGeometry(
-                                        new QueryTime(new QueryBuilderImpl())
-                                )
-                        )
-                ), springDataWebProperties
+                queryBuilder,
+                springDataWebProperties.getPageable().getMaxPageSize(),
+                springDataWebProperties.getPageable().getDefaultPageSize(),
+                0
         );
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderImpl.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderImpl.java
@@ -17,6 +17,7 @@
 
 package pl.cyfronet.s4e.data.repository.query;
 
+import lombok.val;
 import org.springframework.validation.Errors;
 import pl.cyfronet.s4e.bean.Scene;
 
@@ -25,31 +26,40 @@ import java.util.List;
 import java.util.Map;
 
 public class QueryBuilderImpl implements QueryBuilder {
-    private List<String> columns;
-
-    public QueryBuilderImpl() {
-        columns = new ArrayList<>();
-        columns.add(Scene.COLUMN_ID);
+    private static final String SELECT_QUERY_PREFIX;
+    private static final String COUNT_QUERY_PREFIX = "SELECT COUNT(*) FROM scene JOIN product ON scene.product_id = product.id WHERE true ";
+    static {
+        val columns = new ArrayList<String>();
+        columns.add("scene." + Scene.COLUMN_ID);
         columns.add(Scene.COLUMN_PRODUCT_ID);
         columns.add(Scene.COLUMN_SCENE_KEY);
         columns.add("ST_AsText(ST_Transform(" + Scene.COLUMN_FOOTPRINT + ",4326),5) AS footprint");
         columns.add(Scene.COLUMN_METADATA);
         columns.add(Scene.COLUMN_CONTENT);
         columns.add(Scene.COLUMN_TIMESTAMP);
+        SELECT_QUERY_PREFIX =
+                "SELECT " +
+                String.join(", ", columns) +
+                " FROM scene JOIN product ON scene.product_id = product.id WHERE true";
     }
 
     @Override
-    public void prepareQueryAndParameters(Map<String, Object> params,
-                                          List<Object> parameters,
-                                          StringBuilder resultQuery,
-                                          Errors errors) {
-        resultQuery.append("SELECT ");
-        resultQuery.append(String.join(",", columns));
-        resultQuery.append(" FROM Scene WHERE true ");
+    public void prepareQueryAndParameters(
+            Map<String, Object> params,
+            List<Object> parameters,
+            StringBuilder resultQuery,
+            Errors errors
+    ) {
+        resultQuery.append(SELECT_QUERY_PREFIX);
     }
 
     @Override
-    public void prepareCountQueryAndParameters(Map<String, Object> params, List<Object> parameters, StringBuilder resultQuery, Errors errors) {
-        resultQuery.append("SELECT COUNT(*) FROM Scene WHERE true ");
+    public void prepareCountQueryAndParameters(
+            Map<String, Object> params,
+            List<Object> parameters,
+            StringBuilder resultQuery,
+            Errors errors
+    ) {
+        resultQuery.append(COUNT_QUERY_PREFIX);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryDecorator.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import java.util.Map;
 
 @RequiredArgsConstructor
 public abstract class QueryDecorator implements QueryBuilder {
-    public static final String DATE_FORMAT = "YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"";
     private final QueryBuilder queryBuilder;
 
     protected abstract void doPrepareQueryAndParameters(Map<String, Object> params,

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryGeometry.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryGeometry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,11 +43,12 @@ public class QueryGeometry extends QueryDecorator {
                                 StringBuilder resultQuery) {
         if (params.containsKey(FOOTPRINT)) {
 
-            resultQuery.append(" AND ST_Intersects(footprint, " +
-                    "ST_Transform(" +
-                    "ST_GeomFromText(?, "
-                    + GeometryUtil.FACTORY_4326.getSRID() + "), "
-                    + GeometryUtil.FACTORY_3857.getSRID() + "))");
+            resultQuery
+                    .append(" AND ST_Intersects(footprint, ST_Transform(ST_GeomFromText(?, ")
+                    .append(GeometryUtil.FACTORY_4326.getSRID())
+                    .append("), ")
+                    .append(GeometryUtil.FACTORY_3857.getSRID())
+                    .append("))");
             parameters.add(String.valueOf(params.get(FOOTPRINT)));
         }
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryNumber.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryNumber.java
@@ -45,7 +45,7 @@ public class QueryNumber extends QueryDecorator {
                                    StringBuilder resultQuery,
                                    Errors errors) {
         if (params.containsKey(CLOUD_COVER)) {
-            resultQuery.append(" AND (metadata_content ->> 'cloud_cover')::float <= ? ");
+            resultQuery.append(" AND (metadata_content ->> 'cloud_cover')::float <= ?");
             parameters.add(getCloudCover(params, errors));
         }
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryProductType.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryProductType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.data.repository.query;
+
+import org.springframework.validation.Errors;
+
+import java.util.List;
+import java.util.Map;
+
+import static pl.cyfronet.s4e.search.SearchQueryParams.PRODUCT_TYPE;
+
+public class QueryProductType extends QueryDecorator {
+    public QueryProductType(QueryBuilder queryBuilder) {
+        super(queryBuilder);
+    }
+
+    @Override
+    public void doPrepareQueryAndParameters(Map<String, Object> params,
+                                            List<Object> parameters,
+                                            StringBuilder resultQuery,
+                                            Errors errors) {
+        Object paramValue = params.get(PRODUCT_TYPE);
+        if (paramValue instanceof String) {
+            resultQuery.append(" AND product.name = ?");
+            parameters.add(paramValue);
+        }
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryText.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryText.java
@@ -32,7 +32,6 @@ public class QueryText extends QueryDecorator {
         super(queryBuilder);
         paramsToDBField = new LinkedHashMap<>();
         paramsToDBField.put(SATELLITE_PLATFORM, "spacecraft");
-        paramsToDBField.put(PRODUCT_TYPE, "product_type");
         paramsToDBField.put(POLARISATION, "polarisation");
         paramsToDBField.put(PROCESSING_LEVEL, "processing_level");
         paramsToDBField.put(SENSOR_MODE, "sensor_mode");
@@ -57,7 +56,7 @@ public class QueryText extends QueryDecorator {
                          List<Object> parameters,
                          StringBuilder resultQuery) {
         if (params.containsKey(entry.getKey())) {
-            resultQuery.append(" AND metadata_content->>'" + entry.getValue() + "' = ? ");
+            resultQuery.append(" AND metadata_content->>'").append(entry.getValue()).append("' = ?");
             if (params.containsKey(POLARISATION)) {
                 parameters.add(parsePolarisation(String.valueOf(params.get(entry.getKey()))));
             } else {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryTime.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/query/QueryTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,11 +50,11 @@ public class QueryTime extends QueryDecorator {
                                     Errors errors) {
         // [TIMESTAMP] sensingFrom / sensingTo -> sensing_time
         if (params.containsKey(SENSING_FROM)) {
-            resultQuery.append(" AND " + getMetadataTime("sensing_time") + " >= ? ");
+            resultQuery.append(" AND ").append(getMetadataTime("sensing_time")).append(" >= ?");
             parameters.add(parseDateToServerLocalDate(params, SENSING_FROM, errors));
         }
         if (params.containsKey(SENSING_TO)) {
-            resultQuery.append(" AND " + getMetadataTime("sensing_time") + " <= ? ");
+            resultQuery.append(" AND ").append(getMetadataTime("sensing_time")).append(" <= ?");
             parameters.add(parseDateToServerLocalDate(params, SENSING_TO, errors));
         }
     }
@@ -65,17 +65,17 @@ public class QueryTime extends QueryDecorator {
                                       Errors errors) {
         // [TIMESTAMP] ingestionFrom / ingestionTo -> ingestion_time
         if (params.containsKey(INGESTION_FROM)) {
-            resultQuery.append(" AND " + getMetadataTime("ingestion_time") + " >= ? ");
+            resultQuery.append(" AND ").append(getMetadataTime("ingestion_time")).append(" >= ?");
             parameters.add(parseDateToServerLocalDate(params, INGESTION_FROM, errors));
         }
         if (params.containsKey(INGESTION_TO)) {
-            resultQuery.append(" AND " + getMetadataTime("ingestion_time") + " <= ? ");
+            resultQuery.append(" AND ").append(getMetadataTime("ingestion_time")).append(" <= ?");
             parameters.add(parseDateToServerLocalDate(params, INGESTION_TO, errors));
         }
     }
 
     private String getMetadataTime(String timeParameter) {
-        return "to_timestamp(metadata_content->>'" + timeParameter + "', '" + DATE_FORMAT + "')";
+        return "f_cast_isots(metadata_content->>'" + timeParameter + "')";
     }
 
     private LocalDateTime parseDateToServerLocalDate(Map<String, Object> params, String param, Errors errors) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/search/SentinelSearchConfigSupplier.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/search/SentinelSearchConfigSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class SentinelSearchConfigSupplier implements Supplier<SentinelSearchConf
             List.of(
                     new Section("sentinel-1", List.of(
                             new SelectParam(SATELLITE_PLATFORM, List.of("Sentinel-1A", "Sentinel-1B")),
-                            new SelectParam(PRODUCT_TYPE, List.of("", "GRDM", "GRDH", "SLC_")),
+                            new SelectParam(PRODUCT_TYPE, List.of("", "Sentinel-1-GRDM", "Sentinel-1-GRDH", "Sentinel-1-SLC_")),
                             new SelectParam(PROCESSING_LEVEL, List.of("", "1", "2")),
                             new SelectParam(POLARISATION, List.of("", "HH", "VV", "HV", "VH", "HH+HV", "VV+VH")),
                             new SelectParam(SENSOR_MODE, List.of("", "SM", "IW", "EW", "WV")),

--- a/s4e-backend/src/main/resources/db/migration/V66__drop_idx_product_type.sql
+++ b/s4e-backend/src/main/resources/db/migration/V66__drop_idx_product_type.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_product_type;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/api/OSearchControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/api/OSearchControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,13 +72,14 @@ public class OSearchControllerTest {
     @Autowired
     private MockMvc mockMvc;
     private AppUser appUser;
+    private Product product;
 
     @BeforeEach
     public void setUp() throws Exception {
         reset(s3Presigner);
         testDbHelper.clean();
         //add product
-        Product product = productRepository.save(productBuilder().build());
+        product = productRepository.save(productBuilder().build());
         //addscenewithmetadata
         List<Scene> scenes = new ArrayList<>();
         for (long j = 0; j < 30; j++) {
@@ -416,7 +417,7 @@ public class OSearchControllerTest {
         @Test
         public void shouldReturnScenesDhusQueryProductType() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search")
-                    .param("q", "producttype:GRDH")
+                    .param("q", "producttype:" + product.getName())
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(20))));
@@ -751,7 +752,7 @@ public class OSearchControllerTest {
         @Test
         public void shouldReturnScenesDhusQueryProductType() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/dhus/search/count")
-                    .param("q", "producttype:GRDH")
+                    .param("q", "producttype:" + product.getName())
                     .with(jwtBearerToken(appUser, objectMapper)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(30))));

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SearchControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SearchControllerTest.java
@@ -200,7 +200,7 @@ public class SearchControllerTest {
         @Test
         public void shouldGetSceneByProductType() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/search")
-                    .param("productType", "GRDH")
+                    .param("productType", product.getName())
                     .param("limit", "30"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.length()", is(equalTo(30))))
@@ -367,7 +367,7 @@ public class SearchControllerTest {
         @Test
         public void shouldGetSceneByProductType() throws Exception {
             mockMvc.perform(get(API_PREFIX_V1 + "/search/count")
-                    .param("productType", "GRDH")
+                    .param("productType", product.getName())
                     .param("limit", "30"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", is(equalTo(30))))

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/data/repository/query/QueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,20 +61,24 @@ public class QueryBuilderTest {
         params.put("ingestionFrom", "2019-11-09T00:00:00.000000+00:00");
         params.put("ingestionTo", "2019-11-12T00:00:00.000000+00:00");
         StringBuilder resultQuery = new StringBuilder();
-        StringBuilder query = new StringBuilder();
-        query.append("SELECT id,product_id,scene_key,ST_AsText(ST_Transform(footprint,4326),5) AS footprint,");
-        query.append("metadata_content,scene_content,timestamp ");
-        query.append("FROM Scene WHERE true  ");
-        query.append("AND to_timestamp(metadata_content->>'sensing_time', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') >= ?  ");
-        query.append("AND to_timestamp(metadata_content->>'sensing_time', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') <= ?  ");
-        query.append("AND to_timestamp(metadata_content->>'ingestion_time', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') >= ?  ");
-        query.append("AND to_timestamp(metadata_content->>'ingestion_time', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') <= ?  ");
-        query.append("AND metadata_content->>'spacecraft' = ?  AND metadata_content->>'product_type' = ?  ");
-        query.append("AND metadata_content->>'polarisation' = ?  AND metadata_content->>'processing_level' = ?  ");
-        query.append("AND metadata_content->>'relative_orbit_number' = ?  ");
-        query.append("AND (metadata_content ->> 'cloud_cover')::float <= ?  ORDER BY id DESC LIMIT ?  OFFSET ? ;");
         queryBuilder.prepareQueryAndParameters(params, parameters, resultQuery, errors);
-        assertThat(resultQuery.toString(), is(equalTo(query.toString())));
+        String query = "SELECT " +
+                "scene.id, product_id, scene_key, ST_AsText(ST_Transform(footprint,4326),5) AS footprint, " +
+                "metadata_content, scene_content, timestamp " +
+                "FROM scene JOIN product ON scene.product_id = product.id " +
+                "WHERE true " +
+                "AND product.name = ? " +
+                "AND f_cast_isots(metadata_content->>'sensing_time') >= ? " +
+                "AND f_cast_isots(metadata_content->>'sensing_time') <= ? " +
+                "AND f_cast_isots(metadata_content->>'ingestion_time') >= ? " +
+                "AND f_cast_isots(metadata_content->>'ingestion_time') <= ? " +
+                "AND metadata_content->>'spacecraft' = ? " +
+                "AND metadata_content->>'polarisation' = ? " +
+                "AND metadata_content->>'processing_level' = ? " +
+                "AND metadata_content->>'relative_orbit_number' = ? " +
+                "AND (metadata_content ->> 'cloud_cover')::float <= ? " +
+                "ORDER BY id DESC LIMIT ? OFFSET ?;";
+        assertThat(resultQuery.toString(), is(equalTo(query)));
     }
 
     @Test
@@ -83,14 +87,13 @@ public class QueryBuilderTest {
         List<Object> parameters = new ArrayList<>();
         Map<String, Object> params = new HashMap<>();
         StringBuilder resultQuery = new StringBuilder();
-        StringBuilder query = new StringBuilder();
-        query.append("SELECT id,product_id,scene_key,");
-        query.append("ST_AsText(ST_Transform(footprint,4326),5) AS footprint,");
-        query.append("metadata_content,scene_content,timestamp ");
-        query.append("FROM Scene ");
-        query.append("WHERE true  ORDER BY id DESC LIMIT ?  OFFSET ? ;");
         queryBuilder.prepareQueryAndParameters(params, parameters, resultQuery, errors);
-        assertThat(resultQuery.toString(), is(equalTo(query.toString())));
+        String query = "SELECT " +
+                "scene.id, product_id, scene_key, ST_AsText(ST_Transform(footprint,4326),5) AS footprint, " +
+                "metadata_content, scene_content, timestamp " +
+                "FROM scene JOIN product ON scene.product_id = product.id " +
+                "WHERE true ORDER BY id DESC LIMIT ? OFFSET ?;";
+        assertThat(resultQuery.toString(), is(equalTo(query)));
     }
 
     @Test

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/SearchServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/SearchServiceTest.java
@@ -60,11 +60,13 @@ public class SearchServiceTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    private Product product;
+
     @BeforeEach
     public void setUp() throws Exception {
         testDbHelper.clean();
         //add product
-        Product product = productRepository.save(productBuilder().build());
+        product = productRepository.save(productBuilder().build());
         //addscenewithmetadata
         List<Scene> scenes = new ArrayList<>();
         for (long j = 0; j < 10; j++) {
@@ -116,7 +118,7 @@ public class SearchServiceTest {
     @Test
     public void testQueryByProductType() throws Exception {
         Map<String, Object> params = new HashMap<>();
-        params.put("productType", "GRDH");
+        params.put("productType", product.getName());
         List<MappedScene> scenes = searchService.getScenesBy(params);
         assertThat(scenes, hasSize(10));
     }
@@ -223,7 +225,7 @@ public class SearchServiceTest {
         params.put("processingLevel", "2LC");
         params.put("cloudCover", 20);
         params.put("polarisation", "VV VH");
-        params.put("productType", "GRDH");
+        params.put("productType", product.getName());
         params.put("satellitePlatform", "Sentinel-1A");
         params.put("sensingFrom", "2019-11-01T00:00:00.000000+00:00");
         params.put("sensingTo", "2019-11-12T00:00:00.000000+00:00");


### PR DESCRIPTION
Switch to using Product.name by modifying the issued query.
Move handling of the parameter from QueryText to a new QueryProductType
class.

Drop the index on metadata_content.product_type, as it's no longer used
in search queries.

Pre-build the static select and count queries in static initializer of
QueryBuilderImpl.

Implement various IDE suggested code improvements.
Consolidate query creation, so that all appended portions start with a
space, in this way there's no need to leave trailing spaces in some
places.

Use f_cast_isots instead of directly using to_timestamp, removing the
duplication of the date format and using the same function which on
which index is created.

Closes: #1039.