### PR TITLE
[#1144] Expose analytics properties in configuration response

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ By default doesn't force re-seed, but it can be told to do so by setting `seed.u
 
 `run-seed-helpdesk-config`: Runs `SeedHelpdeskConfig`.
 
+`run-seed-analytics-config`: Runs `SeedAnalyticsConfig`.
+
 
 #### DB properties
 
@@ -126,6 +128,8 @@ Authorities are comma-separated.
 Default and example: `ROLE_MEMBER_ZK,ROLE_MEMBER_PAK`.
 
 `helpdesk_config`: a set of helpdesk configuration variables in the following format: `<key>=<value>(,<key>=<value>)+`.
+
+`analytics_config`: a set of analytics configuration variables in the following format: `<key>=<value>(,<key>=<value>)+`.
 
 
 #### Seeding Products

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/Constants.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/Constants.java
@@ -26,5 +26,7 @@ public final class Constants {
 
     public static final String PROPERTY_EXPERT_HELP_EMAIL = "expert_help_email";
     public static final String PROPERTY_EUMETSAT_AUTHORITY_WHITELIST = "eumetsat_authority_whitelist";
+
     public static final String PROPERTY_HELPDESK_CONFIG = "helpdesk_config";
+    public static final String PROPERTY_ANALYTICS_CONFIG = "analytics_config";
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/ConfigController.java
@@ -26,8 +26,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import pl.cyfronet.s4e.Constants;
 import pl.cyfronet.s4e.controller.response.ConfigResponse;
-import pl.cyfronet.s4e.helpdesk.HelpdeskConfigSupplier;
+import pl.cyfronet.s4e.kvconfig.KeyValueConfigSupplier;
 import pl.cyfronet.s4e.properties.GeoServerProperties;
 import pl.cyfronet.s4e.properties.OsmProperties;
 import pl.cyfronet.s4e.search.SearchPanelConfigResponse;
@@ -45,7 +46,7 @@ import static pl.cyfronet.s4e.Constants.API_PREFIX_V1;
 public class ConfigController {
     private final GeoServerProperties geoServerProperties;
     private final OsmProperties osmProperties;
-    private final HelpdeskConfigSupplier helpdeskConfigSupplier;
+    private final KeyValueConfigSupplier keyValueConfigSupplier;
     private final SearchPanelConfigResponseSupplier searchPanelConfigResponseSupplier;
 
     @Value("${recaptcha.validation.siteKey}")
@@ -62,7 +63,8 @@ public class ConfigController {
                 .geoserverUrl(geoServerProperties.getOutsideBaseUrl())
                 .geoserverWorkspace(geoServerProperties.getWorkspace())
                 .recaptchaSiteKey(recaptchaSiteKey)
-                .helpdesk(helpdeskConfigSupplier.getConfig())
+                .helpdesk(keyValueConfigSupplier.getConfig(Constants.PROPERTY_HELPDESK_CONFIG))
+                .analytics(keyValueConfigSupplier.getConfig(Constants.PROPERTY_ANALYTICS_CONFIG))
                 .build();
     }
 

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/controller/response/ConfigResponse.java
@@ -35,4 +35,5 @@ public class ConfigResponse {
     @Schema(example = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI")
     String recaptchaSiteKey;
     Map<String, String> helpdesk;
+    Map<String, String> analytics;
 }

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedAnalyticsConfig.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/db/seed/SeedAnalyticsConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 ACC Cyfronet AGH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pl.cyfronet.s4e.db.seed;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import pl.cyfronet.s4e.Constants;
+import pl.cyfronet.s4e.bean.Property;
+import pl.cyfronet.s4e.data.repository.PropertyRepository;
+
+@Profile({"development", "run-seed-analytics-config"})
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SeedAnalyticsConfig implements ApplicationRunner {
+    private static final String DEVELOPMENT_ANALYTICS_CONFIG = "type=disabled";
+
+    private final PropertyRepository propertyRepository;
+
+    @Async
+    @Override
+    public void run(ApplicationArguments args) {
+        if (propertyRepository.findByName(Constants.PROPERTY_ANALYTICS_CONFIG).isPresent()) {
+            log.info("Analytics config already set, skipping");
+            return;
+        }
+
+        propertyRepository.save(Property.builder()
+                .name(Constants.PROPERTY_ANALYTICS_CONFIG)
+                .value(DEVELOPMENT_ANALYTICS_CONFIG)
+                .build());
+
+        log.info("Analytics config set to " + DEVELOPMENT_ANALYTICS_CONFIG);
+    }
+}

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/kvconfig/KeyValueConfigSupplier.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/kvconfig/KeyValueConfigSupplier.java
@@ -15,11 +15,10 @@
  *
  */
 
-package pl.cyfronet.s4e.helpdesk;
+package pl.cyfronet.s4e.kvconfig;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import pl.cyfronet.s4e.Constants;
 import pl.cyfronet.s4e.bean.Property;
 import pl.cyfronet.s4e.data.repository.PropertyRepository;
 
@@ -31,11 +30,11 @@ import static java.util.function.Predicate.not;
 
 @Service
 @RequiredArgsConstructor
-public class HelpdeskConfigSupplier {
+public class KeyValueConfigSupplier {
     private final PropertyRepository propertyRepository;
 
-    public Map<String, String> getConfig() {
-        return propertyRepository.findByName(Constants.PROPERTY_HELPDESK_CONFIG)
+    public Map<String, String> getConfig(String propertyName) {
+        return propertyRepository.findByName(propertyName)
             .map(Property::getValue)
             .filter(not(String::isBlank))
             .stream()


### PR DESCRIPTION
This is an extension based on the preexisting implementation for the
helpdesk configuration.
If we are to extend the set of keys further it could make sense to
generalize the solution.