### PR TITLE
[#1168][#1149] Fix quicklook image visibility, fix not loading scene on first product selection

### DIFF
--- a/s4e-web/src/app/views/map-view/map-view.component.ts
+++ b/s4e-web/src/app/views/map-view/map-view.component.ts
@@ -222,6 +222,12 @@ export class MapViewComponent implements OnInit, OnDestroy {
     if (this.mapQuery.isLoading()) {
       return;
     }
+
+    // IMPORTANT!!! Prevent loading random date (1970-01-01) on first product visit
+    if ($event === '1970-01-01') {
+      return;
+    }
+
     this.sceneService
       .get(this.productQuery.getActive(), $event, 'first')
       .subscribe();

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.html
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.html
@@ -59,7 +59,10 @@
               <div
                 class="search-result__quicklook"
                 [ngStyle]="{
-                  background: result.image ? 'url(' + result.image + ')' : ''
+                  'background': result.image ? 'url(' + result.image + ')' : '',
+                  'background-position': 'center center',
+                  'background-repeat': 'no-repeat',
+                  'background-size': 'cover'
                 }"
                 (click)="showDetails.emit(result)"
               >

--- a/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.spec.ts
+++ b/s4e-web/src/app/views/map-view/sentinel-search/search-results/search-results.component.spec.ts
@@ -77,7 +77,7 @@ describe('SearchResultsComponent', () => {
         de
           .query(By.css('.search-result__quicklook'))
           .nativeElement.getAttribute('style')
-      ).toBe(`background: url(api/v1/scenes/${result.id}/download/thumbnail);`);
+      ).toContain(`background: url(api/v1/scenes/${result.id}/download/thumbnail);`);
     });
 
     it('should have empty thumbnail', () => {


### PR DESCRIPTION
- QuickLook image background at /map/sentinel-search (after search) is centered
and cover whole div (fix the issue when Quicklook is mostly black icon)
- now on the first product selection loaded scene will be displayed

Closes #1168, #1149