### PR TITLE
[#1189] Handle s3:ObjectCreated:Copy S3 notifications

### DIFF
--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/NotificationDispatcher.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/sync/NotificationDispatcher.java
@@ -35,7 +35,11 @@ import java.util.Set;
 public class NotificationDispatcher {
     // These events correspond to event types listed for example here:
     // https://docs.ceph.com/en/latest/radosgw/s3-notification-compatibility/.
-    private static final Set<String> ACCEPT_EVENTS = Set.of("s3:ObjectCreated:Put", "s3:ObjectCreated:Post");
+    private static final Set<String> ACCEPT_EVENTS = Set.of(
+            "s3:ObjectCreated:Put",
+            "s3:ObjectCreated:Post",
+            "s3:ObjectCreated:Copy"
+    );
     private static final Set<String> DELETE_EVENTS = Set.of("s3:ObjectRemoved:Delete");
 
     private final SceneAcceptor sceneAcceptor;

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/NotificationDispatcherTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/NotificationDispatcherTest.java
@@ -63,7 +63,7 @@ class NotificationDispatcherTest {
             "eventNameValue,",
             ",objectKeyValue",
             ",objectKeyValue",
-            "s3:ObjectCreated:Copy,objectKeyValue"
+            "s3:ObjectCreated:CompleteMultipartUpload,objectKeyValue"
     })
     public void shouldRejectIfAnyNotificationFieldNullOrEventUnsupported(String eventName, String objectKey) {
         Notification notification = mockNotification(eventName, objectKey);

--- a/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/QueueReceiverIntegrationTest.java
+++ b/s4e-backend/src/test/java/pl/cyfronet/s4e/sync/QueueReceiverIntegrationTest.java
@@ -83,8 +83,8 @@ public class QueueReceiverIntegrationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "s3:ObjectCreated:Put", "s3:ObjectCreated:Post" })
-    public void shouldHandlePutAndPost(String eventName) {
+    @ValueSource(strings = { "s3:ObjectCreated:Put", "s3:ObjectCreated:Post", "s3:ObjectCreated:Copy" })
+    public void shouldHandleObjectCreatedEvents(String eventName) {
         assertThat(sceneRepository.count(), is(equalTo(0L)));
 
         sendMessage(incomingQueueName, SCENE_KEY, eventName);
@@ -94,7 +94,7 @@ public class QueueReceiverIntegrationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "s3:ObjectCreated:Put", "s3:ObjectCreated:Post" })
+    @ValueSource(strings = { "s3:ObjectCreated:Put", "s3:ObjectCreated:Post", "s3:ObjectCreated:Copy" })
     public void shouldHandleNonExistentScene(String eventName) {
         assertThat(sceneRepository.count(), is(equalTo(0L)));
 


### PR DESCRIPTION
Ceph in some cases generates s3:ObjectCreated:Copy notifications, even
though :Post would be more appropriate (probably when overwriting an
object).
Handle the incorrect event to accommodate for this behaviour and not
have to run sync manually in such cases.

Closes: #1189.