### PR TITLE
[#1066] Return 404 if an artifact with zip extension is missing

### DIFF
--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/SceneTestHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/SceneTestHelper.java
@@ -89,12 +89,12 @@ public class SceneTestHelper {
                 .metadataContent(metadataContent);
     }
 
-    public static Scene.SceneBuilder sceneWithMetadataBuilder(Product product, JsonNode jsonNode) {
+    public static Scene.SceneBuilder sceneWithMetadataBuilder(Product product, JsonNode metadataContent) {
         return Scene.builder()
                 .product(product)
                 .sceneKey(nextUnique(SCENE_KEY_PATTERN))
                 .sceneContent(getDefaultSceneContent())
-                .metadataContent(jsonNode)
+                .metadataContent(metadataContent)
                 .footprint(TestGeometryHelper.ANY_POLYGON)
                 .legend(Legend.builder()
                         .type("some_type")
@@ -111,39 +111,43 @@ public class SceneTestHelper {
         return sceneContent;
     }
 
-    public static String getMetaDataWithNumber(long number) {
-        return "{\n" +
-                "   \"spacecraft\": \"Sentinel-1A\",\n" +
-                "   \"product_type\": \"GRDH\",\n" +
-                "   \"sensor_mode\": \"IW\",\n" +
-                "   \"collection\": \"S1B_24AU\",\n" +
-                "   \"timeliness\": \"Near Real Time\",\n" +
-                "   \"instrument\": \"OLCI\",\n" +
-                "   \"product_level\": \"L" + number%10 + "\",\n" +
-                "   \"processing_level\": \"" + number%10 + "LC\",\n" +
-                "   \"cloud_cover\": " + number + ",\n" +
-                "   \"polarisation\": \"Dual VV/VH\",\n" +
-                "   \"sensing_time\": \"2019-11-0" + (number%9 + 1) + "T05:07:42.047432+00:00\",\n" +
-                "   \"ingestion_time\": \"2019-11-0" + (number%9 + 1) + "T05:34:27.000000+00:00\",\n" +
-                "   \"relative_orbit_number\": \"" + number + "\",\n" +
-                "   \"absolute_orbit_number\": \"0" + number + "\",\n" +
-                "   \"polygon\": \"55.975475,19.579060 56.395580,15.414984 57.887905,15.835841 57.462494,20.167494\",\n" +
-                "   \"format\": \"GeoTiff" + number + "\",\n" +
-                "   \"schema\": \"Sentinel-1.metadata.v1.json\"\n" +
-                "}";
+    public static JsonNode getMetadataContentWithNumber(long number) {
+        return OBJECT_MAPPER.createObjectNode()
+                .put("spacecraft", "Sentinel-1A")
+                .put("product_type", "GRDH")
+                .put("sensor_mode", "IW")
+                .put("collection", "S1B_24AU")
+                .put("timeliness", "Near Real Time")
+                .put("instrument", "OLCI")
+                .put("product_level", "L" + number%10)
+                .put("processing_level", number%10 + "LC")
+                .put("cloud_cover", number)
+                .put("polarisation", "Dual VV/VH")
+                .put("sensing_time", "2019-11-0" + (number%9 + 1) + "T05:07:42.047432+00:00")
+                .put("ingestion_time", "2019-11-0" + (number%9 + 1) + "T05:34:27.000000+00:00")
+                .put("relative_orbit_number", "" + number)
+                .put("absolute_orbit_number", "0" + number)
+                .put("polygon", "55.975475,19.579060 56.395580,15.414984 57.887905,15.835841 57.462494,20.167494")
+                .put("format", "GeoTiff" + number)
+                .put("schema", "Sentinel-1.metadata.v1.json");
     }
 
-    public static String getSceneContent(){
-        return " {\"schema\": \"Sentinel-1.scene.v1.json\"," +
-                " \"artifacts\": " +
-                "{\"RGB_16b\": \"/Sentinel-1/GRDH_Products/2020-01-04/S1A_IW_GRDH_1SDV_20200104T160956_20200104T161021_030653_038356_BCD9.RGB.tif\"," +
-                " \"RGBs_8b\": \"/Sentinel-1/GRDH_Products/2020-01-04/S1A_IW_GRDH_1SDV_20200104T160956_20200104T161021_030653_038356_BCD9.RGBs.tif\"," +
-                " \"checksum\": \"/Sentinel-1/GRDH/2020-01-04/S1A_IW_GRDH_1SDV_20200104T160956_20200104T161021_030653_038356_BCD9.SAFE.md5\", " +
-                "\"manifest\": \"/Sentinel-1/GRDH/2020-01-04/S1A_IW_GRDH_1SDV_20200104T160956_20200104T161021_030653_038356_BCD9.manifest.xml\"," +
-                " \"metadata\": \"/Sentinel-1/GRDH/2020-01-04/S1A_IW_GRDH_1SDV_20200104T160956_20200104T161021_030653_038356_BCD9.metadata\", " +
-                "\"quicklook\": \"/Sentinel-1/GRDH/2020-01-04/S1A_IW_GRDH_1SDV_20200104T160956_20200104T161021_030653_038356_BCD9.qlf.tif\"," +
-                " \"product_archive\": \"/Sentinel-1/GRDH/2020-01-04/S1A_IW_GRDH_1SDV_20200104T160956_20200104T161021_030653_038356_BCD9.SAFE.zip\"}, " +
-                "\"product_type\": \"Sentinel-1-GRDH\"} ";
+    public static JsonNode getSceneContent() {
+        String pathMain = "/Sentinel-1/GRDH/2020-01-04/";
+        String pathProducts = "/Sentinel-1/GRDH_Products/2020-01-04/";
+        String name = "S1A_IW_GRDH_1SDV_20200104T160956_20200104T161021_030653_038356_BCD9";
+        return OBJECT_MAPPER.createObjectNode()
+                .put("schema", "Sentinel-1.scene.v1.json")
+                .put("product_type", "Sentinel-1-GRDH")
+                .set("artifacts", OBJECT_MAPPER.createObjectNode()
+                        .put("checksum", pathMain + name + ".SAFE.md5")
+                        .put("manifest", pathMain + name + ".manifest.xml")
+                        .put("metadata", pathMain + name + ".metadata")
+                        .put("quicklook", pathMain + name + ".qlf.tif")
+                        .put("product_archive", pathMain + name + ".SAFE.zip")
+                        .put("RGB_16b", pathProducts + name + ".RGB.tif")
+                        .put("RGBs_8b", pathProducts + name + ".RGBs.tif")
+                );
     }
 
     public static Function<LocalDateTime, Scene> toScene(Product product) {

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/api/ODataControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/api/ODataControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package pl.cyfronet.s4e.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.SneakyThrows;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -88,7 +88,7 @@ public class ODataControllerTest {
         //add product
         Product product = productRepository.save(productBuilder().build());
         //addscenewithmetadata
-        scene = sceneRepository.save(buildScene(product, 0));
+        scene = sceneRepository.save(buildScene(product));
         appUser = appUserRepository.save(AppUser.builder()
                 .email(PROFILE_EMAIL)
                 .name("Get")
@@ -98,19 +98,17 @@ public class ODataControllerTest {
                 .build());
     }
 
-    @SneakyThrows
-    private Scene buildScene(Product product, long number) {
-        JsonNode jsonNode = objectMapper.readTree(SceneTestHelper.getMetaDataWithNumber(number));
-        Scene scene = SceneTestHelper.sceneWithMetadataBuilder(product, jsonNode)
-                .build();
-        scene.setSceneContent(objectMapper.readTree(SceneTestHelper.getSceneContent()));
+    private Scene buildScene(Product product) {
+        JsonNode metadataContent = SceneTestHelper.getMetadataContentWithNumber(0);
+        Scene scene = SceneTestHelper.sceneWithMetadataBuilder(product, metadataContent).build();
+        scene.setSceneContent(SceneTestHelper.getSceneContent());
         return scene;
     }
 
     @Nested
     class Download {
         @Nested
-        class Default {
+        class DefaultZip {
             private static final String DEFAULT_DOWNLOAD_URL_TEMPLATE =
                     API_PREFIX_V1 + "/dhus/odata/v1/Products('{sceneId}')/$value";
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/api/ODataControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/api/ODataControllerTest.java
@@ -139,6 +139,28 @@ public class ODataControllerTest {
                         .with(jwtBearerToken(appUser, objectMapper)))
                         .andExpect(status().isNotFound());
             }
+
+            @Nested
+            class WithMissingZipArtifact {
+                @Autowired
+                private ObjectMapper objectMapper;
+
+                @BeforeEach
+                public void beforeEach() {
+                    JsonNode sceneContentCopy = scene.getSceneContent().deepCopy();
+                    ObjectNode artifacts = (ObjectNode) sceneContentCopy.get("artifacts");
+                    artifacts.remove("product_archive");
+                    scene.setSceneContent(sceneContentCopy);
+                    scene = sceneRepository.save(scene);
+                }
+
+                @Test
+                public void shouldReturn404IfZipArtifactNotFound() throws Exception {
+                    mockMvc.perform(get(DEFAULT_DOWNLOAD_URL_TEMPLATE, scene.getId())
+                            .with(jwtBearerToken(appUser, objectMapper)))
+                            .andExpect(status().isNotFound());
+                }
+            }
         }
 
         @Nested

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/api/OSearchControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/api/OSearchControllerTest.java
@@ -100,11 +100,10 @@ public class OSearchControllerTest {
         testDbHelper.clean();
     }
 
-    private Scene buildScene(Product product, long number) throws Exception {
-        JsonNode jsonNode = objectMapper.readTree(SceneTestHelper.getMetaDataWithNumber(number));
-        Scene scene = SceneTestHelper.sceneWithMetadataBuilder(product, jsonNode)
-                .build();
-        scene.setSceneContent(objectMapper.readTree(SceneTestHelper.getSceneContent()));
+    private Scene buildScene(Product product, long number) {
+        JsonNode metadataContent = SceneTestHelper.getMetadataContentWithNumber(number);
+        Scene scene = SceneTestHelper.sceneWithMetadataBuilder(product, metadataContent).build();
+        scene.setSceneContent(SceneTestHelper.getSceneContent());
         return scene;
     }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SearchControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/SearchControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 package pl.cyfronet.s4e.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +37,10 @@ import pl.cyfronet.s4e.bean.Scene;
 import pl.cyfronet.s4e.data.repository.ProductRepository;
 import pl.cyfronet.s4e.data.repository.SceneRepository;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.*;
@@ -60,13 +62,11 @@ public class SearchControllerTest {
     @Autowired
     private TestDbHelper testDbHelper;
     @Autowired
-    private ObjectMapper objectMapper;
-    @Autowired
     private MockMvc mockMvc;
     Product product;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         testDbHelper.clean();
         //add product
         product = productRepository.save(productBuilder()
@@ -86,11 +86,10 @@ public class SearchControllerTest {
         testDbHelper.clean();
     }
 
-    private Scene buildScene(Product product, long number) throws Exception {
-        JsonNode jsonNode = objectMapper.readTree(SceneTestHelper.getMetaDataWithNumber(number));
-        Scene scene = SceneTestHelper.sceneWithMetadataBuilder(product, jsonNode)
-                .build();
-        scene.setSceneContent(objectMapper.readTree(SceneTestHelper.getSceneContent()));
+    private Scene buildScene(Product product, long number) {
+        JsonNode metadataContent = SceneTestHelper.getMetadataContentWithNumber(number);
+        Scene scene = SceneTestHelper.sceneWithMetadataBuilder(product, metadataContent).build();
+        scene.setSceneContent(SceneTestHelper.getSceneContent());
         return scene;
     }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/SearchServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/SearchServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 package pl.cyfronet.s4e.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,13 +56,10 @@ public class SearchServiceTest {
     @Autowired
     private SearchService searchService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     private Product product;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         testDbHelper.clean();
         //add product
         product = productRepository.save(productBuilder().build());
@@ -81,11 +77,10 @@ public class SearchServiceTest {
         testDbHelper.clean();
     }
 
-    private Scene buildScene(Product product, long number) throws Exception {
-        JsonNode jsonNode = objectMapper.readTree(SceneTestHelper.getMetaDataWithNumber(number));
-        Scene scene = SceneTestHelper.sceneWithMetadataBuilder(product, jsonNode)
-                .build();
-        scene.setSceneContent(objectMapper.readTree(SceneTestHelper.getSceneContent()));
+    private Scene buildScene(Product product, long number) {
+        JsonNode metadataContent = SceneTestHelper.getMetadataContentWithNumber(number);
+        Scene scene = SceneTestHelper.sceneWithMetadataBuilder(product, metadataContent).build();
+        scene.setSceneContent(SceneTestHelper.getSceneContent());
         return scene;
     }
 


### PR DESCRIPTION
Before, a NoSuchElementException was thrown in such case, resulting in
500 status code.

Fixes: #1066.

In a separate commit I refactor the SceneTestHelper to directly create Scene and MetadataContent JsonNodes, so that it's easier to manipulate it in tests later.