### PR TITLE
[#1113] Disable RabbitHealthIndicator by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ Application can be configured to listen to notifications from an AMQP queue with
 
 In profile `development` this feature is enabled, and in `production` it has to be enabled by setting
 `amqp.enabled=true` or `AMQP_ENABLED=true`.
+By default, we disable RabbitHealthIndicator as it doesn't respond to lack of `@EnableRabbit` when RabbitTemplate
+is on classpath.
+To enable it, set `management.health.rabbit.enabled=true` or `MANAGEMENT_HEALTH_RABBIT_ENABLED=true`.
 
 By default, the listener subscribes to queue `s4e.scenes.incoming`.
 When an error occurs during scene processing, the message is rejected with option not to requeue it.

--- a/s4e-backend/src/main/resources/application-development.properties
+++ b/s4e-backend/src/main/resources/application-development.properties
@@ -2,6 +2,7 @@ spring.datasource.url=jdbc:postgresql://localhost:5433/sat4envi
 spring.datasource.username=sat4envi
 spring.datasource.password=sat4envi
 
+management.health.rabbit.enabled=true
 amqp.enabled=true
 amqp.create-queues=true
 spring.rabbitmq.host=localhost

--- a/s4e-backend/src/main/resources/application.properties
+++ b/s4e-backend/src/main/resources/application.properties
@@ -23,5 +23,6 @@ springdoc.swagger-ui.tagsSorter=alpha
 
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoints.jmx.exposure.include=
+management.health.rabbit.enabled=false
 
 scene.artifacts.internal-download-whitelist=thumbnail


### PR DESCRIPTION
It doesn't disable itself when @EnableRabbit is not set, it has to be
configured manually.

Fixes: #1113.