### PR TITLE
[#1096] Add SyncRecordController to expose synchronization history

### DIFF
--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -101,6 +101,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-jpa</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.mkopylec</groupId>
             <artifactId>recaptcha-spring-boot-starter</artifactId>
             <version>${recaptcha-starter.version}</version>
@@ -265,6 +275,11 @@
             <artifactId>springdoc-openapi-webmvc-core</artifactId>
             <version>${springdoc-openapi.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-data-rest</artifactId>
+            <version>${springdoc-openapi.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.commonmark</groupId>
@@ -347,6 +362,17 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessors>
+                        <annotationProcessor>org.mapstruct.ap.MappingProcessor</annotationProcessor>
+                        <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor>
+                        <annotationProcessor>com.querydsl.apt.QuerydslAnnotationProcessor</annotationProcessor>
+                    </annotationProcessors>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/Application.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package pl.cyfronet.s4e;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import org.springdoc.core.SpringDocUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -37,6 +38,10 @@ import org.springframework.cache.annotation.EnableCaching;
 public class Application {
 
     public static void main(String[] args) {
+        SpringDocUtils.getConfig().replaceWithClass(
+                org.springframework.data.domain.Pageable.class,
+                org.springdoc.core.converters.models.Pageable.class
+        );
         SpringApplication.run(Application.class, args);
     }
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/SyncRecord.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/bean/SyncRecord.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.bean;
+
+import com.querydsl.core.annotations.QueryEntity;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import lombok.*;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+
+@QueryEntity
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class SyncRecord {
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String initiatedByMethod;
+
+    private String sceneKey;
+
+    private String eventName;
+
+    private LocalDateTime receivedAt;
+
+    private LocalDateTime sensingTime;
+
+    private String productName;
+
+    private String resultCode;
+
+    private String exceptionMessage;
+
+    @Type(type = "jsonb")
+    @ToString.Exclude
+    private Map<String, Object> parameters;
+
+    // The following are necessary for QueryDSL to use date-time ranges.
+
+    @Transient @Getter(AccessLevel.PRIVATE)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime receivedAtFrom;
+
+    @Transient @Getter(AccessLevel.PRIVATE)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime receivedAtTo;
+
+    @Transient @Getter(AccessLevel.PRIVATE)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime sensingTimeFrom;
+
+    @Transient @Getter(AccessLevel.PRIVATE)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime sensingTimeTo;
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/AmqpConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/AmqpConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import pl.cyfronet.s4e.properties.AmqpProperties;
 import pl.cyfronet.s4e.service.SceneService;
+import pl.cyfronet.s4e.sync.ContextRecorder;
 import pl.cyfronet.s4e.sync.NotificationDispatcher;
 import pl.cyfronet.s4e.sync.QueueReceiver;
 import pl.cyfronet.s4e.sync.SceneAcceptor;
+
+import java.time.Clock;
 
 @Configuration
 @ConditionalOnProperty(prefix = "amqp", name = "enabled")
@@ -52,6 +55,12 @@ public class AmqpConfig {
     @Autowired
     private SceneService sceneService;
 
+    @Autowired
+    private ContextRecorder contextRecorder;
+
+    @Autowired
+    private Clock clock;
+
     @Bean
     public String incomingQueueName() {
         return amqpProperties.getQueues().getIncoming();
@@ -71,7 +80,7 @@ public class AmqpConfig {
 
     @Bean
     public NotificationDispatcher notificationDispatcher() {
-        return new NotificationDispatcher(sceneAcceptor, sceneService);
+        return new NotificationDispatcher(sceneAcceptor, sceneService, contextRecorder, clock);
     }
 
     @Bean

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/QueryConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/QueryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SceneSynchronizationConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SceneSynchronizationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,26 @@
 
 package pl.cyfronet.s4e.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import pl.cyfronet.s4e.sync.LoggingAcceptor;
-import pl.cyfronet.s4e.sync.PipelineFactory;
-import pl.cyfronet.s4e.sync.SceneAcceptor;
-import pl.cyfronet.s4e.sync.SceneAcceptorImpl;
+import pl.cyfronet.s4e.data.repository.SyncRecordRepository;
+import pl.cyfronet.s4e.service.SceneService;
+import pl.cyfronet.s4e.sync.*;
 
 @Configuration
 public class SceneSynchronizationConfig {
+    @Autowired
+    private SyncRecordRepository syncRecordRepository;
+
+    @Autowired
+    private SceneService sceneService;
+
+    @Bean
+    public ContextRecorder contextRecorder() {
+        return new ContextRecorder(syncRecordRepository, sceneService);
+    }
+
     @Bean
     public SceneAcceptor sceneAcceptor(PipelineFactory pipelineFactory) {
         return new LoggingAcceptor(new SceneAcceptorImpl(pipelineFactory));

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SecurityConfig.java
@@ -188,6 +188,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/swagger-ui/**"
                 )).permitAll()
 
+                .mvcMatchers(GET, prefix("/sync-records"))
+                    .access("hasRole('ADMIN') || hasAuthority('OP_SYNC_RECORD_READ')")
+                .mvcMatchers(DELETE, prefix("/sync-records"))
+                    .access("hasRole('ADMIN')")
+
                 .mvcMatchers(ADMIN_PREFIX + "/**").hasRole("ADMIN")
 
                 .anyRequest().denyAll();

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SyncJobsConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/config/SyncJobsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import pl.cyfronet.s4e.admin.sync.task.SyncJobManager;
 import pl.cyfronet.s4e.admin.sync.task.SyncJobStore;
 import pl.cyfronet.s4e.properties.S3Properties;
 import pl.cyfronet.s4e.properties.SyncJobsProperties;
+import pl.cyfronet.s4e.sync.ContextRecorder;
 import pl.cyfronet.s4e.sync.SceneAcceptor;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -47,6 +48,9 @@ public class SyncJobsConfig {
 
     @Autowired
     private SceneAcceptor sceneAcceptor;
+
+    @Autowired
+    private ContextRecorder contextRecorder;
 
     @Autowired
     private Clock clock;
@@ -69,7 +73,7 @@ public class SyncJobsConfig {
 
     @Bean
     public SyncJobManager syncJobManager() {
-        return new SyncJobManager(chunkedRunner(), prefixScanner(), sceneAcceptor, clock);
+        return new SyncJobManager(chunkedRunner(), prefixScanner(), sceneAcceptor, contextRecorder, clock);
     }
 
     @Bean

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SyncRecordController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/SyncRecordController.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.controller;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.StringExpression;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pl.cyfronet.s4e.bean.QSyncRecord;
+import pl.cyfronet.s4e.bean.SyncRecord;
+import pl.cyfronet.s4e.data.repository.SyncRecordRepository;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+
+@RestController
+@RequestMapping(path = API_PREFIX_V1 + "/sync-records", produces = APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Tag(name = "sync-records", description = "The Sync Records API")
+public class SyncRecordController implements QuerydslBinderCustomizer<QSyncRecord> {
+    private final SyncRecordRepository syncRecordRepository;
+
+    @Operation(summary = "Search for SyncRecords")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @GetMapping
+    public Page<SyncRecord> search(
+            @QuerydslPredicate(root = SyncRecord.class, bindings = SyncRecordController.class) Predicate predicate,
+            @ParameterObject Pageable pageable
+    ) {
+        return syncRecordRepository.findAll(predicate, pageable);
+    }
+
+    @Operation(summary = "Delete SyncRecords")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Successfully deleted"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    @DeleteMapping
+    public ResponseEntity<Void> delete(
+            @QuerydslPredicate(root = SyncRecord.class, bindings = SyncRecordController.class) Predicate predicate
+    ) {
+        Page<SyncRecord> page = syncRecordRepository.findAll(predicate, PageRequest.of(0, 1000));
+        while (page.hasContent()) {
+            syncRecordRepository.deleteAll(page.getContent());
+            page = syncRecordRepository.findAll(predicate, PageRequest.of(0, 1000));
+        }
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public void customize(QuerydslBindings bindings, QSyncRecord root) {
+        bindings.bind(
+                root.initiatedByMethod,
+                root.sceneKey,
+                root.eventName,
+                root.resultCode
+        ).first(StringExpression::startsWith);
+        bindings.bind(root.receivedAtFrom).first((path, value) -> root.receivedAt.goe(value));
+        bindings.bind(root.receivedAtTo).first((path, value) -> root.receivedAt.lt(value));
+        bindings.bind(root.sensingTimeFrom).first((path, value) -> root.sensingTime.goe(value));
+        bindings.bind(root.sensingTimeTo).first((path, value) -> root.sensingTime.lt(value));
+        bindings.excluding(
+                root.receivedAt,
+                root.sensingTime,
+                root.exceptionMessage,
+                root.parameters
+        );
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SyncRecordRepository.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/data/repository/SyncRecordRepository.java
@@ -15,10 +15,15 @@
  *
  */
 
-package pl.cyfronet.s4e.sync;
+package pl.cyfronet.s4e.data.repository;
 
-import pl.cyfronet.s4e.sync.context.Context;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.transaction.annotation.Transactional;
+import pl.cyfronet.s4e.bean.SyncRecord;
 
-public interface SceneAcceptor {
-    Error accept(Context context);
+@Transactional(readOnly = true)
+public interface SyncRecordRepository extends
+        PagingAndSortingRepository<SyncRecord, Long>,
+        QuerydslPredicateExecutor<SyncRecord> {
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/ContextRecorder.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/ContextRecorder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.sync;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import pl.cyfronet.s4e.bean.SyncRecord;
+import pl.cyfronet.s4e.data.repository.SyncRecordRepository;
+import pl.cyfronet.s4e.data.repository.projection.ProjectionWithId;
+import pl.cyfronet.s4e.service.SceneService;
+import pl.cyfronet.s4e.sync.context.Context;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ContextRecorder {
+    private interface SceneProjection extends ProjectionWithId {
+        LocalDateTime getTimestamp();
+    }
+
+    private final SyncRecordRepository syncRecordRepository;
+    private final SceneService sceneService;
+
+    public void record(Context context, Error error) {
+        try {
+            val syncRecordBuilder = SyncRecord.builder()
+                    .initiatedByMethod(context.getInitiatedByMethod())
+                    .sceneKey(context.getScene().getKey())
+                    .eventName(context.getEventName())
+                    .receivedAt(context.getReceivedAt());
+
+            if (context.getSceneId() != null) {
+                sceneService.findById(context.getSceneId(), SceneProjection.class)
+                        .ifPresent(scene -> syncRecordBuilder.sensingTime(scene.getTimestamp()));
+            }
+
+            if (context.getProduct() != null) {
+                syncRecordBuilder.productName(context.getProduct().getName());
+            }
+            if (error != null) {
+                syncRecordBuilder.resultCode("err:" + error.getCode());
+                syncRecordBuilder.parameters(error.getParameters());
+                if (error.getCause() != null) {
+                    syncRecordBuilder.exceptionMessage(error.getCause().getMessage());
+                }
+            } else {
+                syncRecordBuilder.resultCode("ok");
+            }
+            syncRecordRepository.save(syncRecordBuilder.build());
+        } catch (Exception e) {
+            log.warn("Unexpected exception when recording sync status", e);
+        }
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/Error.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/Error.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ public class Error {
     public static final String ERR_ARTIFACTS_NOT_FOUND = "artifacts_not_found";
     public static final String ERR_ARTIFACT_PATH_INCORRECT = "artifact_path_incorrect";
     public static final String ERR_METADATA_FOOTPRINT_TRANSFORM_FAILED = "metadata_footprint_transform_failed";
+    public static final String ERR_SCENE_S3PATH_NULL = "scene_s3path_null";
 
     private final String sceneKey;
     private final String code;

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/LoggingAcceptor.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/LoggingAcceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package pl.cyfronet.s4e.sync;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import pl.cyfronet.s4e.sync.context.Context;
 
 import java.util.List;
 import java.util.Map;
@@ -30,8 +31,8 @@ public class LoggingAcceptor implements SceneAcceptor {
     private final SceneAcceptor delegate;
 
     @Override
-    public Error accept(String sceneKey) {
-        Error error = delegate.accept(sceneKey);
+    public Error accept(Context context) {
+        Error error = delegate.accept(context);
         if (error != null) {
             handleError(error);
         }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/PipelineFactory.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/PipelineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,6 +177,7 @@ public class PipelineFactory {
         append(pipeline, Persist.<Context>builder()
                 .scenePersister(() -> scenePersister)
                 .prototype(c -> c.getPrototype().build())
+                .updateSceneId(Context::setSceneId)
                 .build()
         );
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/SceneAcceptorImpl.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/SceneAcceptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,8 @@ public class SceneAcceptorImpl implements SceneAcceptor {
     private final PipelineFactory pipelineFactory;
 
     @Override
-    public Error accept(String sceneKey) {
+    public Error accept(Context context) {
         Error result = null;
-        Context context = new Context(sceneKey);
         try {
             List<Step<Context, Error>> pipeline = pipelineFactory.build();
             for (Step<Context, Error> step : pipeline) {

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/context/Context.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/context/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,31 @@
 package pl.cyfronet.s4e.sync.context;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.Prototype;
 import pl.cyfronet.s4e.sync.step.LoadProduct;
 
+import java.time.LocalDateTime;
+
 @Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Context implements BaseContext {
+    private String initiatedByMethod;
+    @EqualsAndHashCode.Include private String sceneKey;
+    private String eventName;
+    private LocalDateTime receivedAt;
+
     private final SceneJsonFileContext scene = new SceneJsonFileContext();
     private final JsonFileContext metadata = new JsonFileContext();
     private LoadProduct.ProductProjection product;
     private Prototype.PrototypeBuilder prototype;
     private final Error.ErrorBuilder error;
 
+    private Long sceneId;
+
     public Context(String sceneKey) {
+        this.sceneKey = sceneKey;
         error = Error.builder(sceneKey);
         scene.setKey(sceneKey);
     }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/metadata/Persist.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/step/metadata/Persist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 package pl.cyfronet.s4e.sync.step.metadata;
 
 import lombok.Builder;
+import lombok.val;
+import org.springframework.dao.DataIntegrityViolationException;
 import pl.cyfronet.s4e.ex.NotFoundException;
 import pl.cyfronet.s4e.sync.Error;
 import pl.cyfronet.s4e.sync.Prototype;
@@ -25,16 +27,19 @@ import pl.cyfronet.s4e.sync.ScenePersister;
 import pl.cyfronet.s4e.sync.context.BaseContext;
 import pl.cyfronet.s4e.sync.step.Step;
 
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static pl.cyfronet.s4e.sync.Error.ERR_PRODUCT_NOT_FOUND;
+import static pl.cyfronet.s4e.sync.Error.ERR_SCENE_S3PATH_NULL;
 
 @Builder
 public class Persist<T extends BaseContext> implements Step<T, Error> {
     private final Supplier<ScenePersister> scenePersister;
 
     private final Function<T, Prototype> prototype;
+    private final BiConsumer<T, Long> updateSceneId;
 
     @Override
     public Error apply(T context) {
@@ -43,10 +48,16 @@ public class Persist<T extends BaseContext> implements Step<T, Error> {
 
         Prototype prototype = this.prototype.apply(context);
         try {
-            scenePersister.persist(prototype);
+            val sceneId = scenePersister.persist(prototype);
+            updateSceneId.accept(context, sceneId);
         } catch (NotFoundException e) {
-            return error.code(ERR_PRODUCT_NOT_FOUND).cause(e)
-                    .parameter("prototype", prototype).build();
+            return error.code(ERR_PRODUCT_NOT_FOUND).cause(e).build();
+        } catch (DataIntegrityViolationException e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("scene_s3path_conditional_not_null")) {
+                return error.code(ERR_SCENE_S3PATH_NULL).cause(e).build();
+            }
+            throw e;
         }
         return null;
     }

--- a/s4e-backend/src/main/resources/db/migration/V70__add_sync_log_table.sql
+++ b/s4e-backend/src/main/resources/db/migration/V70__add_sync_log_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE sync_record (
+    id BIGSERIAL NOT NULL,
+    initiated_by_method VARCHAR,
+    scene_key VARCHAR,
+    event_name VARCHAR,
+    received_at TIMESTAMP,
+    sensing_time TIMESTAMP,
+    product_name VARCHAR,
+    result_code VARCHAR,
+    exception_message VARCHAR,
+    parameters JSONB
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_record_received_at ON sync_record using btree (received_at);
+CREATE INDEX IF NOT EXISTS idx_sync_record_sensing_time ON sync_record using btree (sensing_time);

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/TestDbHelper.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/TestDbHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package pl.cyfronet.s4e;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import pl.cyfronet.s4e.data.repository.*;
+import pl.cyfronet.s4e.data.repository.SyncRecordRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +35,7 @@ public class TestDbHelper {
     private final SldStyleRepository sldStyleRepository;
     private final PropertyRepository propertyRepository;
     private final ProductCategoryRepository productCategoryRepository;
+    private final SyncRecordRepository syncRecordRepository;
 
     public void clean() {
         productCategoryRepository.deleteAllByNameNot(ProductCategoryRepository.DEFAULT_CATEGORY_NAME);
@@ -46,5 +48,6 @@ public class TestDbHelper {
         prgOverlayRepository.deleteAll();
         sldStyleRepository.deleteAll();
         propertyRepository.deleteAll();
+        syncRecordRepository.deleteAll();
     }
 }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/TestJwtUtil.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/TestJwtUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,12 @@ public class TestJwtUtil {
 
     public static RequestPostProcessor jwtBearerToken(AppUser user, ObjectMapper objectMapper, KeyPair jwtKeyPair) {
         return mockRequest -> {
-            mockRequest.addHeader(SecurityConstants.HEADER_NAME, "Bearer " + createToken(createAppUserDetails(user), objectMapper, jwtKeyPair));
+            if (user != null) {
+                mockRequest.addHeader(
+                        SecurityConstants.HEADER_NAME,
+                        "Bearer " + createToken(createAppUserDetails(user), objectMapper, jwtKeyPair)
+                );
+            }
 
             return mockRequest;
         };

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/NotificationDispatcherTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/NotificationDispatcherTest.java
@@ -27,6 +27,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import pl.cyfronet.s4e.ex.NotFoundException;
 import pl.cyfronet.s4e.service.SceneService;
+import pl.cyfronet.s4e.sync.context.Context;
+
+import java.time.Clock;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
@@ -39,11 +42,14 @@ class NotificationDispatcherTest {
     @Mock
     private SceneService sceneService;
 
+    @Mock
+    private ContextRecorder contextRecorder;
+
     private NotificationDispatcher notificationDispatcher;
 
     @BeforeEach
     public void beforeEach() {
-        notificationDispatcher = new NotificationDispatcher(sceneAcceptor, sceneService);
+        notificationDispatcher = new NotificationDispatcher(sceneAcceptor, sceneService, contextRecorder, Clock.systemUTC());
     }
 
     @Test
@@ -68,7 +74,7 @@ class NotificationDispatcherTest {
     @Test
     public void shouldRejectIfAcceptReturnsError() {
         Notification notification = mockNotification("s3:ObjectCreated:Put", "key");
-        doReturn(Error.builder("key").build()).when(sceneAcceptor).accept("key");
+        doReturn(Error.builder("key").build()).when(sceneAcceptor).accept(new Context("key"));
 
         assertRejects(notification);
     }

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/SceneAcceptorIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import pl.cyfronet.s4e.IntegrationTest;
 import pl.cyfronet.s4e.TestDbHelper;
 import pl.cyfronet.s4e.bean.Scene;
 import pl.cyfronet.s4e.data.repository.SceneRepository;
+import pl.cyfronet.s4e.sync.context.Context;
 import pl.cyfronet.s4e.util.GeometryUtil;
 
 import static org.awaitility.Awaitility.await;
@@ -66,7 +67,7 @@ class SceneAcceptorIntegrationTest {
 
         assertThat(sceneRepository.count(), is(equalTo(0L)));
 
-        sceneAcceptor.accept(SCENE_KEY);
+        sceneAcceptor.accept(new Context(SCENE_KEY));
 
         await().until(() -> sceneRepository.findAllByProductId(productId), hasSize(greaterThan(0)));
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/log/SyncRecordControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/log/SyncRecordControllerTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2021 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.sync.log;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.cyfronet.s4e.BasicTest;
+import pl.cyfronet.s4e.TestDbHelper;
+import pl.cyfronet.s4e.bean.AppUser;
+import pl.cyfronet.s4e.bean.SyncRecord;
+import pl.cyfronet.s4e.data.repository.AppUserRepository;
+import pl.cyfronet.s4e.data.repository.SyncRecordRepository;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
+import static pl.cyfronet.s4e.TestJwtUtil.jwtBearerToken;
+
+
+@BasicTest
+@AutoConfigureMockMvc
+class SyncRecordControllerTest {
+    private static final String URL = API_PREFIX_V1 + "/sync-records";
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private SyncRecordRepository syncRecordRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TestDbHelper testDbHelper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void beforeEach() {
+        testDbHelper.clean();
+    }
+
+    private AppUser persistUser(String... authorities) {
+        return appUserRepository.save(AppUser.builder()
+                .email("user@mail.pl")
+                .name("John")
+                .surname("Smith")
+                .password("{noop}password")
+                .enabled(true)
+                .authorities(Arrays.asList(authorities))
+                .build());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "200,GET,ROLE_ADMIN",
+            "200,GET,OP_SYNC_RECORD_READ",
+            "401,GET,",
+            "403,GET,SOME_OTHER_AUTHORITY",
+            "204,DELETE,ROLE_ADMIN",
+            "401,DELETE,",
+            "403,DELETE,OP_SYNC_RECORD_READ",
+            "403,DELETE,SOME_OTHER_AUTHORITY",
+    })
+    public void shouldBeSecured(int status, HttpMethod method, String authority) throws Exception {
+        val user = authority != null ? persistUser(authority) : null;
+
+        mockMvc.perform(request(method, URL)
+                .with(jwtBearerToken(user, objectMapper)))
+                .andExpect(status().is(status));
+    }
+
+    @Nested
+    class WithSyncRecords {
+        private AppUser user;
+
+        @BeforeEach
+        public void beforeEach() {
+            Stream.of(
+                    SyncRecord.builder()
+                            .initiatedByMethod("foo")
+                            .sceneKey("foo")
+                            .eventName("foo")
+                            .resultCode("foo")
+                            .productName("foo")
+                            .build(),
+                    SyncRecord.builder()
+                            .sceneKey("id:1")
+                            .receivedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                            .sensingTime(LocalDateTime.of(2020, 1, 1, 0, 0))
+                            .build(),
+                    SyncRecord.builder()
+                            .sceneKey("id:2")
+                            .receivedAt(LocalDateTime.of(2021, 1, 1, 0, 0))
+                            .sensingTime(LocalDateTime.of(2021, 1, 1, 0, 0))
+                            .build(),
+                    SyncRecord.builder()
+                            .sceneKey("id:3")
+                            .receivedAt(LocalDateTime.of(2022, 1, 1, 0, 0))
+                            .sensingTime(LocalDateTime.of(2022, 1, 1, 0, 0))
+                            .build()
+            ).forEach(syncRecordRepository::save);
+
+            user = persistUser("ROLE_ADMIN");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "initiatedByMethod",
+                "sceneKey",
+                "eventName",
+                "resultCode",
+        })
+        public void prefixFields(String field) throws Exception {
+            verify(field, "foo", 1);
+            verify(field, "fo", 1);
+            verify(field, "foobar", 0);
+            verify(field, "bar", 0);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "productName",
+        })
+        public void exactMatchFields(String field) throws Exception {
+            verify(field, "foo", 1);
+            verify(field, "fo", 0);
+            verify(field, "foobar", 0);
+            verify(field, "bar", 0);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "receivedAt",
+                "sensingTime",
+        })
+        public void rangeFields(String field) throws Exception {
+            mockMvc.perform(get(URL)
+                    .param(field + "From", "2021-01-01T00:00:00.000Z")
+                    .param("sort", field + ",asc")
+                    .with(jwtBearerToken(user, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].sceneKey").value("id:2"))
+                    .andExpect(jsonPath("$.content[1].sceneKey").value("id:3"));
+            mockMvc.perform(get(URL)
+                    .param(field + "From", "2021-01-01T00:00:00.000Z")
+                    .param("sort", field + ",desc")
+                    .with(jwtBearerToken(user, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].sceneKey").value("id:3"))
+                    .andExpect(jsonPath("$.content[1].sceneKey").value("id:2"));
+            mockMvc.perform(get(URL)
+                    .param(field + "From", "2021-01-01T00:00:00.000Z")
+                    .param(field + "To", "2022-01-01T00:00:00.000Z")
+                    .with(jwtBearerToken(user, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(1)))
+                    .andExpect(jsonPath("$.content[0].sceneKey").value("id:2"));
+            mockMvc.perform(get(URL)
+                    .param(field + "To", "2022-01-01T00:00:00.000Z")
+                    .param("sort", field + ",asc")
+                    .with(jwtBearerToken(user, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].sceneKey").value("id:1"))
+                    .andExpect(jsonPath("$.content[1].sceneKey").value("id:2"));
+            mockMvc.perform(get(URL)
+                    .param(field + "To", "2022-01-01T00:00:00.000Z")
+                    .param("sort", field + ",desc")
+                    .with(jwtBearerToken(user, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].sceneKey").value("id:2"))
+                    .andExpect(jsonPath("$.content[1].sceneKey").value("id:1"));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "receivedAt",
+                "sensingTime",
+                "exceptionMessage",
+                "parameters",
+                "non-existent",
+        })
+        public void shouldTolerateIgnoredAndNonExistentParams(String paramName) throws Exception {
+            mockMvc.perform(get(URL)
+                    .param(paramName, "foo")
+                    .with(jwtBearerToken(user, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(4)));
+        }
+
+        @Test
+        public void shouldDelete() throws Exception {
+            assertThat(syncRecordRepository.count(), is(4L));
+
+            mockMvc.perform(delete(URL)
+                    .with(jwtBearerToken(user, objectMapper)))
+                    .andExpect(status().isNoContent());
+
+            assertThat(syncRecordRepository.count(), is(0L));
+        }
+
+        private void verify(String field, String search, int size) throws Exception {
+            mockMvc.perform(get(URL)
+                    .param(field, search)
+                    .with(jwtBearerToken(user, objectMapper)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(size)));
+        }
+    }
+}


### PR DESCRIPTION
Use QueryDSL to expose a flexible search endpoint.
Add an authority OP_SYNC_RECORD_READ to allow access to this endpoint,
it can be assigned to a user by an admin.

Admin can also delete records by an arbitrary search query.

Populate records in SyncRecorder.
To get all the necessary data I had to modify the Context to accommodate
extra data.

Closes: #1096.