### PR TITLE
[#1071] Don't set From header if null in MailService

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/MailService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/MailService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,9 @@ public class MailService {
         try {
             MimeMessage message = javaMailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
-            helper.setFrom(from);
+            if (from != null) {
+                helper.setFrom(from);
+            }
             modifier.modify(helper);
             javaMailSender.send(message);
         } catch (MessagingException e) {


### PR DESCRIPTION
In development profile, this results in a IAE thrown from
MimeMessageHelper::setFrom, so instead refrain from setting the header
in such case.

Fixes: #1071.