### PR TITLE
Allow to disable metrics for certain GetMap requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,17 @@ GRANT readaccess TO eva;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO readaccess;
 ```
 
+__Q: How to disable metrics for selected requests?__
+
+It's not possible for now to do that for all metered endpoints, but the gs-gateway can be instructed not to meter
+certain requests.
+
+The control is on the sender side: if a request has `DISABLE_METRICS` query param, then it won't be counted.
+For example, a request for `https://localhost:4200/wms?REQUEST=GetMap&<other_params>&DISABLE_METRICS` won't be counted.
+
+This feature is suited for monitoring, where a bunch of requests is issued periodically, but we don't want to report
+them.
+
 
 ## License
 

--- a/gs-gateway/src/main/java/pl/cyfronet/gsg/counter/GetMapRequestCounterFilter.java
+++ b/gs-gateway/src/main/java/pl/cyfronet/gsg/counter/GetMapRequestCounterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,16 @@ public class GetMapRequestCounterFilter implements GlobalFilter, Ordered {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         ServerHttpRequest request = exchange.getRequest();
-        if ("GetMap".equals(request.getQueryParams().getFirst("REQUEST"))) {
 
+        if (request.getQueryParams().containsKey("DISABLE_METRICS")) {
+            return chain.filter(exchange);
+        }
+
+        if ("GetMap".equals(request.getQueryParams().getFirst("REQUEST"))) {
             return chain.filter(exchange).doOnSuccess(
                     (aVoid) -> metricService.incrementCounter(request.getQueryParams().getFirst("LAYERS")));
         }
+
         return chain.filter(exchange);
     }
 

--- a/gs-gateway/src/test/java/pl/cyfronet/gsg/counter/GetMapRequestCounterFilterTest.java
+++ b/gs-gateway/src/test/java/pl/cyfronet/gsg/counter/GetMapRequestCounterFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ public class GetMapRequestCounterFilterTest {
                 .build();
         ServerWebExchange exchange = MockServerWebExchange.from(request);
         when(filterChain.filter(exchange)).thenReturn(Mono.empty());
+
         filter.filter(exchange, filterChain).block();
 
         assertThat(exchange.getResponse().isCommitted(), is(equalTo(false)));
@@ -66,8 +67,28 @@ public class GetMapRequestCounterFilterTest {
                 .queryParam("REQUEST", "GetCapabilities")
                 .build();
         ServerWebExchange exchange = MockServerWebExchange.from(request);
+        when(filterChain.filter(exchange)).thenReturn(Mono.empty());
 
-        filter.filter(exchange, filterChain);
+        filter.filter(exchange, filterChain).block();
+
+        assertThat(exchange.getResponse().isCommitted(), is(equalTo(false)));
+        verify(filterChain).filter(exchange);
+        verifyNoInteractions(metricService);
+        verifyNoMoreInteractions(filterChain);
+    }
+
+    @Test
+    public void shouldntCountWithDisableMetrics() {
+        GlobalFilter filter = new GetMapRequestCounterFilter(metricService);
+        MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+                .queryParam("REQUEST", "GetMap")
+                .queryParam("LAYERS", "msg")
+                .queryParam("DISABLE_METRICS")
+                .build();
+        ServerWebExchange exchange = MockServerWebExchange.from(request);
+        when(filterChain.filter(exchange)).thenReturn(Mono.empty());
+
+        filter.filter(exchange, filterChain).block();
 
         assertThat(exchange.getResponse().isCommitted(), is(equalTo(false)));
         verify(filterChain).filter(exchange);


### PR DESCRIPTION
This is to ignore monitoring calls from zabbix.