### PR TITLE
Dependency updates 2021-12

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11.0.12
+          java-version: 17.0.1
       - name: Cache web-e2e
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11.0.12
+          java-version: 17.0.1
       - name: Cache backend
         uses: actions/cache@v2
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11.0.12
+          java-version: 17.0.1
       - name: Cache gs-gateway
         uses: actions/cache@v2
         with:
@@ -62,7 +62,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11.0.12
+          java-version: 17.0.1
       - name: Cache web
         uses: actions/cache@v2
         with:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.3/apache-maven-3.8.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- java `^11`
+- java `^17`
 - docker `^18.09.3`
 - docker-compose `^1.18.0`
 - node `^11`,  npm `^6`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ in GS-Gateway or s4e-backend:
 dsn = <https://url with token to your sentry>
 ```
 
+Alternatively, set envvar `SENTRY_DSN=<dsn>` for backend and gsg-gateway.
+
 ### s4e-backend
 
 #### Prerequisites

--- a/backend-development.env
+++ b/backend-development.env
@@ -1,4 +1,4 @@
-SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/sat4envi
+SPRING_DATASOURCE_URL=jdbc:p6spy:postgresql://db:5432/sat4envi
 SPRING_PROFILES_ACTIVE=development
 SPRING_RABBITMQ_HOST=broker
 SPRING_RABBITMQ_PORT=5672

--- a/backend-e2e.env
+++ b/backend-e2e.env
@@ -1,4 +1,4 @@
-SPRING_DATASOURCE_URL=jdbc:postgresql://db-test:5432/sat4envi_test
+SPRING_DATASOURCE_URL=jdbc:p6spy:postgresql://db-test:5432/sat4envi_test
 SPRING_DATASOURCE_USERNAME=sat4envi_test
 SPRING_DATASOURCE_PASSWORD=sat4envi_test
 SPRING_PROFILES_ACTIVE=development

--- a/backend-production.env.template
+++ b/backend-production.env.template
@@ -1,4 +1,4 @@
-SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/sat4envi
+SPRING_DATASOURCE_URL=jdbc:p6spy:postgresql://db:5432/sat4envi
 SPRING_DATASOURCE_PASSWORD=sat4envi
 SPRING_PROFILES_ACTIVE=production
 AMQP_ENABLED=true

--- a/gs-gateway/Dockerfile
+++ b/gs-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.12-jdk
+FROM openjdk:17.0.1-jdk
 VOLUME /tmp
 ARG DEPENDENCY=target/dependency
 COPY ${DEPENDENCY}/BOOT-INF/lib /app/BOOT-INF/lib

--- a/gs-gateway/pom.xml
+++ b/gs-gateway/pom.xml
@@ -17,7 +17,7 @@
     <description>GeoServer Gateway</description>
 
     <properties>
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.0</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
@@ -83,6 +83,18 @@
             <groupId>io.sentry</groupId>
             <artifactId>sentry-logback</artifactId>
             <version>${sentry.version}</version>
+        </dependency>
+
+        <!-- Override until the version bump is integrated with spring boot dependencies -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4shell.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4shell.version}</version>
         </dependency>
 
         <dependency>

--- a/gs-gateway/src/main/java/pl/cyfronet/gsg/GsGatewayApplication.java
+++ b/gs-gateway/src/main/java/pl/cyfronet/gsg/GsGatewayApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ACC Cyfronet AGH
+ * Copyright 2021 ACC Cyfronet AGH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.jackson.io.JacksonDeserializer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.sentry.Sentry;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -57,6 +58,12 @@ import java.util.Map;
 @EnableConfigurationProperties({JwtProperties.class, GatewayProperties.class})
 public class GsGatewayApplication {
     public static void main(String[] args) {
+        Sentry.init(options -> {
+            options.setDsn("");
+            options.setTracesSampleRate(0.5);
+            options.setEnableExternalConfiguration(true);
+        });
+
         SpringApplication.run(GsGatewayApplication.class, args);
     }
 

--- a/gs-gateway/src/main/resources/logback.xml
+++ b/gs-gateway/src/main/resources/logback.xml
@@ -8,6 +8,7 @@
 
     <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <minimumEventLevel>WARN</minimumEventLevel>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <java.version>11</java.version>
-        <maven.compiler.release>11</maven.compiler.release>
+        <java.version>17</java.version>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <spring-boot.version>2.6.1</spring-boot.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,31 +26,32 @@
         <java.version>11</java.version>
         <maven.compiler.release>11</maven.compiler.release>
 
-        <spring-boot.version>2.5.5</spring-boot.version>
+        <spring-boot.version>2.6.1</spring-boot.version>
 
-        <awssdk.version>2.17.64</awssdk.version>
-        <commonmark.version>0.18.0</commonmark.version>
+        <awssdk.version>2.17.99</awssdk.version>
+        <commonmark.version>0.18.1</commonmark.version>
         <commons-email.version>1.5</commons-email.version>
-        <geotools.version>26.0</geotools.version>
+        <geotools.version>26.1</geotools.version>
         <greenmail.version>1.6.5</greenmail.version>
-        <guava.version>30.1.1-jre</guava.version>
-        <hibernate-types.version>2.13.0</hibernate-types.version>
+        <guava.version>31.0.1-jre</guava.version>
+        <hibernate-types.version>2.14.0</hibernate-types.version>
         <jakarta.json-api.version>2.0.1</jakarta.json-api.version>
         <jjwt.version>0.11.2</jjwt.version>
         <joy.version>2.1.0</joy.version>
         <justify.version>3.1.0</justify.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
-        <poiooxml.version>5.0.0</poiooxml.version>
+        <poiooxml.version>5.1.0</poiooxml.version>
         <recaptcha-starter.version>2.3.1</recaptcha-starter.version>
         <slugify.version>2.5</slugify.version>
-        <springdoc-openapi.version>1.5.12</springdoc-openapi.version>
+        <springdoc-openapi.version>1.6.0</springdoc-openapi.version>
         <unirest.version>4.0.0-RC1</unirest.version>
         <bucket4j-starter.version>0.4.0</bucket4j-starter.version>
+        <log4shell.version>2.16.0</log4shell.version>
         <!--
         update sentry version only when fid instance is updated
         -->
-        <sentry.version>5.2.4</sentry.version>
+        <sentry.version>5.4.3</sentry.version>
     </properties>
 
     <build>
@@ -68,7 +69,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.8.3</version>
+                                    <version>3.8.4</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/s4e-backend/.gitignore
+++ b/s4e-backend/.gitignore
@@ -23,3 +23,5 @@
 /dist/
 /nbdist/
 /.nb-gradle/
+
+spy.log

--- a/s4e-backend/Dockerfile
+++ b/s4e-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.12-jdk-slim
+FROM openjdk:17.0.1-jdk-slim
 
 RUN mkdir /app
 WORKDIR /app

--- a/s4e-backend/pom.xml
+++ b/s4e-backend/pom.xml
@@ -344,6 +344,23 @@
             <artifactId>sentry-logback</artifactId>
             <version>${sentry.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-jdbc</artifactId>
+            <version>${sentry.version}</version>
+        </dependency>
+
+        <!-- Override until the version bump is integrated with spring boot dependencies -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4shell.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4shell.version}</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/Application.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/Application.java
@@ -17,6 +17,7 @@
 
 package pl.cyfronet.s4e;
 
+import io.sentry.Sentry;
 import org.springdoc.core.SpringDocUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -29,6 +30,12 @@ import org.springframework.cache.annotation.EnableCaching;
 public class Application {
 
     public static void main(String[] args) {
+        Sentry.init(options -> {
+            options.setDsn("");
+            options.setTracesSampleRate(0.5);
+            options.setEnableExternalConfiguration(true);
+        });
+
         SpringDocUtils.getConfig().replaceWithClass(
                 org.springframework.data.domain.Pageable.class,
                 org.springdoc.core.converters.models.Pageable.class

--- a/s4e-backend/src/main/java/pl/cyfronet/s4e/api/SearchConverter.java
+++ b/s4e-backend/src/main/java/pl/cyfronet/s4e/api/SearchConverter.java
@@ -18,10 +18,11 @@
 package pl.cyfronet.s4e.api;
 
 import com.google.common.base.Splitter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.time.ZoneId;
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -31,8 +32,11 @@ import java.util.Map;
 import static pl.cyfronet.s4e.api.SearchApiParams.*;
 
 @Service
+@RequiredArgsConstructor
 @Slf4j
 public class SearchConverter {
+    private final Clock clock;
+
     public Map<String, Object> convertParams(String rowsSize, String rowStart, String orderby) {
         Map<String, Object> result = new HashMap<>();
         parseStringToInt(result, LIMIT, rowsSize);
@@ -121,7 +125,7 @@ public class SearchConverter {
         DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
         if (time.contains("NOW-")) {
             // NOW-NDAY(S)
-            ZonedDateTime localTime = ZonedDateTime.now(ZoneId.of("UTC"));
+            ZonedDateTime localTime = ZonedDateTime.now(clock);
             String[] times = time.split("-");
             switch (times[1].replaceAll("[0-9]", "")) {
                 case "MINUTE":
@@ -144,7 +148,7 @@ public class SearchConverter {
             return localTime.format(dateTimeFormat);
         }
         if (time.equals("NOW")) {
-            ZonedDateTime localTime = ZonedDateTime.now(ZoneId.of("UTC"));
+            ZonedDateTime localTime = ZonedDateTime.now(clock);
             return localTime.format(dateTimeFormat);
         }
         return time;

--- a/s4e-backend/src/main/resources/application-development.properties
+++ b/s4e-backend/src/main/resources/application-development.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:postgresql://localhost:5433/sat4envi
+spring.datasource.url=jdbc:p6spy:postgresql://localhost:5433/sat4envi
 spring.datasource.username=sat4envi
 spring.datasource.password=sat4envi
 

--- a/s4e-backend/src/main/resources/application-production.properties
+++ b/s4e-backend/src/main/resources/application-production.properties
@@ -1,5 +1,5 @@
 # BEGIN: props from development
-spring.datasource.url=jdbc:postgresql://localhost:5433/sat4envi
+spring.datasource.url=jdbc:p6spy:postgresql://localhost:5433/sat4envi
 spring.datasource.username=sat4envi
 spring.datasource.password=sat4envi
 

--- a/s4e-backend/src/main/resources/application.properties
+++ b/s4e-backend/src/main/resources/application.properties
@@ -2,7 +2,9 @@ server.port=4201
 server.tomcat.relaxed-query-chars=[,]
 server.forward-headers-strategy=framework
 
-spring.datasource.platform=postgres
+spring.sql.init.platform=postgres
+
+spring.datasource.driver-class-name=com.p6spy.engine.spy.P6SpyDriver
 
 spring.jpa.database-platform=org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false

--- a/s4e-backend/src/main/resources/logback.xml
+++ b/s4e-backend/src/main/resources/logback.xml
@@ -8,6 +8,7 @@
 
     <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <minimumEventLevel>WARN</minimumEventLevel>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>

--- a/s4e-backend/src/test/resources/application-test.properties
+++ b/s4e-backend/src/test/resources/application-test.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:postgresql://localhost:5434/sat4envi_test
+spring.datasource.url=jdbc:p6spy:postgresql://localhost:5434/sat4envi_test
 spring.datasource.username=sat4envi_test
 spring.datasource.password=sat4envi_test
 


### PR DESCRIPTION
Activate sentry performance logging.

Bump log4j to 2.15.0 until the bump isn't present in spring boot.

Update to java 17.