### PR TITLE
[#1137] Add hasZipArtifact field to scene responses

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/mapper/SceneMapper.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/mapper/SceneMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.mapstruct.Named;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.TransformException;
 import org.springframework.beans.factory.annotation.Autowired;
+import pl.cyfronet.s4e.util.ZipArtifact;
 import pl.cyfronet.s4e.config.MapStructCentralConfig;
 import pl.cyfronet.s4e.controller.response.SceneResponse;
 import pl.cyfronet.s4e.util.GeometryUtil;
@@ -54,6 +55,7 @@ public abstract class SceneMapper {
 
     @Mapping(source = "scene", target = "productId", qualifiedByName = "productId")
     @Mapping(source = "sceneContent", target = "artifacts")
+    @Mapping(source = "sceneContent", target = "hasZipArtifact")
     public abstract SceneResponse toResponse(SceneResponse.Projection scene, @Context ZoneId zoneId);
 
     @Named("productId")
@@ -82,5 +84,14 @@ public abstract class SceneMapper {
                 .takeWhile(ignored -> artifactNamesIterator.hasNext())
                 .map(ignored -> artifactNamesIterator.next())
                 .collect(Collectors.toUnmodifiableSet());
+    }
+
+    protected boolean mapToHasZipArtifact(JsonNode sceneContent) {
+        if (sceneContent == null) {
+            return false;
+        }
+
+        JsonNode artifactsNode = sceneContent.get(SCENE_SCHEMA_ARTIFACTS_KEY);
+        return ZipArtifact.getName(artifactsNode).isPresent();
     }
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/SceneResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/SceneResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,4 +49,6 @@ public class SceneResponse {
     private Legend legend;
     private Set<String> artifacts;
     private JsonNode metadataContent;
+
+    private boolean hasZipArtifact;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/SearchResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/SearchResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,4 +34,6 @@ public class SearchResponse {
     private Set<String> artifacts;
     private JsonNode metadataContent;
     private ZonedDateTime timestamp;
+
+    private boolean hasZipArtifact;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/util/ZipArtifact.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/util/ZipArtifact.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.val;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ZipArtifact {
+    public static Optional<String> getName(JsonNode artifactsNode) {
+        if (artifactsNode == null || !artifactsNode.isObject()) {
+            return Optional.empty();
+        }
+
+        return getName(getArtifactsMap(artifactsNode));
+    }
+
+    public static Optional<String> getName(Map<String, String> artifacts) {
+        if (artifacts == null || artifacts.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return artifacts
+                .entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .filter(entry -> entry.getValue().endsWith(".zip"))
+                .map(Map.Entry::getKey)
+                .sorted()
+                .findFirst();
+    }
+
+    private static Map<String, String> getArtifactsMap(JsonNode artifactsNode) {
+        val map = new LinkedHashMap<String, String>();
+        artifactsNode.fields().forEachRemaining(entry -> {
+            val value = entry.getValue();
+            if (value.isTextual()) {
+                map.put(entry.getKey(), value.asText());
+            }
+        });
+        return map;
+    }
+}

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/util/ZipArtifactTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/util/ZipArtifactTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ZipArtifactTest {
+    @Test
+    public void shouldReturnArtifactName() {
+        assertThat(
+                ZipArtifact.getName(Map.of("foo", "etc", "baz", "path.zip", "bar", "another.zip")),
+                isPresentAndIs("bar")
+        );
+    }
+
+    @Test
+    public void shouldReturnEmpty() {
+        assertThat(
+                ZipArtifact.getName(Map.of("foo", "etc")),
+                isEmpty()
+        );
+    }
+
+    @Test
+    public void shouldHandleEmptyMap() {
+        assertThat(
+                ZipArtifact.getName(Map.of()),
+                isEmpty()
+        );
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(
+                ZipArtifact.getName((Map<String, String>) null),
+                isEmpty()
+        );
+    }
+}


### PR DESCRIPTION
Add the hasZipArtifact field to responses, so that front-end can use it to determine if it can call the generic download endpoint without 404 risk.

Closes: #1137.