### PR TITLE
Dependencies and workflow flavour update - 2021.02

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   draft_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Draft release
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11.0.9
+          java-version: 11.0.10
       - name: Cache web-e2e
         uses: actions/cache@v2
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ name: Test E2E
 on: [push]
 jobs:
   web-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -20,12 +20,6 @@ jobs:
           key: ${{ runner.os }}-web-e2e-${{ hashFiles('**/pom.xml', '**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-web-e2e-
-#       For now, install jq 1.6, as the jq 1.5 provided by ubuntu 18.04 has some bugs. When github updates ubuntu-latest
-#       to 20.04 it will be obsolete.
-      - name: Install jq 1.6
-        run: mkdir bin && curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > bin/jq && chmod u+x bin/jq
-      - name: Add bin to path
-        run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: Maven package
         run: ./mvnw clean package -DskipTests -Dsha1=-${GITHUB_SHA}
       - name: Start containers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Build & Test
 on: [push]
 jobs:
   backend:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -33,7 +33,7 @@ jobs:
         run: docker-compose -f docker-compose-test.yml down
 
   gs-gateway:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -56,7 +56,7 @@ jobs:
         working-directory: gs-gateway
 
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11.0.9
+          java-version: 11.0.10
       - name: Cache backend
         uses: actions/cache@v2
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11.0.9
+          java-version: 11.0.10
       - name: Cache gs-gateway
         uses: actions/cache@v2
         with:
@@ -62,7 +62,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11.0.9
+          java-version: 11.0.10
       - name: Cache web
         uses: actions/cache@v2
         with:

--- a/gs-gateway/Dockerfile
+++ b/gs-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.9-jdk
+FROM openjdk:11.0.10-jdk
 VOLUME /tmp
 ARG DEPENDENCY=target/dependency
 COPY ${DEPENDENCY}/BOOT-INF/lib /app/BOOT-INF/lib

--- a/gs-gateway/pom.xml
+++ b/gs-gateway/pom.xml
@@ -17,7 +17,7 @@
     <description>GeoServer Gateway</description>
 
     <properties>
-        <spring-cloud.version>2020.0.0</spring-cloud.version>
+        <spring-cloud.version>2020.0.1</spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,31 +26,31 @@
         <java.version>11</java.version>
         <maven.compiler.release>11</maven.compiler.release>
 
-        <spring-boot.version>2.4.1</spring-boot.version>
+        <spring-boot.version>2.4.2</spring-boot.version>
 
-        <awssdk.version>2.15.57</awssdk.version>
-        <commonmark.version>0.16.1</commonmark.version>
+        <awssdk.version>2.15.74</awssdk.version>
+        <commonmark.version>0.17.0</commonmark.version>
         <commons-email.version>1.5</commons-email.version>
         <geotools.version>23.2</geotools.version>
-        <greenmail.version>1.6.1</greenmail.version>
+        <greenmail.version>1.6.2</greenmail.version>
         <guava.version>30.1-jre</guava.version>
-        <hibernate-types.version>2.10.1</hibernate-types.version>
+        <hibernate-types.version>2.10.2</hibernate-types.version>
         <jakarta.json-api.version>2.0.0</jakarta.json-api.version>
         <jjwt.version>0.11.2</jjwt.version>
-        <joy.version>2.0.0</joy.version>
+        <joy.version>2.1.0</joy.version>
         <justify.version>3.1.0</justify.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
-        <mapstruct.version>1.4.1.Final</mapstruct.version>
+        <mapstruct.version>1.4.2.Final</mapstruct.version>
         <poiooxml.version>4.1.2</poiooxml.version>
         <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
         <slugify.version>2.4</slugify.version>
-        <springdoc-openapi.version>1.5.2</springdoc-openapi.version>
-        <unirest.version>3.11.09</unirest.version>
-        <bucket4j-starter.version>0.2.0</bucket4j-starter.version>
+        <springdoc-openapi.version>1.5.3</springdoc-openapi.version>
+        <unirest.version>3.11.10</unirest.version>
+        <bucket4j-starter.version>0.3.3</bucket4j-starter.version>
         <!--
         update sentry version only when fid instance is updated
         -->
-        <sentry.version>1.6.3</sentry.version>
+        <sentry.version>1.7.30</sentry.version>
     </properties>
 
     <build>

--- a/s4e-backend/Dockerfile
+++ b/s4e-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.9-jdk-slim
+FROM openjdk:11.0.10-jdk-slim
 
 RUN mkdir /app
 WORKDIR /app

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -267,7 +267,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.atlassian.commonmark</groupId>
+            <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
             <version>${commonmark.version}</version>
         </dependency>


### PR DESCRIPTION
Bump sentry to 1.7.30, although current Sentry suggests 1.7.5.
Judging from sentry-java changelog, minor versions introduced no
breaking changes.

Switch to ubuntu-20.04 flavour as it's being rolled-out to ubuntu-latest
anyway and we could suffer an unexpected update.