### PR TITLE
[#1121] Expose helpdesk properties in configuration response

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ By default doesn't force re-seed, but it can be told to do so by setting `seed.u
 
 `run-seed-expert-email`: Runs `SeedExpertEmail`.
 
+`run-seed-helpdesk-config`: Runs `SeedHelpdeskConfig`.
+
 
 #### DB properties
 
@@ -122,6 +124,8 @@ Example: `expert@mail.pl`.
 authorities.
 Authorities are comma-separated.
 Default and example: `ROLE_MEMBER_ZK,ROLE_MEMBER_PAK`.
+
+`helpdesk_config`: a set of helpdesk configuration variables in the following format: `<key>=<value>(,<key>=<value>)+`.
 
 
 #### Seeding Products

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/Constants.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/Constants.java
@@ -26,4 +26,5 @@ public final class Constants {
 
     public static final String PROPERTY_EXPERT_HELP_EMAIL = "expert_help_email";
     public static final String PROPERTY_EUMETSAT_AUTHORITY_WHITELIST = "eumetsat_authority_whitelist";
+    public static final String PROPERTY_HELPDESK_CONFIG = "helpdesk_config";
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import pl.cyfronet.s4e.controller.response.ConfigResponse;
+import pl.cyfronet.s4e.helpdesk.HelpdeskConfigSupplier;
 import pl.cyfronet.s4e.properties.GeoServerProperties;
 import pl.cyfronet.s4e.properties.OsmProperties;
 import pl.cyfronet.s4e.search.SearchPanelConfigResponse;
@@ -44,6 +45,7 @@ import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 public class ConfigController {
     private final GeoServerProperties geoServerProperties;
     private final OsmProperties osmProperties;
+    private final HelpdeskConfigSupplier helpdeskConfigSupplier;
     private final SearchPanelConfigResponseSupplier searchPanelConfigResponseSupplier;
 
     @Value("${recaptcha.validation.siteKey}")
@@ -60,6 +62,7 @@ public class ConfigController {
                 .geoserverUrl(geoServerProperties.getOutsideBaseUrl())
                 .geoserverWorkspace(geoServerProperties.getWorkspace())
                 .recaptchaSiteKey(recaptchaSiteKey)
+                .helpdesk(helpdeskConfigSupplier.getConfig())
                 .build();
     }
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
 
+import java.util.Map;
+
 @Value
 @Builder
 public class ConfigResponse {
@@ -32,4 +34,5 @@ public class ConfigResponse {
     String geoserverWorkspace;
     @Schema(example = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI")
     String recaptchaSiteKey;
+    Map<String, String> helpdesk;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedHelpdeskConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedHelpdeskConfig.java
@@ -28,28 +28,28 @@ import pl.cyfronet.s4e.Constants;
 import pl.cyfronet.s4e.bean.Property;
 import pl.cyfronet.s4e.data.repository.PropertyRepository;
 
-@Profile({"development", "run-seed-expert-email"})
+@Profile({"development", "run-seed-helpdesk-config"})
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class SeedExpertEmail implements ApplicationRunner {
-    private static final String DEVELOPMENT_EXPERT_HELP_EMAIL = "expert-help@mail.pl";
+public class SeedHelpdeskConfig implements ApplicationRunner {
+    private static final String DEVELOPMENT_HELPDESK_CONFIG = "type=jira,href=xyz";
 
     private final PropertyRepository propertyRepository;
 
     @Async
     @Override
     public void run(ApplicationArguments args) {
-        if (propertyRepository.findByName(Constants.PROPERTY_EXPERT_HELP_EMAIL).isPresent()) {
-            log.info("Expert email already set, skipping");
+        if (propertyRepository.findByName(Constants.PROPERTY_HELPDESK_CONFIG).isPresent()) {
+            log.info("Helpdesk config already set, skipping");
             return;
         }
 
         propertyRepository.save(Property.builder()
-                .name(Constants.PROPERTY_EXPERT_HELP_EMAIL)
-                .value(DEVELOPMENT_EXPERT_HELP_EMAIL)
+                .name(Constants.PROPERTY_HELPDESK_CONFIG)
+                .value(DEVELOPMENT_HELPDESK_CONFIG)
                 .build());
 
-        log.info("Expert email set to " + DEVELOPMENT_EXPERT_HELP_EMAIL);
+        log.info("Helpdesk config set to " + DEVELOPMENT_HELPDESK_CONFIG);
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/helpdesk/HelpdeskConfigSupplier.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/helpdesk/HelpdeskConfigSupplier.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.helpdesk;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import pl.cyfronet.s4e.Constants;
+import pl.cyfronet.s4e.bean.Property;
+import pl.cyfronet.s4e.data.repository.PropertyRepository;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.function.Predicate.not;
+
+@Service
+@RequiredArgsConstructor
+public class HelpdeskConfigSupplier {
+    private final PropertyRepository propertyRepository;
+
+    public Map<String, String> getConfig() {
+        return propertyRepository.findByName(Constants.PROPERTY_HELPDESK_CONFIG)
+            .map(Property::getValue)
+            .filter(not(String::isBlank))
+            .stream()
+                .flatMap(value -> Arrays.stream(value.split(",")))
+                .map(entry -> entry.split("=", 2))
+                .filter(split -> split.length == 2)
+                .collect(Collectors.toUnmodifiableMap(
+                        split -> split[0],
+                        split -> split[1],
+                        (v1, v2) -> v1
+                ));
+    }
+}


### PR DESCRIPTION
The properties can be defined by setting `helpdesk_config` DB property
in the format `<key>=<value>(,<key>=<value>)+`.

In development seed its value in SeedHelpdeskConfig.

Fixes: #1121.