### PR TITLE
Expand QueryDsl endpoint argument to OpenAPI parameters

### DIFF
--- a/s4e-backend/src/main/resources/application.properties
+++ b/s4e-backend/src/main/resources/application.properties
@@ -21,27 +21,6 @@ springdoc.swagger-ui.path=/api/v1/docs.html
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.tagsSorter=alpha
 
-springdoc.api-docs.groups.enabled=true
-springdoc.group-configs[0].group=public
-springdoc.group-configs[0].paths-to-match=\
-  /api/v1/token,\
-  /api/v1/products,\
-  /api/v1/scenes/**,\
-  /api/v1/search,\
-  /api/v1/search/count
-springdoc.group-configs[1].group=provider
-springdoc.group-configs[1].paths-to-match=\
-  /api/v1/token,\
-  /api/v1/products,\
-  /api/v1/scenes/**,\
-  /api/v1/search,\
-  /api/v1/search/count,\
-  /api/v1/schemas/,\
-  /api/v1/schemas/**,\
-  /api/v1/sync-records
-springdoc.group-configs[2].group=private
-springdoc.group-configs[2].packages-to-scan=pl.cyfronet.s4e
-
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoints.jmx.exposure.include=
 management.health.rabbit.enabled=false


### PR DESCRIPTION
As per https://github.com/springdoc/springdoc-openapi/pull/1079, when
using group configs the customizers have to be specified in the
GroupedOpenApi bean declarations.
Since we depend on the QueryDsl customizer, the group configs had to be
moved to the java config from properties.