### PR TITLE
Dependencies update - 2021.03

### DIFF
--- a/gs-gateway/pom.xml
+++ b/gs-gateway/pom.xml
@@ -17,7 +17,7 @@
     <description>GeoServer Gateway</description>
 
     <properties>
-        <spring-cloud.version>2020.0.1</spring-cloud.version>
+        <spring-cloud.version>2020.0.2</spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,15 +26,15 @@
         <java.version>11</java.version>
         <maven.compiler.release>11</maven.compiler.release>
 
-        <spring-boot.version>2.4.2</spring-boot.version>
+        <spring-boot.version>2.4.4</spring-boot.version>
 
-        <awssdk.version>2.15.74</awssdk.version>
-        <commonmark.version>0.17.0</commonmark.version>
+        <awssdk.version>2.16.21</awssdk.version>
+        <commonmark.version>0.17.1</commonmark.version>
         <commons-email.version>1.5</commons-email.version>
         <geotools.version>23.2</geotools.version>
         <greenmail.version>1.6.2</greenmail.version>
         <guava.version>30.1-jre</guava.version>
-        <hibernate-types.version>2.10.2</hibernate-types.version>
+        <hibernate-types.version>2.10.3</hibernate-types.version>
         <jakarta.json-api.version>2.0.0</jakarta.json-api.version>
         <jjwt.version>0.11.2</jjwt.version>
         <joy.version>2.1.0</joy.version>
@@ -44,8 +44,8 @@
         <poiooxml.version>4.1.2</poiooxml.version>
         <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
         <slugify.version>2.4</slugify.version>
-        <springdoc-openapi.version>1.5.3</springdoc-openapi.version>
-        <unirest.version>3.11.10</unirest.version>
+        <springdoc-openapi.version>1.5.6</springdoc-openapi.version>
+        <unirest.version>4.0.0-RC1</unirest.version>
         <bucket4j-starter.version>0.3.3</bucket4j-starter.version>
         <!--
         update sentry version only when fid instance is updated

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperations.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/geoserver/op/GeoServerOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,6 @@ public class GeoServerOperations {
                 .routeParam("cs", coverageStore)
                 .basicAuth(geoServerProperties.getUsername(), geoServerProperties.getPassword())
                 .connectTimeout(geoServerProperties.getTimeoutConnect().intValue() * 1000)
-                .socketTimeout(geoServerProperties.getTimeoutRead().intValue() * 1000)
                 .field("file", file)
                 .asString()
                 .ifFailure(String.class, r -> {


### PR DESCRIPTION
Unirest 4 removes the socket timeout property, only the connect timeout
is supported.