### PR TITLE
[#1107] Fix reset password for not enabled user

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/service/PasswordService.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/service/PasswordService.java
@@ -90,6 +90,7 @@ public class PasswordService {
         }
         AppUser appUser = resetPasswordToken.getAppUser();
         appUser.setPassword(passwordEncoder.encode(passwordReset.getPassword()));
+        appUser.setEnabled(true);
         passwordResetRepository.deleteById(resetPasswordToken.getId());
     }
 

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/PasswordControllerTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/controller/PasswordControllerTest.java
@@ -110,7 +110,7 @@ public class PasswordControllerTest {
                 .name("Get")
                 .surname("Profile")
                 .password(passwordEncoder.encode("password"))
-                .enabled(true)
+                .enabled(false)
                 .build());
     }
 
@@ -202,6 +202,7 @@ public class PasswordControllerTest {
                 .build();
         passwordResetRepository.save(token);
         assertThat(passwordService.findByEmail(PROFILE_EMAIL), isPresent());
+        assertThat(appUserRepository.findByEmail(PROFILE_EMAIL).get().isEnabled(), is(false));
 
         String newPassword = "password2";
         String oldPassword = "password";
@@ -217,6 +218,7 @@ public class PasswordControllerTest {
 
         assertThat(passwordEncoder.matches(newPassword, appUserRepository.findByEmail(PROFILE_EMAIL).get().getPassword()), is(true));
         assertThat(passwordEncoder.matches(oldPassword, appUserRepository.findByEmail(PROFILE_EMAIL).get().getPassword()), is(false));
+        assertThat(appUserRepository.findByEmail(PROFILE_EMAIL).get().isEnabled(), is(true));
     }
 
     @Test

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/service/PasswordServiceTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/service/PasswordServiceTest.java
@@ -81,7 +81,7 @@ public class PasswordServiceTest {
                 .name("Get")
                 .surname("Profile")
                 .password(passwordEncoder.encode("password"))
-                .enabled(true)
+                .enabled(false)
                 .build());
     }
 
@@ -144,6 +144,7 @@ public class PasswordServiceTest {
 
     @Test
     public void shouldResetPassword() throws Exception {
+        assertThat(appUserService.findByEmail(PROFILE_EMAIL).get().isEnabled(), is(false));
         PasswordReset token = PasswordReset.builder()
                 .token(UUID.randomUUID().toString())
                 .appUser(appUserService.findByEmail(PROFILE_EMAIL).get())
@@ -157,6 +158,7 @@ public class PasswordServiceTest {
                 .build();
         passwordService.resetPassword(passwordReset);
 
+        assertThat(appUserService.findByEmail(PROFILE_EMAIL).get().isEnabled(), is(true));
         assertThat(passwordService.findByEmail(PROFILE_EMAIL), isEmpty());
         assertThat(passwordEncoder.matches(password, appUserRepository.findByEmail(PROFILE_EMAIL).get().getPassword()), is(true));
     }


### PR DESCRIPTION
Fixed by enabling user during password reset.
Closes #1107 