### PR TITLE
[#1111] Make LoggingMailSender registration configurable by a property

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/LoggingMailSender.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/LoggingMailSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ package pl.cyfronet.s4e;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.mail.util.MimeMessageParser;
-import org.springframework.context.annotation.Profile;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailParseException;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
@@ -28,8 +28,8 @@ import org.springframework.stereotype.Component;
 
 import javax.mail.internet.MimeMessage;
 
-@Profile("development")
 @Component
+@ConditionalOnProperty(name = "mail.logging-mail-sender.enabled", havingValue = "true")
 @Slf4j
 public class LoggingMailSender extends JavaMailSenderImpl {
     @Override

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/MailProperties.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/properties/MailProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package pl.cyfronet.s4e.properties;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotBlank;
@@ -38,4 +39,16 @@ public class MailProperties {
     @NotBlank
     @Pattern(regexp = "https?://[^/]+")
     private String urlDomain;
+
+    @NestedConfigurationProperty
+    private LoggingMailSender loggingMailSender = new LoggingMailSender();
+
+    @Getter
+    @Setter
+    public static class LoggingMailSender {
+        /**
+         * Whether to register LoggingMailSender bean.
+         */
+        private Boolean enabled = false;
+    }
 }

--- a/s4e-backend/src/main/resources/application-development.properties
+++ b/s4e-backend/src/main/resources/application-development.properties
@@ -34,6 +34,7 @@ recaptcha.validation.secretKey=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 recaptcha.validation.siteKey=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 
 mail.urlDomain=https://localhost:4200
+mail.logging-mail-sender.enabled=true
 
 jwt.key-store=dev_key.p12
 jwt.key-store-password=dev_password


### PR DESCRIPTION
The property is named: `mail.logging-mail-sender.enable`, and by default
it is set to false (only in profile development, true).

The LogginMailSender may be undesirable in development profile when
running e2e tests (and you want to connect to an actual SMTP server).
Switching to profile production in e2e tests leads to timeouts in some
difficult to correct places and it may be a topic for further
optimization.

Closes: #1111.